### PR TITLE
Add party member switching functionality to MenuCharacter

### DIFF
--- a/src/game/kotor/menu/MenuCharacter.ts
+++ b/src/game/kotor/menu/MenuCharacter.ts
@@ -9,9 +9,9 @@ import { OdysseyModel } from "../../../odyssey";
 
 /**
  * MenuCharacter class.
- * 
+ *
  * KotOR JS - A remake of the Odyssey Game Engine that powered KotOR I & II
- * 
+ *
  * @file MenuCharacter.ts
  * @author KobaltBlu <https://github.com/KobaltBlu>
  * @license {@link https://www.gnu.org/licenses/gpl-3.0.txt|GPLv3}
@@ -118,8 +118,34 @@ export class MenuCharacter extends GameMenu {
       });
       this._button_y = this.BTN_AUTO;
 
+      this.BTN_CHANGE1?.addEventListener('click', (e) => {
+        e.stopPropagation();
+        if (GameState.PartyManager.party.length > 1) {
+          GameState.PartyManager.SwitchLeaderAtIndex(1);
+          this.updateCharacterPortrait(GameState.PartyManager.party[0]);
+          this.updateCharacterStats(GameState.PartyManager.party[0]);
+          this.updatePartyMemberPortraitButtons();
+        }
+      });
+      this.BTN_CHANGE2?.addEventListener('click', (e) => {
+        e.stopPropagation();
+        if (GameState.PartyManager.party.length > 2) {
+          GameState.PartyManager.SwitchLeaderAtIndex(2);
+          this.updateCharacterPortrait(GameState.PartyManager.party[0]);
+          this.updateCharacterStats(GameState.PartyManager.party[0]);
+          this.updatePartyMemberPortraitButtons();
+        }
+      });
+
+      GameState.PartyManager.AddEventListener('change', () => {
+        if (!this.bVisible) return;
+        this.updateCharacterPortrait(GameState.PartyManager.party[0]);
+        this.updateCharacterStats(GameState.PartyManager.party[0]);
+        this.updatePartyMemberPortraitButtons();
+      });
+
       MDLLoader.loader.load('charrec_light').then((mdl: OdysseyModel) => {
-          
+
         //this.tGuiPanel.widget.children[2].children[0].position.z = -0.5;
         this._3dView = new LBL_3DView(this.LBL_3DCHAR.extent.width, this.LBL_3DCHAR.extent.height);
         this._3dView.setControl(this.LBL_3DCHAR);
@@ -139,7 +165,7 @@ export class MenuCharacter extends GameMenu {
 
         this.BTN_AUTO?.hide();
         this.BTN_LEVELUP?.hide();
-        
+
         OdysseyModel3D.FromMDL(mdl, {
           // manageLighting: false,
           context: this._3dView
@@ -147,7 +173,7 @@ export class MenuCharacter extends GameMenu {
           //console.log('Model Loaded', model);
           this._3dViewModel = model;
           this._3dView.addModel(this._3dViewModel);
-          
+
           this._3dView.camera.position.copy(
             model.camerahook.position
           );
@@ -229,20 +255,17 @@ export class MenuCharacter extends GameMenu {
     }
   }
 
-  show() {
-    super.show();
-    this.manager.MenuTop.LBLH_CHA.onHoverIn();
-    this.recalculatePosition();
-    this.SLD_ALIGN?.setValue(0.5);
-    this.updateCharacterPortrait(GameState.PartyManager.party[0]);
-    this.updateCharacterStats(GameState.PartyManager.party[0]);
+  /**
+   * Refresh the party member portrait buttons (BTN_CHANGE1, BTN_CHANGE2) to match current party order.
+   */
+  updatePartyMemberPortraitButtons() {
     this.BTN_CHANGE1?.hide();
     this.BTN_CHANGE2?.hide();
     let btn_change: GUIControl;
     for (let i = 0; i < GameState.PartyManager.party.length; i++) {
       btn_change = this.getControlByName('BTN_CHANGE' + i);
-      if(btn_change){
-        let partyMember = GameState.PartyManager.party[i];
+      if (btn_change) {
+        const partyMember = GameState.PartyManager.party[i];
         const portraitResRef = partyMember.getPortraitResRef();
         if (i) {
           btn_change.show();
@@ -252,6 +275,16 @@ export class MenuCharacter extends GameMenu {
         }
       }
     }
+  }
+
+  show() {
+    super.show();
+    this.manager.MenuTop.LBLH_CHA.onHoverIn();
+    this.recalculatePosition();
+    this.SLD_ALIGN?.setValue(0.5);
+    this.updateCharacterPortrait(GameState.PartyManager.party[0]);
+    this.updateCharacterStats(GameState.PartyManager.party[0]);
+    this.updatePartyMemberPortraitButtons();
   }
 
   updateCharacterPortrait( creature: ModuleCreature ){
@@ -373,5 +406,5 @@ export class MenuCharacter extends GameMenu {
   triggerControllerBumperRPress() {
     this.manager.MenuTop.BTN_ABI.click();
   }
-  
+
 }

--- a/src/game/tsl/menu/MenuCharacter.ts
+++ b/src/game/tsl/menu/MenuCharacter.ts
@@ -8,9 +8,9 @@ import { MenuCharacter as K1_MenuCharacter } from "../../kotor/KOTOR";
 
 /**
  * MenuCharacter class.
- * 
+ *
  * KotOR JS - A remake of the Odyssey Game Engine that powered KotOR I & II
- * 
+ *
  * @file MenuCharacter.ts
  * @author KobaltBlu <https://github.com/KobaltBlu>
  * @license {@link https://www.gnu.org/licenses/gpl-3.0.txt|GPLv3}
@@ -99,6 +99,32 @@ export class MenuCharacter extends K1_MenuCharacter {
       });
       this._button_y = this.BTN_AUTO;
 
+      this.BTN_CHANGE1?.addEventListener('click', (e) => {
+        e.stopPropagation();
+        if (GameState.PartyManager.party.length > 1) {
+          GameState.PartyManager.SwitchLeaderAtIndex(1);
+          this.updateCharacterPortrait(GameState.PartyManager.party[0]);
+          this.updateCharacterStats(GameState.PartyManager.party[0]);
+          this.updatePartyMemberPortraitButtons();
+        }
+      });
+      this.BTN_CHANGE2?.addEventListener('click', (e) => {
+        e.stopPropagation();
+        if (GameState.PartyManager.party.length > 2) {
+          GameState.PartyManager.SwitchLeaderAtIndex(2);
+          this.updateCharacterPortrait(GameState.PartyManager.party[0]);
+          this.updateCharacterStats(GameState.PartyManager.party[0]);
+          this.updatePartyMemberPortraitButtons();
+        }
+      });
+
+      GameState.PartyManager.AddEventListener('change', () => {
+        if (!this.bVisible) return;
+        this.updateCharacterPortrait(GameState.PartyManager.party[0]);
+        this.updateCharacterStats(GameState.PartyManager.party[0]);
+        this.updatePartyMemberPortraitButtons();
+      });
+
       MDLLoader.loader.load('charmain_light').then((mdl: OdysseyModel) => {
         OdysseyModel3D.FromMDL(mdl, {
           context: this._3dView,
@@ -116,7 +142,7 @@ export class MenuCharacter extends K1_MenuCharacter {
 
             this._3dViewModel = model;
             this._3dView.addModel(this._3dViewModel);
-            
+
             this._3dView.camera.position.copy(model.camerahook.position);
             this._3dView.camera.quaternion.copy(model.camerahook.quaternion);
           }catch(e){
@@ -154,31 +180,14 @@ export class MenuCharacter extends K1_MenuCharacter {
 
   show() {
     super.show();
-    try{
+    try {
       this.recalculatePosition();
       this.updateCharacterPortrait(GameState.PartyManager.party[0]);
       this.updateCharacterStats(GameState.PartyManager.party[0]);
-      
-      this.BTN_CHANGE1?.hide();
-      this.BTN_CHANGE2?.hide();
-      for (let i = 0; i < GameState.PartyManager.party.length; i++) {
-        let partyMember = GameState.PartyManager.party[i];
-        const portraitResRef = partyMember.getPortraitResRef();
-        if (!i) {
-          
-        } else {
-          const BTN_CHANGE = this.getControlByName('BTN_CHANGE' + i);
-          if(BTN_CHANGE){
-            BTN_CHANGE.show();
-            if (BTN_CHANGE.getFillTextureName() != portraitResRef) {
-              BTN_CHANGE.setFillTextureName(portraitResRef);
-            }
-          }
-        }
-      }
-    }catch(e){
+      this.updatePartyMemberPortraitButtons();
+    } catch (e) {
       console.error(e);
     }
   }
-  
+
 }


### PR DESCRIPTION
This address's @LaneDibello 's concern:

> Cannot swap party members on the character sheet screen.

Summary of what was wrong and what was changed:

## Cause

Party swapping on the **character sheet** (MenuCharacter) didn’t work because the portrait buttons (**BTN_CHANGE1**, **BTN_CHANGE2**) had **no click handlers**.

- **Inventory** and **Equipment** already had listeners that call `PartyManager.SwitchLeaderAtIndex(1)` / `(2)` and refresh the UI.
- **Character** (K1 and TSL) only showed and filled the portrait buttons in `show()` and never attached `click` listeners, so clicking them did nothing.

The game’s observed behavior: `ExecuteCommandSetPartyLeader` takes a party index and updates the party leader; the character sheet is supposed to let the player pick that leader by clicking a portrait, which our code now does.

## Changes

### 1. K1 – `src/game/kotor/menu/MenuCharacter.ts`

- **Click listeners** for **BTN_CHANGE1** and **BTN_CHANGE2** in `menuControlInitializer`:
  - On click: `GameState.PartyManager.SwitchLeaderAtIndex(1)` or `(2)` (with length checks), then refresh portrait, stats, and portrait buttons.
- **PartyManager `'change'` listener**: when the party leader changes (from here or elsewhere), if the character sheet is visible, refresh portrait, stats, and portrait buttons.
- **`updatePartyMemberPortraitButtons()`**: new helper that hides BTN_CHANGE1/2, then for each party member shows the right button and sets its portrait texture (logic previously only in `show()`).
- **`show()`**: now calls `updatePartyMemberPortraitButtons()` instead of duplicating that logic.

### 2. TSL – `src/game/tsl/menu/MenuCharacter.ts`

- TSL calls `super.menuControlInitializer(true)`, so it never runs the K1 listener setup. The **same** BTN_CHANGE1/2 **click listeners** and **PartyManager `'change'` listener** were added in TSL’s `menuControlInitializer`.
- **`show()`**: simplified to call `this.updatePartyMemberPortraitButtons()` (inherited from K1) instead of its own loop.

Result:

- Clicking a companion portrait on the character sheet calls `PartyManager.SwitchLeaderAtIndex(index)`, which matches Inventory/Equipment and the original game’s `SetPartyLeader` behavior.
- The sheet’s 3D portrait, stats, and portrait button order all update when you switch party members, and they also update if the leader changes from another screen (e.g. Inventory) thanks to the `'change'` listener.