### PR TITLE
docs: add GitHub issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,51 @@
+---
+name: Bug Report
+about: Create a report to help us improve
+title: '[BUG] '
+labels: bug
+assignees: ''
+---
+
+## Bug Description
+
+<!-- A clear and concise description of what the bug is -->
+
+## Steps to Reproduce
+
+1.
+2.
+3.
+
+## Expected Behavior
+
+<!-- A clear and concise description of what you expected to happen -->
+
+## Actual Behavior
+
+<!-- A clear and concise description of what actually happened -->
+
+## Screenshots
+
+<!-- If applicable, add screenshots to help explain your problem -->
+
+## Environment
+
+- **OS**: [e.g., Windows 10, macOS 13.0, Ubuntu 22.04]
+- **Node.js Version**: [e.g., 18.17.0]
+- **npm Version**: [e.g., 9.6.7]
+- **KotOR.js Version/Commit**: [e.g., 2.0.0 or commit hash]
+- **Game**: [KotOR I / KotOR II (TSL) / Both]
+- **Browser** (if applicable): [e.g., Chrome 120]
+
+## Additional Context
+
+<!-- Add any other context about the problem here -->
+
+## Logs
+
+<!-- If applicable, paste relevant logs or error messages -->
+
+```
+Paste logs here
+```
+

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,36 @@
+---
+name: Feature Request
+about: Suggest an idea for this project
+title: '[FEATURE] '
+labels: enhancement
+assignees: ''
+---
+
+## Feature Description
+
+<!-- A clear and concise description of the feature you'd like to see -->
+
+## Motivation
+
+<!-- Why is this feature needed? What problem does it solve? -->
+
+## Proposed Solution
+
+<!-- Describe how you envision this feature working -->
+
+## Alternatives Considered
+
+<!-- Describe any alternative solutions or features you've considered -->
+
+## Use Cases
+
+<!-- Provide specific examples of how this feature would be used -->
+
+## Additional Context
+
+<!-- Add any other context, mockups, or examples about the feature request -->
+
+## Implementation Notes (Optional)
+
+<!-- If you have ideas about how this could be implemented, share them here -->
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,56 @@
+## Description
+
+<!-- Provide a brief description of your changes -->
+
+## Type of Change
+
+<!-- Mark the relevant option with an 'x' -->
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation update
+- [ ] Code refactoring
+- [ ] Performance improvement
+- [ ] Test addition or update
+
+## Related Issues
+
+<!-- Link related issues using #issue_number -->
+
+Fixes #
+Closes #
+Related to #
+
+## Testing
+
+<!-- Describe the tests you ran and provide instructions so reviewers can reproduce -->
+
+- [ ] Tests pass locally
+- [ ] Added tests for new functionality
+- [ ] Tested in Electron application
+- [ ] Tested in browser (if applicable)
+- [ ] Tested with KotOR I
+- [ ] Tested with KotOR II (TSL)
+
+## Checklist
+
+<!-- Mark completed items with an 'x' -->
+
+- [ ] My code follows the project's style guidelines
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have updated the documentation accordingly
+- [ ] My changes generate no new warnings
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes
+- [ ] Any dependent changes have been merged and published
+
+## Screenshots (if applicable)
+
+<!-- Add screenshots to help explain your changes -->
+
+## Additional Notes
+
+<!-- Add any additional information that reviewers should know -->
+


### PR DESCRIPTION
## Description

Adds GitHub templates for issues and pull requests to standardize submissions and improve issue tracking.

## Changes

- **.github/ISSUE_TEMPLATE/bug_report.md**: Template for bug reports with structured fields
- **.github/ISSUE_TEMPLATE/feature_request.md**: Template for feature requests
- **.github/PULL_REQUEST_TEMPLATE.md**: Template for pull request submissions

## Benefits

- Standardized issue and PR format
- Better issue tracking and triage
- Improved PR review process
- More complete bug reports and feature requests

## Type of Change

- [x] Documentation
- [x] Tooling/configuration