### PR TITLE
Fix bizarre shrinking class choice renderables in the new game / chargen area.

### DIFF
--- a/src/game/kotor/menu/CharGenClass.ts
+++ b/src/game/kotor/menu/CharGenClass.ts
@@ -240,18 +240,23 @@ export class CharGenClass extends GameMenu {
    */
   private captureBaseExtents(): void {
     if (this._baseExtentsCaptured) return;
-    const modelControl = this.getControlByName('_3D_MODEL1');
-    const btnControl = this.getControlByName('BTN_SEL1');
+    //Hover extents can be calculated from the first model and button control
+    //They are sized differently from the other 5 controls
+    const modelControlHovered = this.getControlByName('_3D_MODEL1');
+    const btnControlHovered = this.getControlByName('BTN_SEL1');
+    this._hoverModelExtent.width = modelControlHovered.extent.width;
+    this._hoverModelExtent.height = modelControlHovered.extent.height;
+    this._hoverBtnExtent.width = btnControlHovered.extent.width;
+    this._hoverBtnExtent.height = btnControlHovered.extent.height;
+
+    //Base extents can be calculated from the 2nd model and button controls
+    const modelControl = this.getControlByName('_3D_MODEL2');
+    const btnControl = this.getControlByName('BTN_SEL2');
     if (!modelControl || !btnControl || modelControl.extent.width <= 0 || modelControl.extent.height <= 0) return;
     this._baseModelExtent.width = modelControl.extent.width;
     this._baseModelExtent.height = modelControl.extent.height;
     this._baseBtnExtent.width = btnControl.extent.width;
     this._baseBtnExtent.height = btnControl.extent.height;
-    const hoverDelta = 20;
-    this._hoverModelExtent.width = this._baseModelExtent.width + hoverDelta;
-    this._hoverModelExtent.height = this._baseModelExtent.height + hoverDelta;
-    this._hoverBtnExtent.width = this._baseBtnExtent.width + hoverDelta;
-    this._hoverBtnExtent.height = this._baseBtnExtent.height + hoverDelta;
     this._baseExtentsCaptured = true;
   }
 
@@ -260,13 +265,11 @@ export class CharGenClass extends GameMenu {
     if (!this.bVisible)
       return;
     try {
-      if (!this._baseExtentsCaptured) this.captureBaseExtents();
-
       for (let i = 0; i < 6; i++) {
-        let modelControl = this.getControlByName('_3D_MODEL' + (i + 1));
-        let btnControl = this.getControlByName('BTN_SEL' + (i + 1));
-        let _3dView = GameState.CharGenManager.lbl_3d_views.get(i);
-        let creature = GameState.CharGenManager.creatures.get(i);
+        const modelControl = this.getControlByName('_3D_MODEL' + (i + 1));
+        const btnControl = this.getControlByName('BTN_SEL' + (i + 1));
+        const _3dView = GameState.CharGenManager.lbl_3d_views.get(i);
+        const creature = GameState.CharGenManager.creatures.get(i);
         if (creature) {
           creature.update(delta);
         }

--- a/src/game/kotor/menu/CharGenClass.ts
+++ b/src/game/kotor/menu/CharGenClass.ts
@@ -10,8 +10,7 @@ import { GameState } from "../../../GameState";
 /**
  * CharGenClass class.
  * Character generation "CHOOSE YOUR CLASS" screen; displays six class portrait slots
- * (_3D_MODEL1–6) with hover animation. Corresponds to CSWGuiClassSelection in the
- * original game (swkotor.exe); layout from ClassSel / classsel.gui.
+ * (_3D_MODEL1–6) with hover animation. Corresponds to layout from ClassSel / classsel.gui.
  *
  * KotOR JS - A remake of the Odyssey Game Engine that powered KotOR I & II
  *


### PR DESCRIPTION
## Summary: Character Generation Portrait Shrinking

### Expected

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/f42b2601-1968-4eda-9390-05d9579148bc" />

### Actual

<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/ef9309c5-32d6-405b-91c2-41564ea9ede1" />


### Root cause

The “CHOOSE YOUR CLASS” screen (`CharGenClass`) was using **fixed target sizes** in its `update()` loop:

- **Non-hovered:** shrink toward **187×187** (model) and **193×193** (button).
- **Hovered:** grow toward **207×207** (model) and **213×213** (button).

Control extents are loaded from the GUI layout (`classsel.gui`). If the layout gives larger extents (e.g. 256×256 or 300×300), then every frame the code shrinks non-hovered slots by 1 until they hit 187. So after a few seconds all six portraits collapse to thin strips and almost disappear.

So the bug was: **animation targets were hardcoded (187/207) instead of being derived from the layout**, so any layout with larger base sizes was driven down to 187.

### Fix (in `src/game/kotor/menu/CharGenClass.ts`)

1. **Base extents from layout**  
   - Added `_baseModelExtent`, `_baseBtnExtent`, `_hoverModelExtent`, `_hoverBtnExtent`, and `_baseExtentsCaptured`.  
   - `captureBaseExtents()` runs once when controls are ready and reads the **actual** base size from `_3D_MODEL1` / `BTN_SEL1` (i.e. from the layout).  
   - Hover targets are base + 20 so the hover “pop” is preserved.

2. **Animation uses layout-driven targets**  
   - Non-hovered: animate **down to** `_baseModelExtent` / `_baseBtnExtent` (no lower).  
   - Hovered: animate **up to** `_hoverModelExtent` / `_hoverBtnExtent`.  
   - All changes use `Math.max` / `Math.min` so extents never go below base or above hover.

3. **Guards**  
   - `captureBaseExtents()` only runs when controls exist and have non-zero width/height, and only once (`_baseExtentsCaptured`).  
   - Called from `menuControlInitializer` after setting up the 3D views, and again at the start of `update()` in case the first run was too early.

Result: portraits stay at the size defined by the layout when not hovered, and only grow slightly on hover; they no longer shrink to 187 and disappear.

### original game check

- In **swkotor.exe**, class selection is handled by:
  - loads layout `"ClassSel"`, sets load screen `"classsel"`, initializes six **gui selector class** entries (button + 3D scene view).
  - per-slot control (button + 3D scene view).
- The layout is loaded from the GUI file; the original game does not use hardcoded 187/207. Our fix aligns behavior with that idea: **sizes come from the layout**, and we only animate between “base” and “base + hover delta”.

### TSL (KotOR II)

- `src/game/tsl/menu/CharGenClass.ts` extends the K1 `CharGenClass` and does **not** override `update()`, so it automatically uses the same fix. No change needed there.