### PR TITLE
feat(loading): show asset progress, bar, and ETA on loading screen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+      - main
+
+jobs:
+  unit:
+    name: Unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run unit tests
+        run: npm test
+
+  build:
+    name: Production build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Webpack production build
+        run: npm run webpack:prod

--- a/jest.config.js
+++ b/jest.config.js
@@ -13,6 +13,7 @@ module.exports = {
     }],
   },
   testMatch: ['**/*.test.ts'],
+  testPathIgnorePatterns: ['/node_modules/', '<rootDir>/src/tests/'],
   coverageDirectory: './coverage',
   coverageReporters: ['text', 'lcov', 'html'],
   verbose: true

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,7 +6,11 @@ module.exports = {
     '^@/(.*)$': '<rootDir>/src/$1',
   },
   transform: {
-    "^.+.ts?$": ["ts-jest", {}],
+    "^.+.ts?$": ["ts-jest", {
+      tsconfig: {
+        types: ['jest', 'node'],
+      },
+    }],
   },
   testMatch: ['**/*.test.ts'],
   coverageDirectory: './coverage',

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "electron:icon": "npx --yes electron-icon-builder --input=src/assets/icon-256.png --output=src/assets/icons",
     "generate-manifest": "node scripts/generate-manifest.js",
     "typedoc": "typedoc --out ./wiki ./src/KotOR.ts",
-    "test": "jest --verbose --coverage --no-cache ./src/tests"
+    "test": "jest --verbose --coverage --no-cache"
   },
   "author": "KobaltBlu",
   "license": "GPL-3.0",

--- a/src/apps/common/components/loadingScreen/LoadingScreen.scss
+++ b/src/apps/common/components/loadingScreen/LoadingScreen.scss
@@ -40,6 +40,52 @@
     font-family: sans-serif;
     text-align: center;
   }
