### PR TITLE
Save & Load Subsystems Implementation

### DIFF
--- a/src/GameState.ts
+++ b/src/GameState.ts
@@ -1411,71 +1411,6 @@ export class GameState implements EngineContext {
     GameState.bokehPass.camera = GameState.currentCamera;
 
     GameState.composer.render(delta);
- // Cache last "clean gameplay" thumbnail (WORLD ONLY, no GUI)
-if (
-  GameState.Mode === EngineMode.INGAME &&
-  GameState.State !== EngineState.PAUSED &&
-  GameState.MenuManager.activeModals.length === 0
-) {
-  const size = 256;
-
-  if (!GameState.lastGameplayThumb) {
-    GameState.lastGameplayThumb = new OffscreenCanvas(size, size);
-    GameState.lastGameplayThumbCtx = GameState.lastGameplayThumb.getContext('2d')!;
-  }
-  if (!GameState.lastGameplayThumbRT) {
-    GameState.lastGameplayThumbRT = new THREE.WebGLRenderTarget(size, size, {
-      depthBuffer: true,
-      stencilBuffer: false,
-    });
-  }
-
-  // Render WORLD ONLY into a tiny RT
-  const prevRT = GameState.renderer.getRenderTarget();
-  GameState.renderer.setRenderTarget(GameState.lastGameplayThumbRT);
-  GameState.renderer.clear(true, true, true);
-  GameState.renderer.render(GameState.scene, GameState.camera); // gameplay world camera
-  GameState.renderer.setRenderTarget(prevRT);
-
-  // Read pixels (small 256x256 so this is quick)
-  const pixels = new Uint8Array(size * size * 4);
-  GameState.renderer.readRenderTargetPixels(GameState.lastGameplayThumbRT, 0, 0, size, size, pixels);
-
-  // Flip Y + force alpha
-  const flipped = new Uint8ClampedArray(pixels.length);
-  const rowBytes = size * 4;
-  for (let y = 0; y < size; y++) {
-    const src = (size - 1 - y) * rowBytes;
-    const dst = y * rowBytes;
-    flipped.set(pixels.subarray(src, src + rowBytes), dst);
-  }
-  for (let i = 3; i < flipped.length; i += 4) flipped[i] = 255;
-
-  // Store into the cached canvas
-  GameState.lastGameplayThumbCtx!.putImageData(new ImageData(flipped, size, size), 0, 0);
-}
-
-
-  //Handle screenshot callback
-if (typeof GameState.onScreenShot === 'function') {
-  const cb = GameState.onScreenShot;
-  GameState.onScreenShot = undefined; // clear immediately
-
-  // Prefer the last clean gameplay frame (pre-menu)
-  if (GameState.lastGameplayThumb) {
-    cb(TGAObject.FromCanvas(GameState.lastGameplayThumb));
-    return;
-  }
-
-  // Fallback: if no cached frame exists yet, grab current frame
-  (async () => {
-    const bmp = await createImageBitmap(GameState.canvas);
-    const ssCanvas = new OffscreenCanvas(256, 256);
-    const ctx = ssCanvas.getContext('2d')!;
-    ctx.drawImage(bmp, 0, 0, 256, 256);
-    cb(TGAObject.FromCanvas(ssCanvas));
-  })();
-}
 
     //NoClickTimer: Update
     if( ((GameState.Mode == EngineMode.MINIGAME || GameState.Mode == EngineMode.DIALOG) || (GameState.Mode == EngineMode.INGAME)) && GameState.State != EngineState.PAUSED){
@@ -1498,12 +1433,70 @@ if (typeof GameState.onScreenShot === 'function') {
       GameState.deltaTime = GameState.deltaTime % 1;
   }
 
-  static async GetScreenShot(){
-    return new Promise<TGAObject>( (resolve, reject) => {
-      GameState.onScreenShot = (tga: TGAObject) => {
-        resolve(tga);
-      };
-    });
+  /**
+   * Get a screenshot of the current game from the view of the player camera
+   * @param width - The width of the screenshot (default: 256)
+   * @param height - The height of the screenshot (default: 256)
+   * @returns A promise that resolves to a TGAObject
+   */
+  static async GetScreenShot(width = 256, height = 256): Promise<TGAObject> {
+
+    if (!GameState.lastGameplayThumb) {
+      GameState.lastGameplayThumb = new OffscreenCanvas(width, height);
+      GameState.lastGameplayThumbCtx = GameState.lastGameplayThumb.getContext('2d')!;
+    }else{
+      GameState.lastGameplayThumb.width = width;
+      GameState.lastGameplayThumb.height = height;
+    }
+
+    /**
+     * Initialize the render target
+     */
+    if (!GameState.lastGameplayThumbRT) {
+      GameState.lastGameplayThumbRT = new THREE.WebGLRenderTarget(width, height, {
+        depthBuffer: true,
+        stencilBuffer: false,
+      });
+    }else{
+      GameState.lastGameplayThumbRT.setSize(width, height);
+      GameState.lastGameplayThumbRT.texture.needsUpdate = true;
+    }
+
+    // Render WORLD ONLY into a tiny RT
+    const prevRT = GameState.renderer.getRenderTarget();
+    GameState.renderer.setRenderTarget(GameState.lastGameplayThumbRT);
+    GameState.renderer.clear(true, true, true);
+    GameState.renderer.render(GameState.scene, GameState.camera); // gameplay world camera
+    GameState.renderer.setRenderTarget(prevRT);
+
+    // Read pixels (small 256x256 so this is quick)
+    const pixels = new Uint8Array(width * height * 4);
+    GameState.renderer.readRenderTargetPixels(GameState.lastGameplayThumbRT, 0, 0, width, height, pixels);
+
+    // Flip Y + force alpha
+    const flipped = new Uint8ClampedArray(pixels.length);
+    const rowBytes = width * 4;
+    for (let y = 0; y < height; y++) {
+      const src = (width - 1 - y) * rowBytes;
+      const dst = y * rowBytes;
+      flipped.set(pixels.subarray(src, src + rowBytes), dst);
+    }
+    for (let i = 3; i < flipped.length; i += 4) flipped[i] = 255;
+
+    // Store into the cached canvas
+    GameState.lastGameplayThumbCtx!.putImageData(new ImageData(flipped, width, height), 0, 0);
+
+    // Prefer the last clean gameplay frame (pre-menu)
+    if (GameState.lastGameplayThumb) {
+      return TGAObject.FromCanvas(GameState.lastGameplayThumb);
+    }
+
+    // Fallback: if no cached frame exists yet, grab current frame
+    const bmp = await createImageBitmap(GameState.canvas);
+    const ssCanvas = new OffscreenCanvas(width, height);
+    const ctx = ssCanvas.getContext('2d')!;
+    ctx.drawImage(bmp, 0, 0, width, height);
+    return TGAObject.FromCanvas(ssCanvas);
   }
 
 }

--- a/src/game/kotor/menu/MenuSaveLoad.ts
+++ b/src/game/kotor/menu/MenuSaveLoad.ts
@@ -11,6 +11,7 @@ import { SaveGame } from "../../../engine/SaveGame";
 /**
  * MenuSaveLoad class.
  * 
+ *
  * KotOR JS - A remake of the Odyssey Game Engine that powered KotOR I & II
  * 
  * @file MenuSaveLoad.ts
@@ -32,62 +33,116 @@ export class MenuSaveLoad extends GameMenu {
   BTN_SAVELOAD: GUIButton;
 
   mode: MenuSaveLoadMode;
-  saves: SaveGame[] = [];
   selected: SaveGame;
+
+  // TLK
+  // 1592: "Are you sure you want to delete the save game?"
+  // 1591: "Are you sure you want to overwrite the save game?"
+  private static readonly STRREF_CONFIRM_DELETE = 1592;
+  private static readonly STRREF_CONFIRM_OVERWRITE = 1591;
 
   constructor(){
     super();
-    this.gui_resref = 'saveload';
-    this.background = '1600x1200back';
+    this.gui_resref = "saveload";
+    this.background = "1600x1200back";
     this.voidFill = true;
+  }
+
+  // KotOR lets you delete in both Save and Load screens.
+  // Only disallow deleting the "New Save" row.
+  private canDeleteSelected(): boolean {
+    if (!(this.selected instanceof SaveGame)) return false;
+    if (this.selected instanceof NewSaveItem) return false;
+    return true;
+  }
+
+  private async deleteSelectedSaveNow(): Promise<void> {
+    const save = this.selected;
+    if (!this.canDeleteSelected()) return;
+
+    await SaveGame.DeleteSave(save);
+    this.reloadSaves();
   }
 
   async menuControlInitializer(skipInit: boolean = false) {
     await super.menuControlInitializer();
     if(skipInit) return;
-    return new Promise<void>((resolve, reject) => {
+
+    return new Promise<void>((resolve) => {
 
       this._button_y = this.BTN_DELETE;
 
-      this.BTN_SAVELOAD.setText('Load');
-      this.BTN_SAVELOAD.addEventListener('click', (e) => {
+      // DELETE (available in both modes)
+      this.BTN_DELETE.addEventListener("click", (e) => {
+        e.stopPropagation();
+        if (!this.canDeleteSelected()) return;
+
+        this.manager.InGameConfirm.showConfirmDialog(
+          MenuSaveLoad.STRREF_CONFIRM_DELETE,
+          async () => {
+            await this.deleteSelectedSaveNow();
+          },
+          () => {}
+        );
+      });
+
+      // SAVE / LOAD
+      this.BTN_SAVELOAD.setText("Load");
+      this.BTN_SAVELOAD.addEventListener("click", (e) => {
         e.stopPropagation();
         const savegame = this.selected;
-        if(this.mode == MenuSaveLoadMode.LOADGAME){
-          if(savegame){
+
+        // LOADGAME mode: load selected save
+        if (this.mode === MenuSaveLoadMode.LOADGAME) {
+          if (savegame) {
             this.manager.ClearMenus();
-            if(GameState.module instanceof Module){
+            if (GameState.module instanceof Module) {
               GameState.module.dispose();
               GameState.module = undefined;
             }
             savegame.load();
           }
-        }else{
-          if(savegame instanceof NewSaveItem){
-            this.manager.MenuSaveName.show();
-            this.manager.MenuSaveName.onSave = ( name = '' ) => {
-              console.log('SaveGame', name);
-            };
-          }else{
-
-          }
+          return;
         }
+
+        // SAVEGAME mode
+        if (savegame instanceof NewSaveItem) {
+          // New save slot -> ask for a name
+          this.manager.MenuSaveName.open();
+          this.manager.MenuSaveName.onSave = async (name = "") => {
+            await SaveGame.SaveCurrentGame(name.trim());
+            this.reloadSaves();
+          };
+          return;
+        }
+
+        // Existing slot -> confirm overwrite (KotOR behavior: no rename)
+        this.manager.InGameConfirm.showConfirmDialog(
+          MenuSaveLoad.STRREF_CONFIRM_OVERWRITE,
+          async () => {
+            await SaveGame.OverwriteSave(savegame);
+            this.reloadSaves();
+          },
+          () => {}
+        );
       });
       this._button_a = this.BTN_SAVELOAD;
 
-      this.BTN_BACK = this.getControlByName('BTN_BACK');
-      this.BTN_BACK.addEventListener('click', (e) => {
+      // BACK
+      this.BTN_BACK = this.getControlByName("BTN_BACK");
+      this.BTN_BACK.addEventListener("click", (e) => {
         e.stopPropagation();
         this.close();
       });
       this._button_b = this.BTN_BACK;
 
+      // LIST
       this.LB_GAMES.GUIProtoItemClass = GUISaveGameItem;
       this.LB_GAMES.listMarginTop = 5;
       this.LB_GAMES.onSelected = (save: SaveGame) => {
         this.selected = save;
         this.UpdateSelected();
-      }
+      };
 
       this.tGuiPanel.getFill().position.z = -1;
       resolve();
@@ -98,22 +153,24 @@ export class MenuSaveLoad extends GameMenu {
     super.show();
     this.selectedControl = this.LB_GAMES;
     this.reloadSaves();
-    if (this.mode == MenuSaveLoadMode.SAVEGAME) {
-      this.BTN_SAVELOAD.setText(GameState.TLKManager.TLKStrings[1587].Value);
-    }else{
-      this.BTN_SAVELOAD.setText(GameState.TLKManager.TLKStrings[1589].Value);
+
+    if (this.mode === MenuSaveLoadMode.SAVEGAME) {
+      this.BTN_SAVELOAD.setText(GameState.TLKManager.TLKStrings[1587].Value); // Save
+    } else {
+      this.BTN_SAVELOAD.setText(GameState.TLKManager.TLKStrings[1589].Value); // Load
     }
+
     TextureLoader.LoadQueue();
   }
 
   getSaveGames(): SaveGame[] {
-    let saves: SaveGame[] = [];
-    if (this.mode == MenuSaveLoadMode.SAVEGAME) {
-      saves = SaveGame.saves.filter(save => {
-        return !save.getIsQuickSave() && !save.getIsAutoSave();
-      });
+    let saves: SaveGame[];
+    if (this.mode === MenuSaveLoadMode.SAVEGAME) {
+      // Save screen: only manual saves + "New Save" row
+      saves = SaveGame.saves.filter(s => !s.getIsQuickSave() && !s.getIsAutoSave());
       saves.unshift(new NewSaveItem());
-    }else{
+    } else {
+      // Load screen: all saves (including quick/autosave)
       saves = SaveGame.saves;
     }
     return saves;
@@ -121,9 +178,8 @@ export class MenuSaveLoad extends GameMenu {
 
   reloadSaves(){
     this.LB_GAMES.clearItems();
-    let saves = this.getSaveGames();
-    for (let i = 0; i < saves.length; i++) {
-      let save = saves[i];
+    const saves = this.getSaveGames();
+    for (const save of saves) {
       this.LB_GAMES.addItem(save);
     }
     this.selected = saves[0];
@@ -136,40 +192,33 @@ export class MenuSaveLoad extends GameMenu {
     this.LBL_PM1.setFillTexture(undefined);
     this.LBL_PM2.setFillTexture(undefined);
     this.LBL_PM3.setFillTexture(undefined);
-    this.LBL_PLANETNAME.setText('');
-    this.LBL_AREANAME.setText('');
+    this.LBL_PLANETNAME.setText("");
+    this.LBL_AREANAME.setText("");
+
     if (this.selected instanceof SaveGame) {
       this.LB_GAMES.selectItem(this.selected);
-      if (this.selected instanceof NewSaveItem) {
 
-      }else{
-        this.selected.getThumbnail().then((texture: OdysseyTexture) => {
-          this.LBL_SCREENSHOT.setFillTexture(texture);
-          (this.LBL_SCREENSHOT.getFill().material as THREE.ShaderMaterial).transparent = false;
+      if (!(this.selected instanceof NewSaveItem)) {
+        this.selected.getThumbnail().then((t: OdysseyTexture) => {
+          this.LBL_SCREENSHOT.setFillTexture(t);
         });
-        this.selected.getPortrait(0).then((texture: OdysseyTexture) => {
-          this.LBL_PM1.setFillTexture(texture);
-          (this.LBL_PM1.getFill().material as THREE.ShaderMaterial).transparent = false;
-        });
-        this.selected.getPortrait(1).then((texture: OdysseyTexture) => {
-          this.LBL_PM2.setFillTexture(texture);
-          (this.LBL_PM2.getFill().material as THREE.ShaderMaterial).transparent = false;
-        });
-        this.selected.getPortrait(2).then((texture: OdysseyTexture) => {
-          this.LBL_PM3.setFillTexture(texture);
-          (this.LBL_PM3.getFill().material as THREE.ShaderMaterial).transparent = false;
-        });
-        let areaNames = this.selected.getAreaName().split(' - ');
-        if (areaNames.length == 2) {
-          this.LBL_PLANETNAME.setText(areaNames[0]);
-          this.LBL_AREANAME.setText(areaNames[1]);
-        } else {
-          this.LBL_PLANETNAME.setText('');
-          this.LBL_AREANAME.setText(areaNames[0]);
-        }
+        this.selected.getPortrait(0).then(t => this.LBL_PM1.setFillTexture(t));
+        this.selected.getPortrait(1).then(t => this.LBL_PM2.setFillTexture(t));
+        this.selected.getPortrait(2).then(t => this.LBL_PM3.setFillTexture(t));
+
+        const area = this.selected.getAreaName().split(" - ");
+        this.LBL_PLANETNAME.setText(area.length === 2 ? area[0] : "");
+        this.LBL_AREANAME.setText(area.length === 2 ? area[1] : area[0]);
       }
+
       this.BTN_SAVELOAD.show();
-      this.BTN_DELETE.show();
+
+      // Delete is available in both modes, but not on the "New Save" row
+      if (this.selected instanceof NewSaveItem) {
+        this.BTN_DELETE.hide();
+      } else {
+        this.BTN_DELETE.show();
+      }
     } else {
       this.BTN_SAVELOAD.hide();
       this.BTN_DELETE.hide();
@@ -177,13 +226,12 @@ export class MenuSaveLoad extends GameMenu {
   }
 
   triggerControllerDUpPress() {
-    this.LB_GAMES.directionalNavigate('up');
+    this.LB_GAMES.directionalNavigate("up");
   }
 
   triggerControllerDDownPress() {
-    this.LB_GAMES.directionalNavigate('down');
+    this.LB_GAMES.directionalNavigate("down");
   }
-  
 }
 
 export class NewSaveItem extends SaveGame {

--- a/src/game/kotor/menu/MenuSaveName.ts
+++ b/src/game/kotor/menu/MenuSaveName.ts
@@ -21,6 +21,7 @@ export class MenuSaveName extends GameMenu {
 
   constructor(){
     super();
+    this.isOverlayGUI = true;
     this.gui_resref = 'savename';
     this.background = '';
     this.voidFill = false;
@@ -33,8 +34,8 @@ export class MenuSaveName extends GameMenu {
       this.EDITBOX.setEditable(true);
 
       this.BTN_OK.addEventListener('click', () => {
-        // if(typeof this.onSave == 'function')
-        //   this.onSave(this.EDITBOX.getValue())
+      if(typeof this.onSave == 'function')
+          this.onSave(this.EDITBOX.getValue())
 
         this.close();
       });


### PR DESCRIPTION
## Summary

This PR brings the Save/Load system more in line with **vanilla KotOR engine behavior** and fixes several UX and stability issues around save handling and screenshots by:

- Implementing Delete + Overwrite flows with confirm dialogs.
- Making Save Name actually feed back into the save system.
- Fixing save list refresh/update for both new saves and overwrites.
- Reworking screenshot capture to produce a clean gameplay thumbnail (no menus) reliably.

---

## Changes

### Save / Load Menu (`MenuSaveLoad.ts`)
- **Delete save games** is now available.
- Added confirmation dialogs using existing `InGameConfirm`:
  - **TLK 1592** – delete confirmation
  - **TLK 1591** – overwrite confirmation
- **Overwrite behavior** matches KotOR:
  - Existing saves prompt for confirmation
  - No rename prompt when overwriting
- “New Save” slot correctly opens `MenuSaveName` and saves on confirmation.
- Save list refreshes immediately after delete, new save, or overwrite.
- UI updates avoid loading thumbnails/portraits for the “New Save” entry.
- Delete button is hidden for the “New Save” row.

---

### Save Name Menu (`MenuSaveName.ts`)
- Restored correct save callback execution when pressing **OK**.
- Marked menu as an **overlay GUI** to behave consistently with other modal dialogs.

---

### Save System (`SaveGame.ts`)
- Save list now updates correctly after:
  - creating a new save
  - overwriting an existing save
- Overwritten saves replace the existing entry in `SaveGame.saves`.
- Save metadata (`savenfo.res`) is reloaded immediately to avoid stale UI data.

---

### Screenshot / Game State (`GameState.ts`)
- Reworked save thumbnail capture to avoid freezes and UI contamination:
  - Caches a **clean gameplay render** (world only, no menus).
  - Uses a small render target + pixel readback instead of `toDataURL` / `Image.onload`.
- Save thumbnails now reliably reflect the actual gameplay camera without menus.

---

## Result

- Save/Load UX is now closer to the **original KotOR** behavior.
- Save thumbnails are clean and consistent.
- Delete and overwrite flows are implemented.
- Save list stays in sync without requiring a restart.
