### PR TITLE
feat(nwscript): add 14 missing actions for full K1CP compatibility

### DIFF
--- a/src/effects/EffectTrueSeeing.ts
+++ b/src/effects/EffectTrueSeeing.ts
@@ -1,0 +1,26 @@
+import { GameEffect } from "@/effects/GameEffect";
+import { GameEffectType } from "@/enums/effects/GameEffectType";
+
+/**
+ * EffectTrueSeeing class.
+ *
+ * KotOR JS - A remake of the Odyssey Game Engine that powered KotOR I & II
+ *
+ * @file EffectTrueSeeing.ts
+ * @author KobaltBlu <https://github.com/KobaltBlu>
+ * @license {@link https://www.gnu.org/licenses/gpl-3.0.txt|GPLv3}
+ */
+export class EffectTrueSeeing extends GameEffect {
+  constructor(){
+    super();
+    this.type = GameEffectType.EffectTrueseeing;
+  }
+
+  onApply(){
+    if(this.applied)
+      return;
+
+    super.onApply();
+  }
+
+}

--- a/src/effects/GameEffectFactory.ts
+++ b/src/effects/GameEffectFactory.ts
@@ -58,6 +58,7 @@ import { EffectTemporaryHitPoints } from "@/effects/EffectTemporaryHitPoints";
 import { EffectVisualEffect } from "@/effects/EffectVisualEffect";
 import { EffectForceResistanceIncrease } from "@/effects/EffectForceResistanceIncrease";
 import { EffectForceResistanceDecrease } from "@/effects/EffectForceResistanceDecrease";
