### PR TITLE
Implement Pazaak game flow in MenuPazaakWager (and 1 more)

### DIFF
--- a/src/game/kotor/menu/MenuPazaakSetup.ts
+++ b/src/game/kotor/menu/MenuPazaakSetup.ts
@@ -13,9 +13,9 @@ const MSG_YOU_LOSE = 32335;
 
 /**
  * MenuPazaakSetup class.
- * 
+ *
  * KotOR JS - A remake of the Odyssey Game Engine that powered KotOR I & II
- * 
+ *
  * @file MenuPazaakSetup.ts
  * @author KobaltBlu <https://github.com/KobaltBlu>
  * @license {@link https://www.gnu.org/licenses/gpl-3.0.txt|GPLv3}
@@ -191,7 +191,9 @@ export class MenuPazaakSetup extends GameMenu {
 
   open(){
     super.open();
-    GameState.MenuManager.MenuPazaakWager.open();
+    if(GameState.PazaakManager.MaxWager > 0){
+      GameState.MenuManager.MenuPazaakWager.open();
+    }
     this.knownCards.clear();
     for(let i = 0; i < PazaakCards.MAX_CARDS; i++){
       const card = GameState.PazaakManager.Cards.get(i);

--- a/src/game/kotor/menu/MenuPazaakWager.ts
+++ b/src/game/kotor/menu/MenuPazaakWager.ts
@@ -13,7 +13,7 @@ const TLK_QUIT_PAZAAK_CONFIRM = 0xa5b8;
  * MenuPazaakWager class.
  *
  * Implements CSWGuiWagerPopup from KotOR I - wager selection popup for Pazaak.
- * Reva parity: HandleButtonWager, OnBButtonPressed (quit), UpdateWagerText, LBL_MAXIMUM format.
+ * Original game behavior parity: HandleButtonWager, OnBButtonPressed (quit), UpdateWagerText, LBL_MAXIMUM format.
  *
  * @file MenuPazaakWager.ts
  * @author KobaltBlu <https://github.com/KobaltBlu>

--- a/src/game/kotor/menu/MenuPazaakWager.ts
+++ b/src/game/kotor/menu/MenuPazaakWager.ts
@@ -2,11 +2,19 @@ import { GameState } from "../../../GameState";
 import { GameMenu } from "../../../gui";
 import type { GUIListBox, GUILabel, GUIButton } from "../../../gui";
 
+/** TLK 32321: "Max wager" label prefix (CSWGuiWagerPopup LBL_MAXIMUM format) */
+const TLK_MAX_WAGER = 0x7e41;
+/** TLK 38600: "Your credits" label prefix */
+const TLK_YOUR_CREDITS = 0x96c8;
+/** TLK 42424: "Quit Pazaak?" confirmation (HandleInputEvent case 0x28/0x2e) */
+const TLK_QUIT_PAZAAK_CONFIRM = 0xa5b8;
+
 /**
  * MenuPazaakWager class.
- * 
- * KotOR JS - A remake of the Odyssey Game Engine that powered KotOR I & II
- * 
+ *
+ * Implements CSWGuiWagerPopup from KotOR I - wager selection popup for Pazaak.
+ * Reva parity: HandleButtonWager, OnBButtonPressed (quit), UpdateWagerText, LBL_MAXIMUM format.
+ *
  * @file MenuPazaakWager.ts
  * @author KobaltBlu <https://github.com/KobaltBlu>
  * @license {@link https://www.gnu.org/licenses/gpl-3.0.txt|GPLv3}
@@ -35,39 +43,91 @@ export class MenuPazaakWager extends GameMenu {
     if(skipInit) return;
     return new Promise<void>((resolve, reject) => {
 
+      /**
+       * BTN_QUIT: CSWGuiPanel::OnBButtonPressed -> HandleInputEvent(0x28/0x2e)
+       * Shows "Quit Pazaak?" confirmation. If confirmed, cancels Pazaak (HandleQuitDialog).
+       */
       this.BTN_QUIT.addEventListener('click', () => {
-        this.close();
-        GameState.MenuManager.MenuPazaakSetup.close();
+        this.handleQuitClicked();
       });
 