+
+  .loading-message {
+    max-width: min(90vw, 900px);
+    margin: 0 auto;
+    padding: 0 16px;
+    box-sizing: border-box;
+  }
+
+  .loading-message-text {
+    color: #fff;
+    font-size: 18pt;
+    line-height: 1.3;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    margin-bottom: 12px;
+  }
+
+  .loading-progress {
+    font-size: 11pt;
+  }
+
+  .loading-progress-track {
+    height: 8px;
+    border: 1px solid rgba(33, 135, 231, 0.9);
+    border-radius: 4px;
+    background: rgba(0, 0, 0, 0.45);
+    overflow: hidden;
+    box-shadow: 0 0 12px rgba(33, 135, 231, 0.35);
+  }
+
+  .loading-progress-bar {
+    height: 100%;
+    background: linear-gradient(90deg, rgba(0, 183, 229, 0.95), rgba(33, 135, 231, 0.95));
+    transition: width 0.15s ease-out;
+  }
+
+  .loading-progress-meta {
+    display: flex;
+    justify-content: space-between;
+    gap: 12px;
+    margin-top: 8px;
+    color: rgba(255, 255, 255, 0.85);
+    font-size: 10pt;
+    font-variant-numeric: tabular-nums;
+  }
   
   .background {
     display: block;

--- a/src/apps/common/components/loadingScreen/LoadingScreen.tsx
+++ b/src/apps/common/components/loadingScreen/LoadingScreen.tsx
@@ -1,28 +1,32 @@
 import React, { useEffect, useRef, useState } from "react";
 import "@/apps/common/components/loadingScreen/LoadingScreen.scss";
+import { formatLoaderEta, ILoaderProgress } from "@/apps/common/loader/LoaderProgress";
 
 export interface ILoadingScreenProps {
   active?: boolean;
   message?: string;
   backgroundURL?: string;
   logoURL?: string;
+  progress?: ILoaderProgress | null;
 }
 
 export const LoadingScreen = (props: ILoadingScreenProps) => {
 
-  //component props
   const [active, setActive] = useState<boolean>(!!props.active);
   const [message, setMessage] = useState<string>(props.message || 'Loading...');
   const [backgroundURL, setBackgroundURL] = useState<string>(props.backgroundURL || '');
   const [logoURL, setLogoURL] = useState<string>(props.logoURL || '');
+  const [progress, setProgress] = useState<ILoaderProgress | null>(props.progress ?? null);
+  const [etaLabel, setEtaLabel] = useState<string>('');
 
-  //fade in and out
   const [fadeIn, setFadeIn] = useState<boolean>(false);
   const [fadeOut, setFadeOut] = useState<boolean>(false);
   const [visible, setVisible] = useState<boolean>(false);
 
   const fadeInTimeout = useRef<NodeJS.Timeout | null>(null);
   const fadeOutTimeout = useRef<NodeJS.Timeout | null>(null);
+  const progressStartRef = useRef<number | null>(null);
+  const smoothedRateRef = useRef<number | null>(null);
 
   const onHide = () => {
     clearTimeout(fadeOutTimeout.current as any);
@@ -39,13 +43,10 @@ export const LoadingScreen = (props: ILoadingScreenProps) => {
     clearTimeout(fadeInTimeout.current as any);
     setFadeIn(true);
     setFadeOut(false);
-    // fadeInTimeout.current = setTimeout(() => {
-      setVisible(true);
-    // }, 1000);
+    setVisible(true);
   };
 
   useEffect(() => {
-    console.log('active', active);
     setActive(!!props.active);
     if(!!props.active){
       onShow();
@@ -60,7 +61,51 @@ export const LoadingScreen = (props: ILoadingScreenProps) => {
     setLogoURL(props.logoURL || '');
   }, [props.message, props.backgroundURL, props.logoURL]);
 
-  //se-pre-con class
+  useEffect(() => {
+    const next = props.progress ?? null;
+    setProgress(next);
+
+    if (!next || next.total <= 0) {
+      progressStartRef.current = null;
+      smoothedRateRef.current = null;
+      setEtaLabel('');
+      return;
+    }
+
+    if (progressStartRef.current === null || next.completed === 0) {
+      progressStartRef.current = performance.now();
+      smoothedRateRef.current = null;
+    }
+
+    if (next.completed <= 0) {
+      setEtaLabel('Calculating...');
+      return;
+    }
+
+    const elapsedSeconds = (performance.now() - (progressStartRef.current as number)) / 1000;
+    if (elapsedSeconds <= 0) {
+      setEtaLabel('Calculating...');
+      return;
+    }
+
+    const instantRate = next.completed / elapsedSeconds;
+    smoothedRateRef.current = smoothedRateRef.current === null
+      ? instantRate
+      : smoothedRateRef.current * 0.65 + instantRate * 0.35;
+
+    const remaining = Math.max(0, next.total - next.completed);
+    const etaSeconds = remaining / (smoothedRateRef.current || instantRate);
+    setEtaLabel(formatLoaderEta(etaSeconds));
+  }, [props.progress]);
+
+  const showProgress = !!progress && progress.total > 0;
+  const percent = showProgress
+    ? Math.min(100, Math.round((progress.completed / progress.total) * 100))
+    : 0;
+  const statusLine = showProgress
+    ? (progress.currentAsset || progress.message || message)
+    : message;
+
   return (
     <div className={`app-loader ${visible ? 'active' : ''} ${fadeIn ? 'fade-in' : ''} ${fadeOut ? 'fade-out' : ''}`}>
       <div className="background" style={{backgroundImage: (!!backgroundURL) ? `url(${backgroundURL})` : 'initial'}}></div>
@@ -70,7 +115,21 @@ export const LoadingScreen = (props: ILoadingScreenProps) => {
           <div className="ball"></div>
           <div className="ball1"></div>
         </div>
-        <div className="loading-message">{message}</div>
+        <div className="loading-message">
+          <div className="loading-message-text" title={statusLine}>{statusLine}</div>
+          {showProgress && (
+            <div className="loading-progress">
+              <div className="loading-progress-track">
+                <div className="loading-progress-bar" style={{ width: `${percent}%` }} />
+              </div>
+              <div className="loading-progress-meta">
+                <span>{percent}%</span>
+                <span>{progress.completed} / {progress.total}</span>
+                {etaLabel ? <span>{etaLabel}</span> : null}
+              </div>
+            </div>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/src/apps/common/loader/LoaderProgress.test.ts
+++ b/src/apps/common/loader/LoaderProgress.test.ts
@@ -1,0 +1,63 @@
+import { ILoaderProgress, LoaderProgressTracker, formatLoaderEta } from '@/apps/common/loader/LoaderProgress';
+
+describe('LoaderProgressTracker', () => {
+  it('begins with total and resets completed count', () => {
+    const emissions: ILoaderProgress[] = [];
+    const tracker = new LoaderProgressTracker((p) => emissions.push(p), 'Loading assets');
+
+    tracker.begin(10, 'Loading assets');
+
+    expect(emissions[0]).toEqual({
+      message: 'Loading assets',
+      completed: 0,
+      total: 10,
+    });
+  });
+
+  it('tracks item start and completion', () => {
+    const emissions: ILoaderProgress[] = [];
+    const tracker = new LoaderProgressTracker((p) => emissions.push(p));
+
+    tracker.begin(2);
+    tracker.itemStart('foo.2da');
+    tracker.itemComplete();
+
+    expect(emissions[emissions.length - 1]).toEqual({
+      message: 'Loading...',
+      currentAsset: 'foo.2da',
+      completed: 1,
+      total: 2,
+    });
+  });
+
+  it('adds to total without changing completed', () => {
+    const emissions: ILoaderProgress[] = [];
+    const tracker = new LoaderProgressTracker((p) => emissions.push(p));
+
+    tracker.begin(1);
+    tracker.itemComplete();
+    tracker.addTotal(3);
+
+    expect(emissions[emissions.length - 1]).toEqual({
+      message: 'Loading...',
+      completed: 1,
+      total: 4,
+    });
+  });
+});
+
+describe('formatLoaderEta', () => {
+  it('returns Almost done for short remaining times', () => {
+    expect(formatLoaderEta(3)).toBe('Almost done');
+  });
+
+  it('formats seconds and minutes', () => {
+    expect(formatLoaderEta(45)).toBe('45s remaining');
+    expect(formatLoaderEta(125)).toBe('2m 5s remaining');
+  });
+
+  it('returns empty string for invalid input', () => {
+    expect(formatLoaderEta(Number.NaN)).toBe('');
+    expect(formatLoaderEta(-1)).toBe('');
+  });
+});

--- a/src/apps/common/loader/LoaderProgress.ts
+++ b/src/apps/common/loader/LoaderProgress.ts
@@ -1,0 +1,84 @@
+export interface ILoaderProgress {
+  message: string;
+  currentAsset?: string;
+  completed: number;
+  total: number;
+}
+
+export type LoaderProgressCallback = (progress: ILoaderProgress) => void;
+
+/**
+ * Tracks parallel asset loads and emits normalized progress updates.
+ */
+export class LoaderProgressTracker {
+  #message: string;
+  #total = 0;
+  #completed = 0;
+  #currentAsset = '';
+  #onProgress: LoaderProgressCallback;
+
+  constructor(onProgress: LoaderProgressCallback, message = 'Loading...') {
+    this.#onProgress = onProgress;
+    this.#message = message;
+  }
+
+  setMessage(message: string): void {
+    this.#message = message;
+    this.#emit();
+  }
+
+  begin(total: number, message?: string): void {
+    if (message) {
+      this.#message = message;
+    }
+    this.#total = Math.max(0, total);
+    this.#completed = 0;
+    this.#currentAsset = '';
+    this.#emit();
+  }
+
+  addTotal(count: number): void {
+    this.#total += Math.max(0, count);
+    this.#emit();
+  }
+
+  itemStart(asset: string): void {
+    this.#currentAsset = asset;
+    this.#emit();
+  }
+
+  itemComplete(): void {
+    this.#completed = Math.min(this.#completed + 1, this.#total || this.#completed + 1);
+    this.#emit();
+  }
+
+  #emit(): void {
+    this.#onProgress({
+      message: this.#message,
+      currentAsset: this.#currentAsset || undefined,
+      completed: this.#completed,
+      total: this.#total,
+    });
+  }
+}
+
+export function formatLoaderEta(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds < 0) {
+    return '';
+  }
+  if (seconds < 5) {
+    return 'Almost done';
+  }
+  const totalSeconds = Math.ceil(seconds);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const secs = totalSeconds % 60;
+
+  if (hours > 0) {
+    return `${hours}h ${minutes}m remaining`;
+  }
+  if (minutes > 0) {
+    return `${minutes}m ${secs}s remaining`;
+  }
+  return `${secs}s remaining`;
+}

--- a/src/apps/forge/App.tsx
+++ b/src/apps/forge/App.tsx
@@ -29,6 +29,7 @@ export const App = (props: any) => {
   const [showGrantModal, setShowGrantModal] = appContext.showGrantModal;
   const [showLoadingScreen] = appContext.showLoadingScreen;
   const [loadingScreenMessage] = appContext.loadingScreenMessage;
+  const [loadingScreenProgress] = appContext.loadingScreenProgress;
   const [loadingScreenBackgroundURL] = appContext.loadingScreenBackgroundURL;
   const [loadingScreenLogoURL] = appContext.loadingScreenLogoURL;
   const [isDragOver, setIsDragOver] = useState(false);
@@ -384,7 +385,7 @@ export const App = (props: any) => {
       </div>
       <ModalManager manager={ForgeState.modalManager}></ModalManager>
       <ModalGrantAccess onUserGrant={onUserGrant} onUserCancel={onUserCancel}></ModalGrantAccess>
-      <LoadingScreen active={showLoadingScreen} message={loadingScreenMessage} backgroundURL={loadingScreenBackgroundURL} logoURL={loadingScreenLogoURL} />
+      <LoadingScreen active={showLoadingScreen} message={loadingScreenMessage} progress={loadingScreenProgress} backgroundURL={loadingScreenBackgroundURL} logoURL={loadingScreenLogoURL} />
     </>
   );
 

--- a/src/apps/forge/ForgeInitializer.ts
+++ b/src/apps/forge/ForgeInitializer.ts
@@ -1,5 +1,9 @@
 import * as path from "path";
 import * as KotOR from "@/apps/forge/KotOR";
+import pLimit from "p-limit";
+import { ILoaderProgress, LoaderProgressTracker } from "@/apps/common/loader/LoaderProgress";
+
+const fsLimit = pLimit(16);
 
 /**
  * ForgeInitializer class.
@@ -89,6 +93,11 @@ export class ForgeInitializer {
 
   static SetLoadingMessage(message: string){
     ForgeInitializer.ProcessEventListener('on-loader-message', [message]);
+    ForgeInitializer.ProcessEventListener('on-loader-progress', [null]);
+  }
+
+  static SetLoadingProgress(progress: ILoaderProgress){
+    ForgeInitializer.ProcessEventListener('on-loader-progress', [progress]);
   }
 
   static async Init(game: KotOR.GameEngineType){
@@ -243,93 +252,207 @@ export class ForgeInitializer {
   }
 
   static async LoadGameResources(){
-    ForgeInitializer.SetLoadingMessage("Loading Assets");
+    const tracker = new LoaderProgressTracker(
+      (progress) => ForgeInitializer.SetLoadingProgress(progress),
+      'Loading Assets',
+    );
+
+    const overrideFiles = await ForgeInitializer.listOverrideFiles();
+    const rimFiles = await ForgeInitializer.listRimFiles();
+    const moduleFiles = await ForgeInitializer.listModuleFiles();
+    const lipModules = await ForgeInitializer.listLipModules();
+    const twoDAResources = KotOR.KEYManager.Key.getFilesByResType(KotOR.ResourceTypes['2da']);
+    const texturePackErfs = await ForgeInitializer.listTexturePackErfs();
+
+    tracker.begin(
+      overrideFiles.length + rimFiles.length + moduleFiles.length + lipModules.length + twoDAResources.length + texturePackErfs.length,
+      'Loading Assets',
+    );
+
     const promises = [
-      ForgeInitializer.LoadOverride(), 
-      ForgeInitializer.LoadRIMs(), 
-      ForgeInitializer.LoadModules(), 
-      ForgeInitializer.LoadLips(), 
-      ForgeInitializer.Load2DAs(), 
-      ForgeInitializer.LoadTexturePacks(), 
-      ForgeInitializer.LoadGameAudioResources('streammusic'), 
-      ForgeInitializer.LoadGameAudioResources('streamsounds'), 
-      ForgeInitializer.LoadGameAudioResources(KotOR.GameState.GameKey != KotOR.GameEngineType.TSL ? 'streamwaves' : 'streamvoice')
+      ForgeInitializer.LoadOverride(tracker, overrideFiles),
+      ForgeInitializer.LoadRIMs(tracker, rimFiles),
+      ForgeInitializer.LoadModules(tracker, moduleFiles),
+      ForgeInitializer.LoadLips(tracker, lipModules),
+      ForgeInitializer.Load2DAs(tracker, twoDAResources),
+      ForgeInitializer.LoadTexturePacks(tracker, texturePackErfs),
+      ForgeInitializer.LoadGameAudioResources('streammusic'),
+      ForgeInitializer.LoadGameAudioResources('streamsounds'),
+      ForgeInitializer.LoadGameAudioResources(KotOR.GameState.GameKey != KotOR.GameEngineType.TSL ? 'streamwaves' : 'streamvoice'),
     ];
     await Promise.all(promises);
   }
 
-  static async LoadRIMs(){
-    if(KotOR.GameState.GameKey == KotOR.GameEngineType.TSL){
-      return;
-    }
-    KotOR.PerformanceMonitor.start('RIMManager.Load');
-    await KotOR.RIMManager.Load();
-    KotOR.PerformanceMonitor.stop('RIMManager.Load');
-  }
-
-  static async LoadLips(){
-    KotOR.PerformanceMonitor.start('ForgeInitializer.LoadLips');
-    const data_dir = 'lips';
-    const filenames = await KotOR.GameFileSystem.readdir(data_dir);
-    const modules = filenames.map(function(file) {
-      const filename = file.split(path.sep).pop() as string;
-      const args = filename.split('.');
-      return {
-        ext: args[1].toLowerCase(), 
-        name: args[0], 
-        filename: filename
-      };
-    }).filter(function(file_obj){
-      return file_obj.ext == 'mod';
-    });
-    await Promise.all(modules.map(async (module_obj) => {
-      const mod = new KotOR.ERFObject(path.join(data_dir, module_obj.filename));
-      await mod.load();
-      mod.group = 'Lips';
-      KotOR.ERFManager.addERF(module_obj.name, mod);
-    }));
-    KotOR.PerformanceMonitor.stop('ForgeInitializer.LoadLips');
-  }
-
-  static async LoadModules(){
-    let data_dir = 'modules';
-    KotOR.PerformanceMonitor.start('ForgeInitializer.LoadModules');
+  static async listOverrideFiles(){
     try{
-      const filenames = await KotOR.GameFileSystem.readdir(data_dir);
-      const modules = filenames.map(function(file) {
+      const files = await KotOR.GameFileSystem.readdir('Override', {recursive: false});
+      return files
+        .map((f) => {
+          const _parsed = path.parse(f);
+          const ext = _parsed.ext.substr(1, _parsed.ext.length)?.toLocaleLowerCase();
+          return { f, _parsed, resId: KotOR.ResourceTypes[ext] };
+        })
+        .filter(({ resId }) => typeof resId !== 'undefined');
+    }catch(e){
+      return [];
+    }
+  }
+
+  static async listRimFiles(){
+    if(KotOR.GameState.GameKey == KotOR.GameEngineType.TSL){
+      return [] as { ext: string; name: string; filename: string }[];
+    }
+    try{
+      const filenames = await KotOR.GameFileSystem.readdir('rims');
+      return filenames.map(function(file: string) {
         const filename = file.split(path.sep).pop() as string;
         const args = filename.split('.');
         return {
-          ext: args[1].toLowerCase(), 
-          name: args[0], 
-          filename: filename
+          ext: args[1].toLowerCase(),
+          name: args[0],
+          filename: path.join('rims', filename),
+        };
+      }).filter(function(file_obj){
+        return file_obj.ext == 'rim';
+      });
+    }catch(e){
+      return [];
+    }
+  }
+
+  static async listModuleFiles(){
+    const data_dir = 'modules';
+    try{
+      const filenames = await KotOR.GameFileSystem.readdir(data_dir);
+      return filenames.map(function(file) {
+        const filename = file.split(path.sep).pop() as string;
+        const args = filename.split('.');
+        return {
+          ext: args[1].toLowerCase(),
+          name: args[0],
+          filename: filename,
         };
       }).filter(function(file_obj){
         return file_obj.ext == 'rim' || file_obj.ext == 'mod';
       });
+    }catch(e){
+      return [];
+    }
+  }
 
-      await Promise.all(modules.map(async (module_obj) => {
-        switch(module_obj.ext){
-          case 'rim': {
-            const rim = new KotOR.RIMObject(path.join(data_dir, module_obj.filename));
-            await rim.load();
-            rim.group = 'Module';
-            KotOR.RIMManager.addRIM(module_obj.name, rim);
-            break;
+  static async listLipModules(){
+    const data_dir = 'lips';
+    try{
+      const filenames = await KotOR.GameFileSystem.readdir(data_dir);
+      return filenames.map(function(file) {
+        const filename = file.split(path.sep).pop() as string;
+        const args = filename.split('.');
+        return {
+          ext: args[1].toLowerCase(),
+          name: args[0],
+          filename: filename,
+        };
+      }).filter(function(file_obj){
+        return file_obj.ext == 'mod';
+      });
+    }catch(e){
+      return [];
+    }
+  }
+
+  static async listTexturePackErfs(){
+    const data_dir = 'TexturePacks';
+    try{
+      const filenames = await KotOR.GameFileSystem.readdir(data_dir);
+      return filenames.map(function(file) {
+        const filename = file.split(path.sep).pop() as string;
+        const args = filename.split('.');
+        return {
+          ext: args[1].toLowerCase(),
+          name: args[0],
+          filename: filename,
+        };
+      }).filter(function(file_obj){
+        return file_obj.ext == 'erf';
+      });
+    }catch(e){
+      return [];
+    }
+  }
+
+  static async LoadRIMs(tracker?: LoaderProgressTracker, rims?: { ext: string; name: string; filename: string }[]){
+    const rimFiles = rims ?? await ForgeInitializer.listRimFiles();
+    if(!rimFiles.length){
+      return;
+    }
+    KotOR.PerformanceMonitor.start('RIMManager.Load');
+    await Promise.all(rimFiles.map((rimObj) => fsLimit(async () => {
+      tracker?.itemStart(path.basename(rimObj.filename));
+      try{
+        const rim = await KotOR.RIMManager.LoadRIMObject(rimObj);
+        rim.group = 'RIMs';
+      }catch(e){
+        console.error(e);
+      }finally{
+        tracker?.itemComplete();
+      }
+    })));
+    KotOR.PerformanceMonitor.stop('RIMManager.Load');
+  }
+
+  static async LoadLips(tracker?: LoaderProgressTracker, modules?: { ext: string; name: string; filename: string }[]){
+    const lipModules = modules ?? await ForgeInitializer.listLipModules();
+    KotOR.PerformanceMonitor.start('ForgeInitializer.LoadLips');
+    const data_dir = 'lips';
+    await Promise.all(lipModules.map((module_obj) => fsLimit(async () => {
+      tracker?.itemStart(module_obj.filename);
+      try{
+        const mod = new KotOR.ERFObject(path.join(data_dir, module_obj.filename));
+        await mod.load();
+        mod.group = 'Lips';
+        KotOR.ERFManager.addERF(module_obj.name, mod);
+      }catch(e){
+        console.error(e);
+      }finally{
+        tracker?.itemComplete();
+      }
+    })));
+    KotOR.PerformanceMonitor.stop('ForgeInitializer.LoadLips');
+  }
+
+  static async LoadModules(tracker?: LoaderProgressTracker, modules?: { ext: string; name: string; filename: string }[]){
+    const moduleFiles = modules ?? await ForgeInitializer.listModuleFiles();
+    let data_dir = 'modules';
+    KotOR.PerformanceMonitor.start('ForgeInitializer.LoadModules');
+    try{
+      await Promise.all(moduleFiles.map((module_obj) => fsLimit(async () => {
+        tracker?.itemStart(module_obj.filename);
+        try{
+          switch(module_obj.ext){
+            case 'rim': {
+              const rim = new KotOR.RIMObject(path.join(data_dir, module_obj.filename));
+              await rim.load();
+              rim.group = 'Module';
+              KotOR.RIMManager.addRIM(module_obj.name, rim);
+              break;
+            }
+            case 'mod': {
+              const mod = new KotOR.ERFObject(path.join(data_dir, module_obj.filename));
+              await mod.load();
+              mod.group = 'Module';
+              KotOR.ERFManager.addERF(module_obj.name, mod);
+              break;
+            }
+            default:
+              console.warn('ForgeInitializer.LoadModules: Encountered incorrect filetype');
+              break;
           }
-          case 'mod': {
-            const mod = new KotOR.ERFObject(path.join(data_dir, module_obj.filename));
-            await mod.load();
-            mod.group = 'Module';
-            KotOR.ERFManager.addERF(module_obj.name, mod);
-            break;
-          }
-          default:
-            console.warn('ForgeInitializer.LoadModules: Encountered incorrect filetype');
-            console.log(module_obj);
-            break;
+        }catch(e){
+          console.error(e);
+        }finally{
+          tracker?.itemComplete();
         }
-      }));
+      })));
     }catch(e){
       console.warn('ForgeInitializer.LoadModules: Failed to load modules');
       console.error(e);
@@ -337,37 +460,49 @@ export class ForgeInitializer {
     KotOR.PerformanceMonitor.stop('ForgeInitializer.LoadModules');
   }
 
-  static async Load2DAs(){
+  static async Load2DAs(tracker?: LoaderProgressTracker, resources?: ReturnType<typeof KotOR.KEYManager.Key.getFilesByResType>){
+    const twoDAResources = resources ?? KotOR.KEYManager.Key.getFilesByResType(KotOR.ResourceTypes['2da']);
     KotOR.PerformanceMonitor.start('ForgeInitializer.Load2DAs');
-    await KotOR.GameState.TwoDAManager.Load2DATables();
+    KotOR.TwoDAManager.datatables = new Map();
+    await Promise.all(twoDAResources.map((res) => fsLimit(async () => {
+      const key = KotOR.KEYManager.Key.getFileKeyByRes(res);
+      if(!key){
+        tracker?.itemComplete();
+        return;
+      }
+      tracker?.itemStart(`${key.resRef}.2da`);
+      try{
+        const d = await KotOR.ResourceLoader.loadResource(KotOR.ResourceTypes['2da'], key.resRef);
+        KotOR.TwoDAManager.datatables.set(key.resRef, new KotOR.TwoDAObject(d));
+      }catch(e){
+        console.error(e);
+      }finally{
+        tracker?.itemComplete();
+      }
+    })));
     KotOR.PerformanceMonitor.stop('ForgeInitializer.Load2DAs');
   }
 
-  static async LoadTexturePacks(){
+  static async LoadTexturePacks(tracker?: LoaderProgressTracker, erfs?: { ext: string; name: string; filename: string }[]){
+    const texturePackErfs = erfs ?? await ForgeInitializer.listTexturePackErfs();
     KotOR.PerformanceMonitor.start('ForgeInitializer.LoadTexturePacks');
     const data_dir = 'TexturePacks';
     try{
-      const filenames = await KotOR.GameFileSystem.readdir(data_dir)
-      const erfs = filenames.map(function(file) {
-        const filename = file.split(path.sep).pop() as string;
-        const args = filename.split('.');
-        return {
-          ext: args[1].toLowerCase(), 
-          name: args[0], 
-          filename: filename
-        };
-      }).filter(function(file_obj){
-        return file_obj.ext == 'erf';
-      });
-
-      await Promise.all(erfs.map(async (_erf) => {
-        const erf = new KotOR.ERFObject(path.join(data_dir, _erf.filename));
-        await erf.load();
-        if(erf instanceof KotOR.ERFObject){
-          erf.group = 'Textures';
-          KotOR.ERFManager.addERF(_erf.name, erf);
+      await Promise.all(texturePackErfs.map((_erf) => fsLimit(async () => {
+        tracker?.itemStart(_erf.filename);
+        try{
+          const erf = new KotOR.ERFObject(path.join(data_dir, _erf.filename));
+          await erf.load();
+          if(erf instanceof KotOR.ERFObject){
+            erf.group = 'Textures';
+            KotOR.ERFManager.addERF(_erf.name, erf);
+          }
+        }catch(e){
+          console.error(e);
+        }finally{
+          tracker?.itemComplete();
         }
-      }));
+      })));
     }catch(e){
       console.warn('ForgeInitializer.LoadTexturePacks: Failed to load texture packs');
       console.error(e);
@@ -403,23 +538,23 @@ export class ForgeInitializer {
     KotOR.PerformanceMonitor.stop(`ForgeInitializer.LoadGameAudioResources[${folder}]`);
   }
 
-  static async LoadOverride(){
+  static async LoadOverride(tracker?: LoaderProgressTracker, validOverrideFiles?: Awaited<ReturnType<typeof ForgeInitializer.listOverrideFiles>>){
+    const overrideFiles = validOverrideFiles ?? await ForgeInitializer.listOverrideFiles();
     KotOR.PerformanceMonitor.start('ForgeInitializer.LoadOverride');
     try{
-      const files = await KotOR.GameFileSystem.readdir('Override', {recursive: false});
-      const validOverrideFiles = files
-        .map(f => {
-          const _parsed = path.parse(f);
-          const ext = _parsed.ext.substr(1, _parsed.ext.length)?.toLocaleLowerCase();
-          return { f, _parsed, resId: KotOR.ResourceTypes[ext] };
-        })
-        .filter(({ resId }) => typeof resId !== 'undefined');
-
-      await Promise.all(validOverrideFiles.map(async ({ f, _parsed, resId }) => {
-        const buffer = await KotOR.GameFileSystem.readFile(f);
-        if(!buffer || !buffer.length) return;
-        KotOR.ResourceLoader.setCache(KotOR.CacheScope.OVERRIDE, resId, _parsed.name.toLocaleLowerCase(), buffer);
-      }));
+      await Promise.all(overrideFiles.map(({ f, _parsed, resId }) => fsLimit(async () => {
+        tracker?.itemStart(path.basename(f));
+        try{
+          const buffer = await KotOR.GameFileSystem.readFile(f);
+          if(buffer && buffer.length){
+            KotOR.ResourceLoader.setCache(KotOR.CacheScope.OVERRIDE, resId, _parsed.name.toLocaleLowerCase(), buffer);
+          }
+        }catch(e){
+          console.error(e);
+        }finally{
+          tracker?.itemComplete();
+        }
+      })));
     }catch(e){
       console.warn('ForgeInitializer.LoadOverride: Failed to load override');
       console.error(e);

--- a/src/apps/forge/context/AppContext.tsx
+++ b/src/apps/forge/context/AppContext.tsx
@@ -4,6 +4,7 @@ import { EditorTabManager } from "@/apps/forge/managers/EditorTabManager";
 import { LoadingScreenProvider } from "@/apps/forge/context/LoadingScreenContext";
 
 import * as KotOR from "@/apps/forge/KotOR";
+import { ILoaderProgress } from "@/apps/common/loader/LoaderProgress";
 
 export interface AppProviderValues {
   // someValue: [any, React.Dispatch<any>];
@@ -12,6 +13,7 @@ export interface AppProviderValues {
   showGrantModal: [boolean, React.Dispatch<any>];
   showLoadingScreen: [boolean, React.Dispatch<any>];
   loadingScreenMessage: [string, React.Dispatch<any>];
+  loadingScreenProgress: [ILoaderProgress | null, React.Dispatch<ILoaderProgress | null>];
   loadingScreenBackgroundURL: [string, React.Dispatch<any>];
   loadingScreenLogoURL: [string, React.Dispatch<any>];
 }
@@ -27,11 +29,19 @@ export const AppProvider = (props: any) => {
   const [showGrantModal, setShowGrantModal] = useState<boolean>(false);
   const [showLoadingScreen, setShowLoadingScreen] = useState<boolean>(false);
   const [loadingScreenMessage, setLoadingScreenMessage] = useState<string>('');
+  const [loadingScreenProgress, setLoadingScreenProgress] = useState<ILoaderProgress | null>(null);
   const [loadingScreenBackgroundURL, setLoadingScreenBackgroundURL] = useState<string>('');
   const [loadingScreenLogoURL, setLoadingScreenLogoURL] = useState<string>('');
 
   const onLoadingScreenMessage = (message: string) => {
     setLoadingScreenMessage(message);
+    setLoadingScreenProgress(null);
+  }
+  const onLoadingScreenProgress = (progress: ILoaderProgress | null) => {
+    setLoadingScreenProgress(progress);
+    if(progress?.message){
+      setLoadingScreenMessage(progress.message);
+    }
   }
   const onLoadingScreenShow = () => {
     setShowLoadingScreen(true);
@@ -47,11 +57,13 @@ export const AppProvider = (props: any) => {
   useEffect(() => { 
     // ForgeState.tabManager = tabManager;
     ForgeState.addEventListener('on-loader-message', onLoadingScreenMessage);
+    ForgeState.addEventListener('on-loader-progress', onLoadingScreenProgress);
     ForgeState.addEventListener('on-loader-show', onLoadingScreenShow);
     ForgeState.addEventListener('on-loader-hide', onLoadingScreenHide);
     ForgeState.addEventListener('on-loader-init', onLoadingScreenInit);
     return () => {
       ForgeState.removeEventListener('on-loader-message', onLoadingScreenMessage);
+      ForgeState.removeEventListener('on-loader-progress', onLoadingScreenProgress);
       ForgeState.removeEventListener('on-loader-show', onLoadingScreenShow);
       ForgeState.removeEventListener('on-loader-hide', onLoadingScreenHide);
       ForgeState.removeEventListener('on-loader-init', onLoadingScreenInit);
@@ -64,6 +76,7 @@ export const AppProvider = (props: any) => {
     showGrantModal: [showGrantModal, setShowGrantModal],
     showLoadingScreen: [showLoadingScreen, setShowLoadingScreen],
     loadingScreenMessage: [loadingScreenMessage, setLoadingScreenMessage],
+    loadingScreenProgress: [loadingScreenProgress, setLoadingScreenProgress],
     loadingScreenBackgroundURL: [loadingScreenBackgroundURL, setLoadingScreenBackgroundURL],
     loadingScreenLogoURL: [loadingScreenLogoURL, setLoadingScreenLogoURL],
   };

--- a/src/apps/forge/states/ForgeState.ts
+++ b/src/apps/forge/states/ForgeState.ts
@@ -16,6 +16,7 @@ import { AudioPlayerState } from "@/apps/forge/states/AudioPlayerState";
 
 import * as KotOR from "@/apps/forge/KotOR";
 import { ForgeInitializer } from "@/apps/forge/ForgeInitializer";
+import { ILoaderProgress } from "@/apps/common/loader/LoaderProgress";
 import { NWScriptLanguageService } from "@/apps/forge/states/NWScriptLanguageService";
 import { LYTLanguageService } from "@/apps/forge/states/LYTLanguageService";
 import { TXILanguageService } from "@/apps/forge/states/TXILanguageService";
@@ -114,6 +115,12 @@ export class ForgeState {
    */
   static loaderMessage(message: string): void {
     ForgeState.processEventListener('on-loader-message', [message]);
+    ForgeState.processEventListener('on-loader-progress', [null]);
+  }
+
+  static loaderProgress(progress: ILoaderProgress): void {
+    ForgeState.processEventListener('on-loader-message', [progress.message]);
+    ForgeState.processEventListener('on-loader-progress', [progress]);
   }
 
   static async InitializeApp(): Promise<void>{
@@ -137,6 +144,13 @@ export class ForgeState {
       KotOR.GameState.GameKey = KotOR.ApplicationProfile.GameKey;
       ForgeInitializer.AddEventListener('on-loader-message', (message: string) => {
         ForgeState.loaderMessage(message);
+      });
+      ForgeInitializer.AddEventListener('on-loader-progress', (progress: ILoaderProgress | null) => {
+        if(progress){
+          ForgeState.loaderProgress(progress);
+        }else{
+          ForgeState.processEventListener('on-loader-progress', [null]);
+        }
       });
       ForgeInitializer.Init(KotOR.ApplicationProfile.GameKey).then( async () => {
         await this.initNWScriptParser();

--- a/src/apps/game/GameInitializer.ts
+++ b/src/apps/game/GameInitializer.ts
@@ -1,6 +1,7 @@
 import * as path from "path";
 import * as KotOR from "@/apps/game/KotOR";
 import pLimit from "p-limit";
+import { ILoaderProgress, LoaderProgressTracker } from "@/apps/common/loader/LoaderProgress";
 
 const fsLimit = pLimit(16);
 
@@ -92,6 +93,11 @@ export class GameInitializer {
 
   static SetLoadingMessage(message: string){
     GameInitializer.ProcessEventListener('on-loader-message', [message]);
+    GameInitializer.ProcessEventListener('on-loader-progress', [null]);
+  }
+
+  static SetLoadingProgress(progress: ILoaderProgress){
+    GameInitializer.ProcessEventListener('on-loader-progress', [progress]);
   }
 
   static async Init(game: KotOR.GameEngineType){
@@ -246,12 +252,26 @@ export class GameInitializer {
   }
 
   static async LoadGameResources(){
-    GameInitializer.SetLoadingMessage("Loading Assets");
+    const tracker = new LoaderProgressTracker(
+      (progress) => GameInitializer.SetLoadingProgress(progress),
+      'Loading Assets',
+    );
+
+    const overrideFiles = await GameInitializer.listOverrideFiles();
+    const rimFiles = await GameInitializer.listRimFiles();
+    const twoDAResources = KotOR.KEYManager.Key.getFilesByResType(KotOR.ResourceTypes['2da']);
+    const texturePackErfs = await GameInitializer.listTexturePackErfs();
+
+    tracker.begin(
+      overrideFiles.length + rimFiles.length + twoDAResources.length + texturePackErfs.length,
+      'Loading Assets',
+    );
+
     const promises = [
-      GameInitializer.LoadOverride(), 
-      GameInitializer.LoadRIMs(), 
-      GameInitializer.Load2DAs(), 
-      GameInitializer.LoadTexturePacks()
+      GameInitializer.LoadOverride(tracker, overrideFiles),
+      GameInitializer.LoadRIMs(tracker, rimFiles),
+      GameInitializer.Load2DAs(tracker, twoDAResources),
+      GameInitializer.LoadTexturePacks(tracker, texturePackErfs),
     ];
     await Promise.all(promises);
     const nonBlockingPromises = [
@@ -262,44 +282,124 @@ export class GameInitializer {
     Promise.all(nonBlockingPromises);
   }
 
-  static async LoadRIMs(){
-    if(KotOR.GameState.GameKey == KotOR.GameEngineType.TSL){
-      return;
-    }
-    KotOR.PerformanceMonitor.start('RIMManager.Load');
-    await KotOR.RIMManager.Load();
-    KotOR.PerformanceMonitor.stop('RIMManager.Load');
-  }
-
-  static async Load2DAs(){
-    KotOR.PerformanceMonitor.start('GameInitializer.Load2DAs');
-    await KotOR.GameState.TwoDAManager.Load2DATables();
-    KotOR.PerformanceMonitor.stop('GameInitializer.Load2DAs');
-  }
-
-  static async LoadTexturePacks(){
-    KotOR.PerformanceMonitor.start('GameInitializer.LoadTexturePacks');
-    const data_dir = 'TexturePacks';
+  static async listOverrideFiles(){
     try{
-      const filenames = await KotOR.GameFileSystem.readdir(data_dir)
-      const erfs = filenames.map(function(file) {
+      const files = await KotOR.GameFileSystem.readdir('Override', {recursive: false});
+      return files
+        .map((f) => {
+          const _parsed = path.parse(f);
+          const ext = _parsed.ext.substr(1, _parsed.ext.length)?.toLocaleLowerCase();
+          return { f, _parsed, resId: KotOR.ResourceTypes[ext] };
+        })
+        .filter(({ resId }) => typeof resId !== 'undefined');
+    }catch(e){
+      return [];
+    }
+  }
+
+  static async listRimFiles(){
+    if(KotOR.GameState.GameKey == KotOR.GameEngineType.TSL){
+      return [] as { ext: string; name: string; filename: string }[];
+    }
+    try{
+      const filenames = await KotOR.GameFileSystem.readdir('rims');
+      return filenames.map(function(file: string) {
         const filename = file.split(path.sep).pop() as string;
         const args = filename.split('.');
         return {
-          ext: args[1].toLowerCase(), 
-          name: args[0], 
-          filename: filename
+          ext: args[1].toLowerCase(),
+          name: args[0],
+          filename: path.join('rims', filename),
+        };
+      }).filter(function(file_obj){
+        return file_obj.ext == 'rim';
+      });
+    }catch(e){
+      return [];
+    }
+  }
+
+  static async listTexturePackErfs(){
+    const data_dir = 'TexturePacks';
+    try{
+      const filenames = await KotOR.GameFileSystem.readdir(data_dir);
+      return filenames.map(function(file) {
+        const filename = file.split(path.sep).pop() as string;
+        const args = filename.split('.');
+        return {
+          ext: args[1].toLowerCase(),
+          name: args[0],
+          filename: filename,
         };
       }).filter(function(file_obj){
         return file_obj.ext == 'erf';
       });
+    }catch(e){
+      return [];
+    }
+  }
 
-      await Promise.all(erfs.map((_erf) => fsLimit(async () => {
-        const erf = new KotOR.ERFObject(path.join(data_dir, _erf.filename));
-        await erf.load();
-        if(erf instanceof KotOR.ERFObject){
-          erf.group = 'Textures';
-          KotOR.ERFManager.addERF(_erf.name, erf);
+  static async LoadRIMs(tracker?: LoaderProgressTracker, rims?: { ext: string; name: string; filename: string }[]){
+    const rimFiles = rims ?? await GameInitializer.listRimFiles();
+    if(!rimFiles.length){
+      return;
+    }
+    KotOR.PerformanceMonitor.start('RIMManager.Load');
+    await Promise.all(rimFiles.map((rimObj) => fsLimit(async () => {
+      tracker?.itemStart(path.basename(rimObj.filename));
+      try{
+        const rim = await KotOR.RIMManager.LoadRIMObject(rimObj);
+        rim.group = 'RIMs';
+      }catch(e){
+        console.error(e);
+      }finally{
+        tracker?.itemComplete();
+      }
+    })));
+    KotOR.PerformanceMonitor.stop('RIMManager.Load');
+  }
+
+  static async Load2DAs(tracker?: LoaderProgressTracker, resources?: ReturnType<typeof KotOR.KEYManager.Key.getFilesByResType>){
+    const twoDAResources = resources ?? KotOR.KEYManager.Key.getFilesByResType(KotOR.ResourceTypes['2da']);
+    KotOR.PerformanceMonitor.start('GameInitializer.Load2DAs');
+    KotOR.TwoDAManager.datatables = new Map();
+    await Promise.all(twoDAResources.map((res) => fsLimit(async () => {
+      const key = KotOR.KEYManager.Key.getFileKeyByRes(res);
+      if(!key){
+        tracker?.itemComplete();
+        return;
+      }
+      tracker?.itemStart(`${key.resRef}.2da`);
+      try{
+        const d = await KotOR.ResourceLoader.loadResource(KotOR.ResourceTypes['2da'], key.resRef);
+        KotOR.TwoDAManager.datatables.set(key.resRef, new KotOR.TwoDAObject(d));
+      }catch(e){
+        console.error(e);
+      }finally{
+        tracker?.itemComplete();
+      }
+    })));
+    KotOR.PerformanceMonitor.stop('GameInitializer.Load2DAs');
+  }
+
+  static async LoadTexturePacks(tracker?: LoaderProgressTracker, erfs?: { ext: string; name: string; filename: string }[]){
+    const texturePackErfs = erfs ?? await GameInitializer.listTexturePackErfs();
+    KotOR.PerformanceMonitor.start('GameInitializer.LoadTexturePacks');
+    const data_dir = 'TexturePacks';
+    try{
+      await Promise.all(texturePackErfs.map((_erf) => fsLimit(async () => {
+        tracker?.itemStart(_erf.filename);
+        try{
+          const erf = new KotOR.ERFObject(path.join(data_dir, _erf.filename));
+          await erf.load();
+          if(erf instanceof KotOR.ERFObject){
+            erf.group = 'Textures';
+            KotOR.ERFManager.addERF(_erf.name, erf);
+          }
+        }catch(e){
+          console.error(e);
+        }finally{
+          tracker?.itemComplete();
         }
       })));
     }catch(e){
@@ -337,22 +437,22 @@ export class GameInitializer {
     KotOR.PerformanceMonitor.stop(`GameInitializer.LoadGameAudioResources[${folder}]`);
   }
 
-  static async LoadOverride(){
+  static async LoadOverride(tracker?: LoaderProgressTracker, validOverrideFiles?: Awaited<ReturnType<typeof GameInitializer.listOverrideFiles>>){
+    const overrideFiles = validOverrideFiles ?? await GameInitializer.listOverrideFiles();
     KotOR.PerformanceMonitor.start('GameInitializer.LoadOverride');
     try{
-      const files = await KotOR.GameFileSystem.readdir('Override', {recursive: false});
-      const validOverrideFiles = files
-        .map(f => {
-          const _parsed = path.parse(f);
-          const ext = _parsed.ext.substr(1, _parsed.ext.length)?.toLocaleLowerCase();
-          return { f, _parsed, resId: KotOR.ResourceTypes[ext] };
-        })
-        .filter(({ resId }) => typeof resId !== 'undefined');
-
-      await Promise.all(validOverrideFiles.map(({ f, _parsed, resId }) => fsLimit(async () => {
-        const buffer = await KotOR.GameFileSystem.readFile(f);
-        if(!buffer || !buffer.length) return;
-        KotOR.ResourceLoader.setCache(KotOR.CacheScope.OVERRIDE, resId, _parsed.name.toLocaleLowerCase(), buffer);
+      await Promise.all(overrideFiles.map(({ f, _parsed, resId }) => fsLimit(async () => {
+        tracker?.itemStart(path.basename(f));
+        try{
+          const buffer = await KotOR.GameFileSystem.readFile(f);
+          if(buffer && buffer.length){
+            KotOR.ResourceLoader.setCache(KotOR.CacheScope.OVERRIDE, resId, _parsed.name.toLocaleLowerCase(), buffer);
+          }
+        }catch(e){
+          console.error(e);
+        }finally{
+          tracker?.itemComplete();
+        }
       })));
     }catch(e){
       console.warn('GameInitializer.LoadOverride: Failed to load override');

--- a/src/apps/game/app.tsx
+++ b/src/apps/game/app.tsx
@@ -13,6 +13,7 @@ export const GameApp = () => {
   const [showCheatConsole] = appContext.showCheatConsole;
   const [showLoadingScreen] = appContext.showLoadingScreen;
   const [loadingScreenMessage] = appContext.loadingScreenMessage;
+  const [loadingScreenProgress] = appContext.loadingScreenProgress;
   const [loadingScreenBackgroundURL] = appContext.loadingScreenBackgroundURL;
   const [loadingScreenLogoURL] = appContext.loadingScreenLogoURL;
   return (
@@ -26,7 +27,7 @@ export const GameApp = () => {
       {gameLoaded && showCheatConsole && (
         <CheatConsole />
       )}
-      <LoadingScreen active={showLoadingScreen} message={loadingScreenMessage} backgroundURL={loadingScreenBackgroundURL} logoURL={loadingScreenLogoURL} />
+      <LoadingScreen active={showLoadingScreen} message={loadingScreenMessage} progress={loadingScreenProgress} backgroundURL={loadingScreenBackgroundURL} logoURL={loadingScreenLogoURL} />
     </>
   )
 }

--- a/src/apps/game/context/AppContext.tsx
+++ b/src/apps/game/context/AppContext.tsx
@@ -1,6 +1,7 @@
 import React, { createContext, useContext, useEffect, useState } from "react";
 import { AppState } from "@/apps/game/states/AppState";
 import * as KotOR from "@/apps/game/KotOR";
+import { ILoaderProgress } from "@/apps/common/loader/LoaderProgress";
 
 export interface AppProviderValues {
   appState: [typeof AppState];
@@ -13,6 +14,7 @@ export interface AppProviderValues {
   showPerformanceMonitor: [boolean, React.Dispatch<boolean>];
   showLoadingScreen: [boolean, React.Dispatch<boolean>];
   loadingScreenMessage: [string, React.Dispatch<string>];
+  loadingScreenProgress: [ILoaderProgress | null, React.Dispatch<ILoaderProgress | null>];
   loadingScreenBackgroundURL: [string, React.Dispatch<string>];
   loadingScreenLogoURL: [string, React.Dispatch<string>];
 }
@@ -33,6 +35,7 @@ export const AppProvider = (props: any) => {
 
   const [showLoadingScreen, setShowLoadingScreen] = useState<boolean>(true);
   const [loadingScreenMessage, setLoadingScreenMessage] = useState<string>('Loading...');
+  const [loadingScreenProgress, setLoadingScreenProgress] = useState<ILoaderProgress | null>(null);
   const [loadingScreenBackgroundURL, setLoadingScreenBackgroundURL] = useState<string>('');
   const [loadingScreenLogoURL, setLoadingScreenLogoURL] = useState<string>('');
 
@@ -79,6 +82,14 @@ export const AppProvider = (props: any) => {
 
   const onLoadingScreenMessage = (message: string) => {
     setLoadingScreenMessage(message);
+    setLoadingScreenProgress(null);
+  }
+
+  const onLoadingScreenProgress = (progress: ILoaderProgress | null) => {
+    setLoadingScreenProgress(progress);
+    if(progress?.message){
+      setLoadingScreenMessage(progress.message);
+    }
   }
 
   useEffect(() => { 
@@ -90,6 +101,7 @@ export const AppProvider = (props: any) => {
     AppState.addEventListener('on-loader-hide', onLoadingScreenHide);
     AppState.addEventListener('on-loader-init', onLoadingScreenInit);
     AppState.addEventListener('on-loader-message', onLoadingScreenMessage);
+    AppState.addEventListener('on-loader-progress', onLoadingScreenProgress);
     AppState.initApp();
     return () => {
       window.removeEventListener('keypress', onKeyPress);
@@ -100,6 +112,7 @@ export const AppProvider = (props: any) => {
       AppState.removeEventListener('on-loader-hide', onLoadingScreenHide);
       AppState.removeEventListener('on-loader-init', onLoadingScreenInit);
       AppState.removeEventListener('on-loader-message', onLoadingScreenMessage);
+      AppState.removeEventListener('on-loader-progress', onLoadingScreenProgress);
     }
   }, []);
 
@@ -121,6 +134,7 @@ export const AppProvider = (props: any) => {
     showPerformanceMonitor: [showPerformanceMonitor, setShowPerformanceMonitor],
     showLoadingScreen: [showLoadingScreen, setShowLoadingScreen],
     loadingScreenMessage: [loadingScreenMessage, setLoadingScreenMessage],
+    loadingScreenProgress: [loadingScreenProgress, setLoadingScreenProgress],
     loadingScreenBackgroundURL: [loadingScreenBackgroundURL, setLoadingScreenBackgroundURL],
     loadingScreenLogoURL: [loadingScreenLogoURL, setLoadingScreenLogoURL],
   };

--- a/src/apps/game/states/AppState.ts
+++ b/src/apps/game/states/AppState.ts
@@ -2,6 +2,7 @@ import * as KotOR from "@/apps/game/KotOR";
 import { Launcher } from "@/apps/launcher/context/Launcher";
 import { ApplicationEnvironment } from "@/enums/ApplicationEnvironment";
 import { GameInitializer } from "@/apps/game/GameInitializer";
+import { ILoaderProgress } from "@/apps/common/loader/LoaderProgress";
 
 export class AppState {
   static eulaAccepted: boolean = false;
@@ -161,6 +162,12 @@ export class AppState {
    */
   static loaderMessage(message: string): void {
     AppState.processEventListener('on-loader-message', [message]);
+    AppState.processEventListener('on-loader-progress', [null]);
+  }
+
+  static loaderProgress(progress: ILoaderProgress): void {
+    AppState.processEventListener('on-loader-message', [progress.message]);
+    AppState.processEventListener('on-loader-progress', [progress]);
   }
 
   /**
@@ -180,6 +187,13 @@ export class AppState {
     KotOR.TextureLoader.GameKey = KotOR.GameState.GameKey;
     GameInitializer.AddEventListener('on-loader-message', (message: string) => {
       AppState.loaderMessage(message);
+    });
+    GameInitializer.AddEventListener('on-loader-progress', (progress: ILoaderProgress | null) => {
+      if(progress){
+        AppState.loaderProgress(progress);
+      }else{
+        AppState.processEventListener('on-loader-progress', [null]);
+      }
     });
     GameInitializer.AddEventListener('on-loader-show', () => {
       AppState.loaderShow();


### PR DESCRIPTION
## Summary

Adds live loading feedback to the shared `LoadingScreen` used by the game client and Forge:

- current asset filename
- progress bar with percent and completed/total
- smoothed ETA during `LoadGameResources`

## Split from PR #99

PR #99 mixed HMR and loading commits. This PR replaces it:

| Item | Branch / PR |
|------|-------------|
| Loading screen only | **this PR** (`feat/loading-screen-only`) |
| Game client HMR | PR #98 |

## Test plan

- [x] `npm test` (6 LoaderProgress tests)
- [x] `npm run webpack:prod`
- [ ] Manual: grant game directory and confirm progress bar advances with filenames during asset load