+import { EffectTrueSeeing } from "@/effects/EffectTrueSeeing";
 import { GameEffect } from "@/effects/GameEffect";
 
 /**
@@ -136,7 +137,7 @@ export class GameEffectFactory {
   static EffectRacialType: typeof EffectRacialType = EffectRacialType;
   // static EffectSeeInvisible: typeof EffectSeeInvisible = EffectSeeInvisible;
   // static EffectUltraVision: typeof EffectUltraVision = EffectUltraVision;
-  // static EffectTrueseeing: typeof EffectTrueseeing = EffectTrueseeing;
+  static EffectTrueSeeing: typeof EffectTrueSeeing = EffectTrueSeeing;
   // static EffectBlindness: typeof EffectBlindness = EffectBlindness;
   // static EffectDarkness: typeof EffectDarkness = EffectDarkness;
   static EffectMissChance: typeof EffectMissChance = EffectMissChance;
@@ -375,6 +376,9 @@ export class GameEffectFactory {
       break;
       case GameEffectType.EffectSetState: //EffectSetState
         effect = new EffectSetState();
+      break;
+      case GameEffectType.EffectTrueseeing: //TrueSeeing
+        effect = new EffectTrueSeeing();
       break;
     }
 

--- a/src/effects/index.ts
+++ b/src/effects/index.ts
@@ -57,5 +57,6 @@ export * from "@/effects/EffectSlow";
 export * from "@/effects/EffectSpellImmunity";
 export * from "@/effects/EffectTemporaryForce";
 export * from "@/effects/EffectTemporaryHitPoints";
+export * from "@/effects/EffectTrueSeeing";
 export * from "@/effects/EffectVisualEffect";
 export * from "@/effects/GameEffectFactory";

--- a/src/module/Module.ts
+++ b/src/module/Module.ts
@@ -67,6 +67,7 @@ export class Module {
   customTokens: Map<number, string>;
   transition: any;
   transWP: string;
+  lastItemAcquired: any = undefined;
 
   /**
    * List of Areas in the module

--- a/src/module/ModuleObject.ts
+++ b/src/module/ModuleObject.ts
@@ -162,6 +162,9 @@ export class ModuleObject {
   _locals: { Booleans: any[]; Numbers: {}; };
   objectsInside: any[];
   lockDialogOrientation: boolean = false;
+  lastInventoryDisturbType: number = 0;
+  lastInventoryDisturbItem: any = undefined;
+  lastItemAcquired: any = undefined;
   context: any;
 
   heartbeatTimer: any;

--- a/src/nwscript/NWScriptDefK1.ts
+++ b/src/nwscript/NWScriptDefK1.ts
@@ -6008,7 +6008,30 @@ NWScriptDefK1.Actions = {
     comment: "501: The action subject will fake casting a spell at oTarget; the conjure and cast\nanimations and visuals will occur, nothing else.\n- nSpell\n- oTarget\n- nProjectilePathType: PROJECTILE_PATH_TYPE_*\n",
     name: "ActionCastFakeSpellAtObject",
     type: NWScriptDataType.VOID,
-    args: [NWScriptDataType.INTEGER, NWScriptDataType.OBJECT, NWScriptDataType.INTEGER]
+    args: [NWScriptDataType.INTEGER, NWScriptDataType.OBJECT, NWScriptDataType.INTEGER],
+    action: function(this: NWScriptInstance, args: [number, ModuleObject, number]){
+      if(!BitWise.InstanceOfObject(this.caller, ModuleObjectType.ModuleObject)){
+        return;
+      }
+      if(!BitWise.InstanceOfObject(args[1], ModuleObjectType.ModuleObject)){
+        return;
+      }
+
+      const action = new GameState.ActionFactory.ActionCastSpell();
+      action.setParameter(0, ActionParameterType.INT, args[0]); //Spell Id
+      action.setParameter(1, ActionParameterType.INT, -1); //Cheat enabled
+      action.setParameter(2, ActionParameterType.INT, 0); //DomainLevel
+      action.setParameter(3, ActionParameterType.INT, 0);
+      action.setParameter(4, ActionParameterType.INT, 0);
+      action.setParameter(5, ActionParameterType.DWORD, args[1].id); //Target Object
+      action.setParameter(6, ActionParameterType.FLOAT, args[1].position.x);
+      action.setParameter(7, ActionParameterType.FLOAT, args[1].position.y);
+      action.setParameter(8, ActionParameterType.FLOAT, args[1].position.z);
+      action.setParameter(9, ActionParameterType.INT, args[2] || 0); //ProjectilePath
+      action.setParameter(10, ActionParameterType.INT, -1);
+      action.setParameter(11, ActionParameterType.INT, -1);
+      this.caller.actionQueue.add(action);
+    }
   },
   502:{
     comment: "502: The action subject will fake casting a spell at lLocation; the conjure and\ncast animations and visuals will occur, nothing else.\n- nSpell\n- lTarget\n- nProjectilePathType: PROJECTILE_PATH_TYPE_*\n",

--- a/src/nwscript/NWScriptDefK1.ts
+++ b/src/nwscript/NWScriptDefK1.ts
@@ -8490,7 +8490,16 @@ NWScriptDefK1.Actions = {
     comment: "767. SetAvailableNPCId\nThis will set the object id that should be used for a specific available NPC\n",
     name: "SetAvailableNPCId",
     type: NWScriptDataType.VOID,
-    args: []
+    args: [NWScriptDataType.INTEGER, NWScriptDataType.OBJECT],
+    action: function(this: NWScriptInstance, args: [number, ModuleObject]){
+      const npc = GameState.PartyManager.NPCS[args[0]];
+      if(!npc){
+        return;
+      }
+      if(BitWise.InstanceOfObject(args[1], ModuleObjectType.ModuleCreature)){
+        npc.moduleObject = args[1];
+      }
+    }
   },
   768:{
     comment: "768. IsMoviePlaying\nChecks if a movie is currently playing.\n",

--- a/src/nwscript/NWScriptDefK1.ts
+++ b/src/nwscript/NWScriptDefK1.ts
@@ -1373,7 +1373,23 @@ NWScriptDefK1.Actions = {
     comment: "106: Get the object type (OBJECT_TYPE_*) of oTarget\n* Return value if oTarget is not a valid object: -1\n",
     name: "GetObjectType",
     type: NWScriptDataType.INTEGER,
-    args: [NWScriptDataType.OBJECT]
+    args: [NWScriptDataType.OBJECT],
+    action: function(this: NWScriptInstance, args: [ModuleObject]){
+      if(!BitWise.InstanceOfObject(args[0], ModuleObjectType.ModuleObject)){
+        return -1;
+      }
+      if(BitWise.InstanceOfObject(args[0], ModuleObjectType.ModuleCreature)) return NWModuleObjectType.CREATURE;
+      if(BitWise.InstanceOfObject(args[0], ModuleObjectType.ModuleItem)) return NWModuleObjectType.ITEM;
+      if(BitWise.InstanceOfObject(args[0], ModuleObjectType.ModuleTrigger)) return NWModuleObjectType.TRIGGER;
+      if(BitWise.InstanceOfObject(args[0], ModuleObjectType.ModuleDoor)) return NWModuleObjectType.DOOR;
+      if(BitWise.InstanceOfObject(args[0], ModuleObjectType.ModuleAreaOfEffect)) return NWModuleObjectType.AOE;
+      if(BitWise.InstanceOfObject(args[0], ModuleObjectType.ModuleWaypoint)) return NWModuleObjectType.WAYPOINT;
+      if(BitWise.InstanceOfObject(args[0], ModuleObjectType.ModulePlaceable)) return NWModuleObjectType.PLACEABLE;
+      if(BitWise.InstanceOfObject(args[0], ModuleObjectType.ModuleStore)) return NWModuleObjectType.STORE;
+      if(BitWise.InstanceOfObject(args[0], ModuleObjectType.ModuleEncounter)) return NWModuleObjectType.ENCOUNTER;
+      if(BitWise.InstanceOfObject(args[0], ModuleObjectType.ModuleSound)) return NWModuleObjectType.SOUND;
+      return -1;
+    }
   },
   107:{
     comment: "107: Get the racial type (RACIAL_TYPE_*) of oCreature\n* Return value if oCreature is not a valid creature: RACIAL_TYPE_INVALID\n",

--- a/src/nwscript/NWScriptDefK1.ts
+++ b/src/nwscript/NWScriptDefK1.ts
@@ -4544,7 +4544,10 @@ NWScriptDefK1.Actions = {
     comment: "374: Send a server message (szMessage) to the oPlayer.\n",
     name: "SendMessageToPC",
     type: NWScriptDataType.VOID,
-    args: [NWScriptDataType.OBJECT, NWScriptDataType.STRING]
+    args: [NWScriptDataType.OBJECT, NWScriptDataType.STRING],
+    action: function(this: NWScriptInstance, args: [ModuleObject, string]){
+      console.log('[SendMessageToPC]', args[1]);
+    }
   },
   375:{
     comment: "375: Get the target at which the caller attempted to cast a spell.\nThis value is set every time a spell is cast and is reset at the end of\ncombat.\n* Returns OBJECT_INVALID if the caller is not a valid creature.\n",

--- a/src/nwscript/NWScriptDefK1.ts
+++ b/src/nwscript/NWScriptDefK1.ts
@@ -5693,7 +5693,13 @@ NWScriptDefK1.Actions = {
     comment: "465: Create a True Seeing effect.\n",
     name: "EffectTrueSeeing",
     type: NWScriptDataType.EFFECT,
-    args: []
+    args: [],
+    action: function(this: NWScriptInstance, args: []){
+      let effect = new GameState.GameEffectFactory.EffectTrueSeeing();
+      effect.setCreator(this.caller);
+      effect.setSpellId(this.getSpellId());
+      return effect.initialize();
+    }
   },
   466:{
     comment: "466: Create a See Invisible effect.\n",

--- a/src/nwscript/NWScriptDefK1.ts
+++ b/src/nwscript/NWScriptDefK1.ts
@@ -8528,7 +8528,30 @@ NWScriptDefK1.Actions = {
     comment: "762: SurrenderRetainBuffs()\nThis will do the same as SurrenderToEnemies, except that affected creatures will not\nlose effects which they have put on themselves\n",
     name: "SurrenderRetainBuffs",
     type: NWScriptDataType.VOID,
-    args: []
+    args: [],
+    action: function(this: NWScriptInstance, args: []){
+      if(!BitWise.InstanceOfObject(this.caller, ModuleObjectType.ModuleCreature)){
+        return;
+      }
+      if(BitWise.InstanceOfObject(this.caller, ModuleObjectType.ModulePlayer)){
+        return;
+      }
+
+      const caller = this.caller as ModuleCreature;
+      const creatures = GameState.module.area.creatures;
+      for(let i = 0; i < creatures.length; i++){
+        const creature = creatures[i];
+        if(creature === caller) continue;
+        const dx = creature.position.x - caller.position.x;
+        const dy = creature.position.y - caller.position.y;
+        if(dx * dx + dy * dy > 100) continue; // 10m radius = 100 sq
+        if(creature.isHostile(caller)){
+          creature.clearAllActions();
+          // Unlike SurrenderToEnemies, do NOT clear effects
+          GameState.FactionManager.SetFactionReputation(caller, creature, 50);
+        }
+      }
+    }
   },
   763:{
     comment: "763. SuppressStatusSummaryEntry\nThis will prevent the next n entries that should have shown up in the status summary\nfrom being added\nThis will not add on to any existing summary suppressions, but rather replace it.  So\nto clear the supression system pass 0 as the entry value\n",

--- a/src/nwscript/NWScriptDefK1.ts
+++ b/src/nwscript/NWScriptDefK1.ts
@@ -5800,7 +5800,30 @@ NWScriptDefK1.Actions = {
     comment: "476: Use this on an NPC to cause all creatures within a 10-metre radius to stop\nwhat they are doing and sets the NPC's enemies within this range to be\nneutral towards the NPC. If this command is run on a PC or an object that is\nnot a creature, nothing will happen.\n",
     name: "SurrenderToEnemies",
     type: NWScriptDataType.VOID,
-    args: []
+    args: [],
+    action: function(this: NWScriptInstance, args: []){
+      if(!BitWise.InstanceOfObject(this.caller, ModuleObjectType.ModuleCreature)){
+        return;
+      }
+      if(BitWise.InstanceOfObject(this.caller, ModuleObjectType.ModulePlayer)){
+        return;
+      }
+
+      const caller = this.caller as ModuleCreature;
+      const creatures = GameState.module.area.creatures;
+      for(let i = 0; i < creatures.length; i++){
+        const creature = creatures[i];
+        if(creature === caller) continue;
+        const dx = creature.position.x - caller.position.x;
+        const dy = creature.position.y - caller.position.y;
+        if(dx * dx + dy * dy > 100) continue; // 10m radius = 100 sq
+        if(creature.isHostile(caller)){
+          creature.clearAllActions();
+          creature.clearAllEffects();
+          GameState.FactionManager.SetFactionReputation(caller, creature, 50);
+        }
+      }
+    }
   },
   477:{
     comment: "477: Create a Miss Chance effect.\n- nPercentage: 1-100 inclusive\n* Returns an effect of type EFFECT_TYPE_INVALIDEFFECT if nPercentage < 1 or\nnPercentage > 100.\n",

--- a/src/nwscript/NWScriptDefK1.ts
+++ b/src/nwscript/NWScriptDefK1.ts
@@ -3446,7 +3446,22 @@ NWScriptDefK1.Actions = {
     comment: "271: Give oItem to oGiveTo (instant; for similar Action use ActionGiveItem)\nIf oItem is not a valid item, or oGiveTo is not a valid object, nothing will\nhappen.\n",
     name: "GiveItem",
     type: NWScriptDataType.VOID,
-    args: [NWScriptDataType.OBJECT, NWScriptDataType.OBJECT]
+    args: [NWScriptDataType.OBJECT, NWScriptDataType.OBJECT],
+    action: function(this: NWScriptInstance, args: [ModuleObject, ModuleObject]){
+      if(!BitWise.InstanceOfObject(args[0], ModuleObjectType.ModuleItem)){
+        return;
+      }
+
+      if(!BitWise.InstanceOfObject(args[1], ModuleObjectType.ModuleObject)){
+        return;
+      }
+
+      if(GameState.PartyManager.party.indexOf(args[1] as any) >= 0){
+        GameState.InventoryManager.addItem(args[0] as ModuleItem);
+      }else{
+        args[1].addItem(args[0] as ModuleItem);
+      }
+    }
   },
   272:{
     comment: "272: Convert oObject into a hexadecimal string.\n",

--- a/src/nwscript/NWScriptDefK1.ts
+++ b/src/nwscript/NWScriptDefK1.ts
@@ -319,6 +319,48 @@ NWScriptDefK1.Actions = {
     name: "ActionMoveAwayFromObject",
     type: NWScriptDataType.VOID,
     args: [NWScriptDataType.OBJECT, NWScriptDataType.INTEGER, NWScriptDataType.FLOAT],
+    action: function(this: NWScriptInstance, args: [ModuleObject, number, number]){
+      if(!BitWise.InstanceOfObject(this.caller, ModuleObjectType.ModuleCreature)){
+        return;
+      }
+      if(!BitWise.InstanceOfObject(args[0], ModuleObjectType.ModuleObject)){
+        return;
+      }
+
+      const caller = this.caller as ModuleCreature;
+      const fleeFrom = args[0];
+      const bRun = !!args[1];
+      const range = args[2] || 10.0;
+
+      // Calculate a point that is range meters from fleeFrom, along the
+      // direction from fleeFrom through the caller
+      const dx = caller.position.x - fleeFrom.position.x;
+      const dy = caller.position.y - fleeFrom.position.y;
+      const dist = Math.sqrt(dx * dx + dy * dy) || 1.0;
+
+      // Already far enough away
+      if(dist >= range){
+        return;
+      }
+
+      const nx = dx / dist;
+      const ny = dy / dist;
+      const targetX = fleeFrom.position.x + nx * range;
+      const targetY = fleeFrom.position.y + ny * range;
+      const targetZ = caller.position.z;
+
+      const action = new GameState.ActionFactory.ActionMoveToPoint();
+      action.setParameter(0, ActionParameterType.FLOAT, targetX);
+      action.setParameter(1, ActionParameterType.FLOAT, targetY);
+      action.setParameter(2, ActionParameterType.FLOAT, targetZ);
+      action.setParameter(3, ActionParameterType.DWORD, GameState.module.area.id);
+      action.setParameter(4, ActionParameterType.DWORD, 0);
+      action.setParameter(5, ActionParameterType.INT, bRun ? 1 : 0);
+      action.setParameter(6, ActionParameterType.FLOAT, 1.0);
+      action.setParameter(7, ActionParameterType.INT, 0);
+      action.setParameter(8, ActionParameterType.FLOAT, 30.0);
+      caller.actionQueue.add(action);
+    }
   },
   24:{
     comment: "24: Get the area that oTarget is currently in\n* Return value on error: OBJECT_INVALID\n",

--- a/src/nwscript/NWScriptDefK1.ts
+++ b/src/nwscript/NWScriptDefK1.ts
@@ -3579,7 +3579,10 @@ NWScriptDefK1.Actions = {
     comment: "282: Use this in an OnItemAcquired script to get the item that was acquired.\n* Returns OBJECT_INVALID if the module is not valid.\n",
     name: "GetModuleItemAcquired",
     type: NWScriptDataType.OBJECT,
-    args: []
+    args: [],
+    action: function(this: NWScriptInstance, args: []){
+      return GameState.module?.lastItemAcquired ?? undefined;
+    }
   },
   283:{
     comment: "283: Use this in an OnItemAcquired script to get the creatre that previously\npossessed the item.\n* Returns OBJECT_INVALID if the item was picked up from the ground.\n",

--- a/src/nwscript/NWScriptDefK1.ts
+++ b/src/nwscript/NWScriptDefK1.ts
@@ -4359,13 +4359,19 @@ NWScriptDefK1.Actions = {
     comment: "352: Get the type of disturbance (INVENTORY_DISTURB_*) that caused the caller's\nOnInventoryDisturbed script to fire.  This will only work for creatures and\nplaceables.\n",
     name: "GetInventoryDisturbType",
     type: NWScriptDataType.INTEGER,
-    args: []
+    args: [],
+    action: function(this: NWScriptInstance, args: []){
+      return this.caller.lastInventoryDisturbType ?? 0;
+    }
   },
   353:{
     comment: "353: get the item that caused the caller's OnInventoryDisturbed script to fire.\n* Returns OBJECT_INVALID if the caller is not a valid object.\n",
     name: "GetInventoryDisturbItem",
     type: NWScriptDataType.OBJECT,
-    args: []
+    args: [],
+    action: function(this: NWScriptInstance, args: []){
+      return this.caller.lastInventoryDisturbItem ?? undefined;
+    }
   },
   354:{
     comment: "354: Displays the upgrade screen where the player can modify weapons and armor\n",

--- a/src/nwscript/NWScriptDefK1.ts
+++ b/src/nwscript/NWScriptDefK1.ts
@@ -5984,7 +5984,12 @@ NWScriptDefK1.Actions = {
     comment: "506: SetLockHeadFollowInDialog\nAllows the locking and undlocking of head following for an object in dialog\n- oObject - Object\n- nValue - TRUE or FALSE\n",
     name: "SetLockHeadFollowInDialog",
     type: NWScriptDataType.VOID,
-    args: [NWScriptDataType.OBJECT, NWScriptDataType.INTEGER]
+    args: [NWScriptDataType.OBJECT, NWScriptDataType.INTEGER],
+    action: function(this: NWScriptInstance, args: [ModuleObject, number]){
+      if(BitWise.InstanceOfObject(args[0], ModuleObjectType.ModuleCreature)){
+        (args[0] as ModuleCreature).headTrackingEnabled = !args[1];
+      }
+    }
   },
   507:{
     comment: "507: CutsceneMoveToPoint\nUsed by the cutscene system to allow designers to script combat\n",

--- a/src/nwscript/NWScriptDefK1.ts
+++ b/src/nwscript/NWScriptDefK1.ts
@@ -3394,7 +3394,12 @@ NWScriptDefK1.Actions = {
     comment: "266: Flag the specified item as being non-equippable or not.  Set bNonEquippable\nto TRUE to prevent this item from being equipped, and FALSE to allow\nthe normal equipping checks to determine if the item can be equipped.\nNOTE: This will do nothing if the object passed in is not an item.  Items that\nare already equipped when this is called will not automatically be\nunequipped.  These items will just be prevented from being re-equipped\nshould they be unequipped.\n",
     name: "SetItemNonEquippable",
     type: NWScriptDataType.VOID,
-    args: [NWScriptDataType.OBJECT, NWScriptDataType.INTEGER]
+    args: [NWScriptDataType.OBJECT, NWScriptDataType.INTEGER],
+    action: function(this: NWScriptInstance, args: [ModuleObject, number]){
+      if(BitWise.InstanceOfObject(args[0], ModuleObjectType.ModuleItem)){
+        (args[0] as ModuleItem).nonEquippable = !!args[1];
+      }
+    }
   },
   267:{
     comment: "267: GetButtonMashCheck\nThis function returns whether the button mash check, used for the combat tutorial, is on\n",


### PR DESCRIPTION
Hello there!

I'm a chronic kotOR nostalgic (and a web/PHP developer with almost 20 years of experience), and I've often wondered how I could contribute to amazing open source projects around this game, but they are mostly in programming languages I know nothing about, or require extensive modder/games internals knowledge. I only did some mapping/scripting in JK2/JKA, but that was a loooong time ago, so... anyway! :'D

Today I found your project, noticed it was active, and was curious to learn more about it. So I looked around the repo/history/PRs, ran the online playground, and noticed the character creation menu only allowed "the quick path" (no way to define skills, traits and such). Knowing this project was in JS, which felt less intimidating, I thought maybe that was my opportunity to contribute. So I fired up Claude to investigate these menus actions. It quickly got a bit complicated, so I set it aside. But then I got curious if the project was fully compatible with K1CP or not.

As KotOR.js already loads K1CP's modified files automatically when pointed at a patched game directory (Override files, modified .mod archives, patched dialog.tlk, recompiled .ncs scripts all load through the existing resource system), the only missing piece was to make sure all functions used in K1CP's files were implemented in KotOR.js.

Here's how Claude found these 14 missing functions, and then proceeded to implement them :

1. Cloned K1CP and extracted all 824 `.nss` source files.
2. Parsed every script to extract engine function calls (filtering out user-defined `cp_*`, `GN_*`, `UT_*` functions).
3. Cross-referenced with all 772 engine function definitions in `NWScriptDefK1.ts`.

I thought this was probably a good candidate for a first PR on such a project ; small, isolated scope. So here it is!

I've re-read every commit attentively, and challenged Claude on every possible topic I could think of (code style convention, type conversion, function signature mismatches, etc), so the quality is "as good as I can get it" with the knowledge I have. This might not look like it, but this PR took me the whole afternoon. :sweat_smile: 

**Important disclaimer:** I've not tested any of these changes, as I wouldn't know how. It would require saves for a dozen specific game points, which I don't have. And even with those, most of these won't have a visible/lasting effect anyway, or wouldn't crash the game. So they seemed safe enough for me to at least open a PR about them. Below you'll find some patches for more changes that I wasn't so sure were safe.

Each function is a separate commit for easy cherry-picking, in case you like some but not all of them.

## Implemented Functions

| # | Function | Used by | Implementation approach |
|---|---|---|---|
| 1 | `GetObjectType` | 3 scripts | Maps internal `ModuleObjectType` bitmask → `NWModuleObjectType` enum |
| 2 | `SendMessageToPC` | 1 script | Logs to console (single-player equivalent) |
| 3 | `SetItemNonEquippable` | 1 script | Sets existing `ModuleItem.nonEquippable` property |
| 4 | `SetLockHeadFollowInDialog` | 6 scripts | Toggles existing `ModuleCreature.headTrackingEnabled` (mirrors `SetLockOrientationInDialog`) |
| 5 | `GiveItem` | 6 scripts | Instant item transfer, reuses `ActionGiveItem` logic without action queue |
| 6+7 | `GetInventoryDisturbType` + `GetInventoryDisturbItem` | 1 script | Accessors reading from new properties on `ModuleObject` (see limitations) |
| 8 | `GetModuleItemAcquired` | 1 script | Accessor reading from new property on `Module` (see limitations) |
| 9 | `SetAvailableNPCId` | 1 script | Sets `moduleObject` on `PartyManager.NPCS` slot; **also fixes arg signature** (stub had empty `args: []` but function takes `[int, object]`) |
| 10 | `ActionMoveAwayFromObject` | 5 scripts | Calculates opposite-direction point, queues `ActionMoveToPoint` |
| 11 | `ActionCastFakeSpellAtObject` | 7 scripts | Queues `ActionCastSpell` with cheat mode (animations only, no spell effects) |
| 12 | `EffectTrueSeeing` | 1 script | New `EffectTrueSeeing` class + factory registration |
| 13 | `SurrenderToEnemies` | 5 scripts | 10m radius scan, clear actions/effects, set faction rep to neutral |
| 14 | `SurrenderRetainBuffs` | 1 script | Same as above but preserves self-applied effects |

## Known Limitations

### Event wiring not yet connected for some actions

`GetInventoryDisturbType`, `GetInventoryDisturbItem`, and `GetModuleItemAcquired` have working accessor implementations, but the properties they read from are **never populated** by the current event system. This means they will return default values (0 / undefined) at runtime.

**Why these are still worth including:** The accessor plumbing is correct and follows the patterns of other event-based getters (e.g., `GetLastOpenedBy`, `GetEnteringObject`). The event wiring is a separate concern that touches high-traffic code paths (`ModuleObject.addItem()`, `InventoryManager.addItem()`), so I'd prefer to discuss the approach rather than include it silently.

<details>
<summary><b>Proposed patch: wire up OnInventoryDisturbed in ModuleObject.addItem()</b></summary>

The K1CP script `k_pkor_therangen.nss` (Korriban Therangen Obelisk) checks for `INVENTORY_DISTURB_TYPE_ADDED` when a grenade is placed into the obelisk. This requires firing the event from `addItem()`:

```diff
--- a/src/module/ModuleObject.ts
+++ b/src/module/ModuleObject.ts
@@ -1717,6 +1717,16 @@
   addItem(item: ModuleItem){
     item.load();
 
+    // Fire OnInventoryDisturbed event (INVENTORY_DISTURB_TYPE_ADDED = 0)
+    this.lastInventoryDisturbType = 0;
+    this.lastInventoryDisturbItem = item;
+    if(BitWise.InstanceOfObject(this, ModuleObjectType.ModulePlaceable)){
+      const instance = (this as any).scripts?.[ModuleObjectScript.PlaceableOnInvDisturbed];
+      if(instance){
+        instance.run(this);
+      }
+    }
+
     const eItem = this.getItemByTag(item.getTag());
```

And set the properties during the existing `retrieveInventory()` flow:

```diff
--- a/src/module/ModulePlaceable.ts
+++ b/src/module/ModulePlaceable.ts
@@ -405,6 +405,8 @@
   retrieveInventory(){
     while(this.inventory.length){
       const item = this.inventory.pop();
+      this.lastInventoryDisturbType = 1; // INVENTORY_DISTURB_TYPE_REMOVED
+      this.lastInventoryDisturbItem = item;
       GameState.InventoryManager.addItem(item);
     }
```

**Concern:** `addItem()` is called from many places (NWScript actions, store purchases, save game loading, creature inventory init). The original engine likely only fires OnInventoryDisturbed for player-initiated UI actions, not programmatic transfers. This may need a guard or a `silent` parameter to avoid unintended script triggers during loading.

</details>

<details>
<summary><b>Proposed patch: wire up Mod_OnAcquirItem in InventoryManager</b></summary>

The K1CP script `k_pdan_14b_itmaq.nss` (Dantooine diary) expects the module-level `Mod_OnAcquirItem` event to fire when the player picks up an item:

```diff
--- a/src/managers/InventoryManager.ts
+++ b/src/managers/InventoryManager.ts
@@ -143,6 +143,14 @@
         InventoryManager.inventory.push(item);
+
+        // Fire module OnAcquireItem event
+        if(GameState.module){
+          GameState.module.lastItemAcquired = item;
+          const script = GameState.module.scripts?.[ModuleObjectScript.ModuleOnPlayerAcquireItem];
+          if(script){
+            script.run(GameState.module.area, 0);
+          }
+        }
+
         return item;
```

**Concern:** Same issue — `InventoryManager.addItem()` is called during save game deserialization, store purchases, and scripted item creation, not just player pickup. The event should probably only fire from specific call sites (`retrieveInventory`, `ActionGiveItem`, `ActionTakeItem`), not globally.

</details>

I'd appreciate guidance on the right approach to implement and test these event-wiring changes, in case you want me to include them.
Let me know if there's anything else I can do.