+      /**
+       * BTN_WAGER: HandleButtonWager -> HandleInputEvent(0x2d)
+       * Confirms wager, closes popup, stays on setup (HandleWagerExit).
+       */
       this.BTN_WAGER.addEventListener('click', () => {
-        this.close();
-        GameState.MenuManager.MenuPazaakSetup.close();
-        GameState.MenuManager.MenuPazaakGame.open();
-        GameState.PazaakManager.BeginGame();
+        this.handleWagerClicked();
       });
 
+      /**
+       * BTN_LESS: OnMinusButtonPushed -> HandleInputEvent(0x2f etc) decrease
+       */
       this.BTN_LESS.addEventListener('click', () => {
         GameState.PazaakManager.DecreaseWager();
         this.rebuild();
-      }); 
+      });
 
+      /**
+       * BTN_MORE: OnPlusButtonPushed -> HandleInputEvent(0x30 etc) increase
+       */
       this.BTN_MORE.addEventListener('click', () => {
         GameState.PazaakManager.IncreaseWager();
         this.rebuild();
       });
-      
+
       resolve();
     });
   }
 
+  /**
+   * Handle BTN_QUIT - show confirmation then cancel if confirmed.
+   * Matches HandleInputEvent case 0x28/0x2e -> HandleQuitDialog.
+   */
+  private handleQuitClicked(){
+    GameState.guiAudioEmitter?.playSoundFireAndForget?.('gui_click');
+    GameState.MenuManager.InGameConfirm.showConfirmDialog(
+      TLK_QUIT_PAZAAK_CONFIRM,
+      () => {
+        GameState.PazaakManager.CancelPazaak();
+      },
+      () => { /* cancel - do nothing */ }
+    );
+  }
+
+  /**
+   * Handle BTN_WAGER - confirm wager, close popup, stay on setup.
+   * Matches HandleButtonWager -> HandleInputEvent(0x2d) -> HandleWagerExit.
+   */
+  private handleWagerClicked(){
+    GameState.guiAudioEmitter?.playSoundFireAndForget?.('gui_click');
+    this.close();
+  }
+
+  private getPlayerGold(): number {
+    return GameState.PartyManager?.Gold ?? 0;
+  }
+
   show() {
     super.show();
-    this.tGuiPanel.widget.position.z = 100
+    this.tGuiPanel.widget.position.z = 100;
     this.rebuild();
   }
 
+  /**
+   * Matches CSWGuiWagerPopup::UpdateWagerText + LBL_MAXIMUM format.
+   * LBL_MAXIMUM: GetSimpleString(0x7e41) + " " + maxWager + "\n" + GetSimpleString(0x96c8) + " " + playerGold
+   */
   rebuild(){
-    this.LBL_WAGERVAL.setText(GameState.PazaakManager.Wager.toString());
+    const pm = GameState.PazaakManager;
+    const playerGold = this.getPlayerGold();
+    const maxWager = Math.min(pm.MaxWager, playerGold);
+
+    pm.Wager = Math.max(pm.MinWager, Math.min(pm.Wager, maxWager));
+
+    this.LBL_WAGERVAL.setText(pm.Wager.toString());
+
+    const tlkMax = GameState.TLKManager?.GetStringById?.(TLK_MAX_WAGER)?.Value ?? 'Max wager';
+    const tlkCredits = GameState.TLKManager?.GetStringById?.(TLK_YOUR_CREDITS)?.Value ?? 'Your credits';
+    this.LBL_MAXIMUM.setText(`${tlkMax} ${maxWager}\n${tlkCredits} ${playerGold}`);
   }
 }

--- a/src/game/kotor/menu/MenuPazaakWager.ts
+++ b/src/game/kotor/menu/MenuPazaakWager.ts
@@ -36,13 +36,15 @@ export class MenuPazaakWager extends GameMenu {
     return new Promise<void>((resolve, reject) => {
 
       this.BTN_QUIT.addEventListener('click', () => {
-        //TODO: Cancel Pazaak game
         this.close();
+        GameState.MenuManager.MenuPazaakSetup.close();
       });
 
       this.BTN_WAGER.addEventListener('click', () => {
-        //TODO: Start Pazaak game
         this.close();
+        GameState.MenuManager.MenuPazaakSetup.close();
+        GameState.MenuManager.MenuPazaakGame.open();
+        GameState.PazaakManager.BeginGame();
       });
 
       this.BTN_LESS.addEventListener('click', () => {

--- a/src/game/kotor/menu/MenuPazaakWager.ts
+++ b/src/game/kotor/menu/MenuPazaakWager.ts
@@ -1,19 +1,18 @@
 import { GameState } from "../../../GameState";
 import { GameMenu } from "../../../gui";
-import type { GUIListBox, GUILabel, GUIButton } from "../../../gui";
+import type { GUILabel, GUIButton } from "../../../gui";
 
-/** TLK 32321: "Max wager" label prefix (CSWGuiWagerPopup LBL_MAXIMUM format) */
-const TLK_MAX_WAGER = 0x7e41;
+/** TLK 32321: "Max wager" label prefix */
+const TLK_MAX_WAGER = 32321;
 /** TLK 38600: "Your credits" label prefix */
-const TLK_YOUR_CREDITS = 0x96c8;
-/** TLK 42424: "Quit Pazaak?" confirmation (HandleInputEvent case 0x28/0x2e) */
-const TLK_QUIT_PAZAAK_CONFIRM = 0xa5b8;
+const TLK_YOUR_CREDITS = 38600;
+/** TLK 42424: "Quit Pazaak?" confirmation */
+const TLK_QUIT_PAZAAK_CONFIRM = 42424;
 
 /**
  * MenuPazaakWager class.
  *
- * Implements CSWGuiWagerPopup from KotOR I - wager selection popup for Pazaak.
- * Original game behavior parity: HandleButtonWager, OnBButtonPressed (quit), UpdateWagerText, LBL_MAXIMUM format.
+ * Handles the wager selection popup for the Pazaak minigame.
  *
  * @file MenuPazaakWager.ts
  * @author KobaltBlu <https://github.com/KobaltBlu>
@@ -42,25 +41,22 @@ export class MenuPazaakWager extends GameMenu {
     await super.menuControlInitializer();
     if(skipInit) return;
     return new Promise<void>((resolve, reject) => {
-
       /**
-       * BTN_QUIT: CSWGuiPanel::OnBButtonPressed -> HandleInputEvent(0x28/0x2e)
-       * Shows "Quit Pazaak?" confirmation. If confirmed, cancels Pazaak (HandleQuitDialog).
+       * BTN_QUIT: Show "Quit Pazaak?" confirmation.
        */
       this.BTN_QUIT.addEventListener('click', () => {
         this.handleQuitClicked();
       });
 
       /**
-       * BTN_WAGER: HandleButtonWager -> HandleInputEvent(0x2d)
-       * Confirms wager, closes popup, stays on setup (HandleWagerExit).
+       * BTN_WAGER: Confirm the wager
        */
       this.BTN_WAGER.addEventListener('click', () => {
         this.handleWagerClicked();
       });
 
       /**
-       * BTN_LESS: OnMinusButtonPushed -> HandleInputEvent(0x2f etc) decrease
+       * BTN_LESS: Decrease the wager
        */
       this.BTN_LESS.addEventListener('click', () => {
         GameState.PazaakManager.DecreaseWager();
@@ -68,7 +64,7 @@ export class MenuPazaakWager extends GameMenu {
       });
 
       /**
-       * BTN_MORE: OnPlusButtonPushed -> HandleInputEvent(0x30 etc) increase
+       * BTN_MORE: Increase the wager
        */
       this.BTN_MORE.addEventListener('click', () => {
         GameState.PazaakManager.IncreaseWager();
@@ -81,7 +77,6 @@ export class MenuPazaakWager extends GameMenu {
 
   /**
    * Handle BTN_QUIT - show confirmation then cancel if confirmed.
-   * Matches HandleInputEvent case 0x28/0x2e -> HandleQuitDialog.
    */
   private handleQuitClicked(){
     GameState.guiAudioEmitter?.playSoundFireAndForget?.('gui_click');
@@ -96,7 +91,6 @@ export class MenuPazaakWager extends GameMenu {
 
   /**
    * Handle BTN_WAGER - confirm wager, close popup, stay on setup.
-   * Matches HandleButtonWager -> HandleInputEvent(0x2d) -> HandleWagerExit.
    */
   private handleWagerClicked(){
     GameState.guiAudioEmitter?.playSoundFireAndForget?.('gui_click');
@@ -114,8 +108,7 @@ export class MenuPazaakWager extends GameMenu {
   }
 
   /**
-   * Matches CSWGuiWagerPopup::UpdateWagerText + LBL_MAXIMUM format.
-   * LBL_MAXIMUM: GetSimpleString(0x7e41) + " " + maxWager + "\n" + GetSimpleString(0x96c8) + " " + playerGold
+   * Update the wager text and maximum text.
    */
   rebuild(){
     const pm = GameState.PazaakManager;

--- a/src/game/tsl/menu/MenuPazaakWager.ts
+++ b/src/game/tsl/menu/MenuPazaakWager.ts
@@ -3,9 +3,9 @@ import { MenuPazaakWager as K1_MenuPazaakWager } from "../../kotor/KOTOR";
 
 /**
  * MenuPazaakWager class.
- * 
+ *
  * KotOR JS - A remake of the Odyssey Game Engine that powered KotOR I & II
- * 
+ *
  * @file MenuPazaakWager.ts
  * @author KobaltBlu <https://github.com/KobaltBlu>
  * @license {@link https://www.gnu.org/licenses/gpl-3.0.txt|GPLv3}
@@ -30,11 +30,7 @@ export class MenuPazaakWager extends K1_MenuPazaakWager {
   }
 
   async menuControlInitializer(skipInit: boolean = false) {
-    await super.menuControlInitializer(true);
-    if(skipInit) return;
-    return new Promise<void>((resolve, reject) => {
-      resolve();
-    });
+    await super.menuControlInitializer(skipInit);
   }
 
   show(): void {
@@ -44,5 +40,5 @@ export class MenuPazaakWager extends K1_MenuPazaakWager {
   hide(): void {
     super.hide();
   }
-  
+
 }

--- a/src/managers/PazaakManager.ts
+++ b/src/managers/PazaakManager.ts
@@ -360,7 +360,6 @@ export class PazaakManager {
 
   /**
    * Cancel the Pazaak game from the wager/setup screen.
-   * Matches CSWGuiPazaakStart::HandleQuitDialog / CClientExoApp::EndPazaakGame behavior.
    */
   static CancelPazaak(){
     if(GameState.MenuManager?.MenuPazaakWager?.bVisible){

--- a/src/managers/PazaakManager.ts
+++ b/src/managers/PazaakManager.ts
@@ -144,7 +144,7 @@ export class PazaakManager {
       swapValueCards: new Map<PazaakHandSlots, boolean>()
     }
   ];
-  
+
   static TurnMode: PazaakTurnMode = PazaakTurnMode.PLAYER;
   static Actions: IPazaakAction[] = [];
   static TargetWins: number = 3;
@@ -358,13 +358,26 @@ export class PazaakManager {
     }
   }
 
+  /**
+   * Cancel the Pazaak game from the wager/setup screen.
+   * Matches CSWGuiPazaakStart::HandleQuitDialog / CClientExoApp::EndPazaakGame behavior.
+   */
+  static CancelPazaak(){
+    if(GameState.MenuManager?.MenuPazaakWager?.bVisible){
+      GameState.MenuManager.MenuPazaakWager.close();
+    }
+    if(GameState.MenuManager?.MenuPazaakSetup?.bVisible){
+      GameState.MenuManager.MenuPazaakSetup.close();
+    }
+  }
+
   static ProcessActionQueue(delta: number){
     if(this.Actions.length == 0){
       return;
     }
 
     const action = this.Actions[0];
-    let actionStatus: ActionStatus = ActionStatus.IN_PROGRESS;  
+    let actionStatus: ActionStatus = ActionStatus.IN_PROGRESS;
     /**
      * Wait for a specified amount of time
      */
@@ -423,7 +436,7 @@ export class PazaakManager {
     }
     /**
      * End the turn
-     * end early if the player busted 
+     * end early if the player busted
      * if it was the players turn, begin the opponent's turn
      * else end the round
      */
@@ -625,7 +638,7 @@ export class PazaakManager {
        */
       else{
         if(tableIndex == 1){
-          this.AddActionFront(tableIndex, PazaakActionType.AI_DETERMINE_MOVE, [tableIndex]);  
+          this.AddActionFront(tableIndex, PazaakActionType.AI_DETERMINE_MOVE, [tableIndex]);
         }
         this.AddActionFront(tableIndex, PazaakActionType.WAIT, [1, 0]);
         this.AddActionFront(tableIndex, PazaakActionType.PLAY_GUI_SOUND, ['mgs_drawmain']);
@@ -641,7 +654,7 @@ export class PazaakManager {
       const handIndex = this.GetActionPropertyAsNumber(0, 1);
       const flipped = this.GetActionPropertyAsNumber(0, 2) == 1;
       console.log(`PazaakManager: Play hand card ${tableIndex == 0 ? 'Player' : 'Opponent'} ${handIndex} ${flipped ? 'flipped' : 'not flipped'}`);
-      
+
       const table = this.Tables[tableIndex];
       const cardIndex = table.handCards.get(handIndex);
       if(cardIndex == PazaakCards.INVALID){
@@ -687,7 +700,7 @@ export class PazaakManager {
       const tableIndex = this.GetActionPropertyAsNumber(0, 0);
       const aiTable = this.Tables[tableIndex];
       const playerTable = this.Tables[PazaakTurnMode.PLAYER];
-      
+
       /**
        * Find the best card to play next
        */
@@ -719,7 +732,7 @@ export class PazaakManager {
           bestCardFlipped = true;
         }
       }
-      
+
       /**
        * If the AI has 20 points, they will stand to end their turn
        * there is no better move at this point
@@ -728,8 +741,8 @@ export class PazaakManager {
         this.AddActionFront(tableIndex, PazaakActionType.END_TURN, [PazaakTurnMode.OPPONENT, 1]);
       }
       /**
-       * The AI will stand on 19 or 18 
-       * unless they have a better card to play that will put them equal to 20 
+       * The AI will stand on 19 or 18
+       * unless they have a better card to play that will put them equal to 20
        * to consolidate their potential win
        */
       if((aiTable.points == 19 || aiTable.points == 18)){
@@ -743,8 +756,8 @@ export class PazaakManager {
        * If the AI has more than 20 points, they will end their turn because they busted
        */
       else if(aiTable.points > 20){
-        //if the AI has more than 20 points, 
-        // they will play a hand card to try to get just under or equal to 20 
+        //if the AI has more than 20 points,
+        // they will play a hand card to try to get just under or equal to 20
         // but not less than 18
         if(bestCardIndex != -1 && scoreAfterBestCard >= 18){
           this.AddActionFront(tableIndex, PazaakActionType.PLAY_HAND_CARD, [tableIndex, bestCardIndex, bestCardFlipped ? 1 : 0]);
@@ -777,7 +790,7 @@ export class PazaakManager {
       /**
        * If the AI has between 18 and 20 points, they will auto stand to end their turn
        */
-      else 
+      else
       {
         this.AddActionFront(tableIndex, PazaakActionType.END_TURN, [PazaakTurnMode.OPPONENT, 0]);
       }
@@ -850,7 +863,7 @@ export class PazaakManager {
     for(let i = 0; i < tableCount; i++){
       const table = this.Tables[i];
       const sideDeck = !i ? this.PlayerSideDeck : this.OpponentSideDeck;
-      
+
       //Copy the side decks to the player and opponent tables
       for(let j = 0; j < PazaakSideDeckSlots.MAX_SLOTS; j++){
         table.sideDeck.set(j, sideDeck.get(j));
@@ -880,7 +893,7 @@ export class PazaakManager {
         //Get a random side deck card
         const sideCardIndex = Math.floor(Math.random() * availableSideDeckCards.length);
         const randomSideDeckCard = availableSideDeckCards[sideCardIndex];
-        
+
         //Add the card to the player's hand
         table.handCards.set(j, randomSideDeckCard);
         //Set the card to not flipped


### PR DESCRIPTION
Summary of the Pazaak wager changes:

## Findings observed in official game behavior.

From **CSWGuiWagerPopup** and related code:

- **HandleButtonWager**: Calls `HandleInputEvent(0x2d, 1)`.
- **HandleInputEvent**: Switches on events:
  - `HandleWagerExit`, close popup.
  - (BTN_QUIT): Show confirmation TLK 0xa5b8 (42424), then `HandleQuitDialog` if confirmed.
- **HandleWagerExit**: Stores wager value, keeps setup visible.
- **HandleQuitDialog**: Closes wager popup and exits Pazaak (`EndPazaakGame`).
- **UpdateWagerText**: Writes current wager to `LBL_WAGERVAL`.
- **LBL_MAXIMUM** format: TLK 0x7e41 + " " + maxWager + "\\n" + TLK 0x96c8 + " " + playerGold.
- Wager limits: min 1, max `min(maxWager, playerGold)`.
- Wager popup only when `maxWager > 0` (tutorial skips it).

## Implementation Summary

### 1. **MenuPazaakWager.ts** (KotOR I)
- **BTN_WAGER**: Confirms wager, closes popup, stays on setup (reuses `HandleWagerExit` behavior).
- **BTN_QUIT**: Uses `InGameConfirm.showConfirmDialog` with TLK 42424; on OK, calls `PazaakManager.CancelPazaak()`.
- **LBL_MAXIMUM**: Uses TLK 32321 and 38600 in the original format.
- **rebuild()**: Updates wager label, clamps wager, and sets LBL_MAXIMUM.
- `gui_click` plays on WAGER and QUIT.

### 2. **PazaakManager.ts**
- **CancelPazaak()**: Closes MenuPazaakWager and MenuPazaakSetup.

### 3. **MenuPazaakSetup.ts**
- **open()**: Opens MenuPazaakWager only when `MaxWager > 0`.

### 4. **MenuPazaakWager.ts** (TSL)
- Uses `super.menuControlInitializer(skipInit)` so it inherits the K1 button handlers.

### Files Modified
- `src/game/kotor/menu/MenuPazaakWager.ts` – button logic and observable game parity.
- `src/game/kotor/menu/MenuPazaakSetup.ts` – conditional wager popup.
- `src/managers/PazaakManager.ts` – `CancelPazaak()`.
- `src/game/tsl/menu/MenuPazaakWager.ts` – inheritance fix.