### PR TITLE
feat(forge): resource explorer startup progress on loading screen

### DIFF
--- a/.cursor/agents/kotor-hmr-verifier.md
+++ b/.cursor/agents/kotor-hmr-verifier.md
@@ -1,0 +1,58 @@
+---
+name: kotor-hmr-verifier
+description: Live browser verification specialist for KotOR.js HMR, dev-FS, and dev-session-resume. Use proactively whenever HMR, dev server, session preservation, or reload-resume behavior must be proven functional in a real browser (Chrome DevTools MCP) BEFORE any unit/e2e tests are written or trusted. Also use to diagnose "HMR doesn't work" reports with evidence.
+---
+
+You are the KotOR.js HMR verification specialist. Your job is to prove — with live browser evidence, never from source inspection alone — whether hot reload and session resume actually work in a running game session. You never claim something works without runtime proof, and you never write or run unit tests until live functionality is confirmed.
+
+## Hard rules
+
+1. **Evidence before assertions.** A claim like "HMR works" requires: unchanged `pageLoadId` across a hot apply (for in-place HMR) or a successful auto-resume into the same module/position (for reload-resume), observed via browser tooling in the same session.
+2. **No tests until functional.** Do not create or run unit tests / e2e suites until the live browser loop has passed. Green CI does not prove manual browser parity.
+3. **Distinguish the three HMR tiers.** KotOR.js has:
+   - **In-place HMR** — only for accepted boundaries: React UI shell (`@/apps/game/app`, `@/apps/game/context/AppContext`) and the canary `@/dev/HmrTestProbe`. Verified by `acceptCount`/`loopGeneration` increments with constant `pageLoadId`.
+   - **Engine-file edits** — cannot hot-swap in place (static singletons, `#private` fields, `instanceof` identity). Expected behavior: state snapshot → full reload → auto-resume.
+   - **F5 / manual reload** — must resume the session in-module at the saved position via the dev resume snapshot, not return to main menu.
+4. **Restore any instrumentation** (probe values, marker lines in engine files) before finishing.
+
+## Environment
+
+| Item | Value |
+|---|---|
+| Dev server | `KOTOR_DEV_GAME_DIR=/run/media/brunner56/MyBook/SteamLibrary/steamapps/common/swkotor KOTOR_DEV_PORT=8130 npm run webpack:serve-hmr` |
+| Game URL | `http://127.0.0.1:8130/game/?key=kotor` |
+| Port 8080 | default HMR (FS picker) — do not use for real-asset verification |
+| Port 8099 | CI HMR e2e only — never for manual verification |
+| Compile wait | watch server log for `Compiled successfully` (first build can take 2+ min) |
+
+## Browser workflow (Chrome DevTools MCP)
+
+1. `new_page` → game URL. Wait for bridge: `window.__KOTOR_HMR_TEST__` truthy.
+2. Wait for bootstrap: `getBootstrapStatus().gameReady === true` (2DA count ~209, heads table loaded).
+3. Quick-play: `startQuickPlayToModule('end_m01aa')` (catch errors into `window.__KOTOR_HMR_E2E_QUICKPLAY_ERROR__`); pump `skipIntroMovies()` while polling `snapshotSession()` until `ready && module === 'end_m01aa' && player`. Budget up to ~240 s.
+4. Record baseline: `pageLoadId`, `acceptCount`, `loopGeneration`, `probeValue`, full `snapshotSession()` (module, area, creatureCount, player xyz). Set a heap marker: `window.__HEAP_MARKER__ = pageLoadId`.
+5. Take a screenshot as visual proof of an in-module session.
+
+## Verification matrix
+
+| Test | Action | Pass criteria |
+|---|---|---|
+| A: probe in-place HMR | Edit `src/dev/HmrTestProbe.ts` `HMR_PROBE` value, wait ~15 s | `pageLoadId` and heap marker unchanged; `acceptCount` +1; `loopGeneration` +1; `probeValue` = new value; `snapshotSession().ready` true, module unchanged |
+| B: engine edit reload-resume | Add a temporary marker line to a per-frame engine method (e.g. `ModuleArea.update`) | Page reloads automatically, then auto-resumes into the same module near the saved position; marker counter increments (new code live) |
+| C: manual F5 resume | `navigate_page` reload | Boot skips main menu, auto-resumes same module; player position within 0.25 epsilon of pre-reload snapshot |
+
+Position comparisons use epsilon 0.25 (physics settling). `snapshotSession().ready` counts DIALOG and FREELOOK as in-module (module intros auto-start dialog).
+
+## Key files
+
+- `src/dev/HmrTestBridge.ts` — `window.__KOTOR_HMR_TEST__` API (snapshotSession, startQuickPlayToModule, skipIntroMovies, getBootstrapStatus, nudgePlayer)
+- `src/dev/HmrTestProbe.ts` — HMR canary (restore to `0` when done)
+- `src/dev/HotReloadManager.ts` — accept counters, loop invalidation
+- `src/dev/DevSessionResume.ts` — localStorage snapshot + boot auto-resume (reload-resume tier)
+- `src/apps/game/index.tsx` — accept boundaries and abort/fail status handler
+- `src/GameState.ts` — `hmrLoopGeneration` / `ensureUpdateLoop` mechanics
+- `docs/solutions/` — search before debugging (stale dev-FS handles, ranged BIF reads, real-asset e2e patterns)
+
+## Reporting
+
+Finish with a compact evidence table: each test, the observed counters/snapshots (before → after), screenshot paths, and an explicit verdict per tier. Label any unverified claim as such. If a tier fails, report the exact console errors (`list_console_messages` types error/warn) and the failing step — do not paper over it.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,168 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+    branches:
+      - '**'
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  quality:
+    name: Quality checks
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Detect changed files
+        id: changed
+        env:
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
+          BEFORE_SHA: ${{ github.event.before || '' }}
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          if [ "${GITHUB_EVENT_NAME}" = "pull_request" ] && [ -n "${PR_BASE_SHA}" ]; then
+            base_sha="${PR_BASE_SHA}"
+          elif [ -n "${BEFORE_SHA}" ] && [ "${BEFORE_SHA}" != "0000000000000000000000000000000000000000" ]; then
+            base_sha="${BEFORE_SHA}"
+          else
+            base_sha="$(git rev-list --max-parents=0 HEAD)"
+          fi
+
+          changed_files="$(git diff --name-only "${base_sha}" "${HEAD_SHA}" || true)"
+          echo "Changed files since ${base_sha}:"
+          echo "${changed_files}"
+
+          src_ts_files=""
+          prettier_files=""
+          jest_related_files=""
+          run_full_tests="false"
+
+          while IFS= read -r file; do
+            [ -z "${file}" ] && continue
+
+            if [[ "${file}" == src/* ]] && [[ "${file}" == *.ts || "${file}" == *.tsx ]]; then
+              src_ts_files="${src_ts_files}"$'\n'"${file}"
+            fi
+
+            if [[ "${file}" == src/* ]] && [[ "${file}" == *.ts || "${file}" == *.tsx || "${file}" == *.js || "${file}" == *.jsx ]]; then
+              jest_related_files="${jest_related_files}"$'\n'"${file}"
+            fi
+
+            case "${file}" in
+              jest.config.js|package.json|package-lock.json|tsconfig.jest.json|*.test.ts|*.spec.ts)
+                run_full_tests="true"
+                ;;
+            esac
+
+            case "${file}" in
+              *.ts|*.tsx|*.js|*.jsx|*.json|*.md|*.yml|*.yaml)
+                prettier_files="${prettier_files}"$'\n'"${file}"
+                ;;
+            esac
+          done <<< "${changed_files}"
+
+          {
+            echo "src_ts_files<<EOF"
+            echo "${src_ts_files}"
+            echo "EOF"
+            echo "prettier_files<<EOF"
+            echo "${prettier_files}"
+            echo "EOF"
+            echo "jest_related_files<<EOF"
+            echo "${jest_related_files}"
+            echo "EOF"
+            echo "run_full_tests=${run_full_tests}"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Check formatting on changed files
+        if: ${{ steps.changed.outputs.prettier_files != '' }}
+        env:
+          PRETTIER_FILES: ${{ steps.changed.outputs.prettier_files }}
+        run: |
+          set -euo pipefail
+          printf '%s\n' "${PRETTIER_FILES}" | xargs -r npx prettier --check
+
+      - name: Lint changed TypeScript files
+        if: ${{ steps.changed.outputs.src_ts_files != '' }}
+        env:
+          SRC_TS_FILES: ${{ steps.changed.outputs.src_ts_files }}
+        run: |
+          set -euo pipefail
+          printf '%s\n' "${SRC_TS_FILES}" | xargs -r npx cross-env ESLINT_USE_FLAT_CONFIG=false eslint
+
+      - name: Run tests
+        if: ${{ steps.changed.outputs.run_full_tests == 'true' }}
+        run: npm test
+
+      - name: Run related tests
+        if: ${{ steps.changed.outputs.run_full_tests != 'true' && steps.changed.outputs.jest_related_files != '' }}
+        env:
+          JEST_RELATED_FILES: ${{ steps.changed.outputs.jest_related_files }}
+        run: |
+          set -euo pipefail
+          printf '%s\n' "${JEST_RELATED_FILES}" | xargs -r npx jest --findRelatedTests --verbose --coverage --no-cache --passWithNoTests
+
+      - name: Skip tests when no related files changed
+        if: ${{ steps.changed.outputs.run_full_tests != 'true' && steps.changed.outputs.jest_related_files == '' }}
+        run: echo "No Jest-related files changed; skipping tests."
+
+      - name: Compile Electron entrypoints
+        run: npm run electron:compile
+
+  build:
+    name: Build bundles
+    runs-on: ubuntu-latest
+    needs: quality
+    strategy:
+      matrix:
+        mode: [dev, prod]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build bundle
+        run: npm run webpack:${{ matrix.mode }}
+
+      - name: Verify launcher output exists
+        run: test -f dist/launcher/index.html
+
+      - name: Upload dist artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-${{ matrix.mode }}
+          path: dist
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
   hmr-e2e:
     name: HMR session E2E
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,83 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+      - main
+
+jobs:
+  unit:
+    name: Unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: HotReloadManager tests
+        run: npx jest src/dev/HotReloadManager.test.ts --no-cache
+
+  hmr-e2e:
+    name: HMR session E2E
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Chromium
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y chromium-browser || sudo apt-get install -y chromium
+
+      - name: Resolve Chromium path
+        id: chromium
+        run: |
+          for candidate in /usr/bin/chromium-browser /usr/bin/chromium /usr/bin/google-chrome; do
+            if [ -x "$candidate" ]; then
+              echo "path=$candidate" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          done
+          echo "No Chromium executable found"
+          exit 1
+
+      - name: HMR session preservation E2E
+        run: npm run test:hmr-e2e
+        env:
+          PUPPETEER_EXECUTABLE_PATH: ${{ steps.chromium.outputs.path }}
+
+  build:
+    name: Production build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Webpack production build
+        run: npm run webpack:prod

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ debug.log
 docs/*
 !docs/solutions/
 !docs/solutions/**
+.hmr-investigation/
+.audit/
 coverage/
 scratch/
 research/

--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,9 @@ tests/
 # src/**/*.js
 dist/
 debug.log
-docs/
+docs/*
+!docs/solutions/
+!docs/solutions/**
 coverage/
 scratch/
 research/

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,68 @@
+# Agent guide — KotOR.js (feat/forge-explorer-progress / PR #101)
+
+Short entrypoint for coding agents. Human developers: see [README.md](README.md).
+
+## Branch context
+
+This branch adds **HMR dev play** (`webpack:serve-hmr`, `DevGameFileBackend`, `/__kotor_dev_fs` middleware) and **Forge explorer progress**. Upstream `KobaltBlu/KotOR.js` master has **no HMR stack** — browser errors during HMR dev are often branch-only dev infrastructure, not Odyssey engine regressions. See `docs/solutions/runtime-errors/dev-fs-stale-handle-hmr-parity.md`.
+
+## Port map (do not mix these)
+
+| Port | Use |
+|------|-----|
+| **8080** | Default `webpack:serve-hmr` — File System Access picker unless `KOTOR_DEV_GAME_DIR` set at compile time |
+| **8130** | **Recommended manual dev** with real KOTOR install via `KOTOR_DEV_GAME_DIR` |
+| **8099** | **CI HMR E2E only** (`KOTOR_HMR_E2E_PORT`) — not for manual browser play |
+
+## Real-asset HMR dev (Linux / local install)
+
+```bash
+KOTOR_DEV_GAME_DIR=/path/to/swkotor KOTOR_DEV_PORT=8130 npm run dev:hmr
+```
+
+Open: **http://127.0.0.1:8130/game/?key=kotor**
+
+After server is up:
+
+```bash
+KOTOR_DEV_PORT=8130 ./scripts/prove-dev-fs-smoke.sh
+```
+
+Browser diagnostic: `window.__KOTOR_HMR_TEST__?.getBootstrapStatus?.()`
+
+## Verification ladder (narrowest first)
+
+1. **Unit** — `npm test -- --testPathPatterns=DevGameFileBackend|dev-game-fs-middleware|HotReloadManager`
+2. **CI HMR E2E** — `npm run test:hmr-e2e` (synthetic session, port 8099; no game install in CI)
+3. **Dev FS smoke** — live server + `prove-dev-fs-smoke.sh` (requires `KOTOR_DEV_GAME_DIR`)
+4. **In-module proof** — `KOTOR_VERIFY_HMR=1 node scripts/verify-in-module.cjs` (Puppeteer; slow on external drives)
+
+Green CI **does not** prove manual browser parity. Always run tier 3 when changing dev FS or bootstrap paths.
+
+## Key env vars
+
+| Variable | Purpose |
+|----------|---------|
+| `KOTOR_DEV_GAME_DIR` | Absolute path to swkotor install; enables `/__kotor_dev_fs` middleware |
+| `KOTOR_DEV_PORT` | webpack-dev-server port (default 8080) |
+| `KOTOR_HMR_E2E_PORT` | HMR e2e script only (default 8099) |
+| `KOTOR_HMR_E2E_MODULE` | Real-asset in-module e2e target (e.g. `end_m01aa`) |
+
+## Documented solutions
+
+`docs/solutions/` — compound learnings (YAML frontmatter: `module`, `tags`, `problem_type`). Search here before debugging HMR, dev FS, or e2e issues.
+
+- `runtime-errors/dev-fs-stale-handle-hmr-parity.md` — stale IndexedDB handle, CI vs manual drift
+- `performance-issues/dev-game-fs-range-reads-and-size-guards.md` — ranged BIF reads, 413 guards
+- `developer-experience/hmr-real-asset-in-module-e2e.md` — real-asset / in-module e2e patterns
+
+`docs/plans/` and `docs/knowledgebase/` are **local-only** (gitignored).
+
+## Tests location
+
+Jest uses co-located `*.test.ts` under `src/` and `webpack/`. The top-level `tests/` directory is gitignored.
+
+## Remotes
+
+- `origin` — fork (th3w1zard1/KotOR.js)
+- `upstream` — KobaltBlu/KotOR.js (PR #101 target)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,13 @@ Short entrypoint for coding agents. Human developers: see [README.md](README.md)
 
 ## Branch context
 
-This branch adds **HMR dev play** (`webpack:serve-hmr`, `DevGameFileBackend`, `/__kotor_dev_fs` middleware) and **Forge explorer progress**. Upstream `KobaltBlu/KotOR.js` master has **no HMR stack** — browser errors during HMR dev are often branch-only dev infrastructure, not Odyssey engine regressions. See `docs/solutions/runtime-errors/dev-fs-stale-handle-hmr-parity.md`.
+This branch adds **HMR dev play** (`webpack:serve-hmr`, `DevGameFileBackend`, `/__kotor_dev_fs` middleware) and **Forge explorer progress**.
+
+HMR has three tiers (see `src/dev/DevSessionResume.ts`, `src/apps/game/index.tsx`):
+
+1. **In-place hot swap** — only React UI shell (`@/apps/game/app`, AppContext) and the `HmrTestProbe` canary.
+2. **Engine-file edits** — cannot hot-swap in place (static singletons, `#private` fields, `instanceof` identity). The HMR status handler snapshots the session to `localStorage` and full-reloads; boot auto-resumes into the same module/position.
+3. **Manual F5** — same snapshot/auto-resume path (continuous 2 s autosave + `beforeunload`). Disable with `?devresume=0`. Upstream `KobaltBlu/KotOR.js` master has **no HMR stack** — browser errors during HMR dev are often branch-only dev infrastructure, not Odyssey engine regressions. See `docs/solutions/runtime-errors/dev-fs-stale-handle-hmr-parity.md`.
 
 ## Port map (do not mix these)
 

--- a/README.md
+++ b/README.md
@@ -182,6 +182,10 @@ Notes:
 
 | Command | What it does |
 |---|---|
+| `npm run dev:hmr` | HMR dev server + engine watch (see Option B2 for `KOTOR_DEV_GAME_DIR`) |
+| `npm run test:hmr-e2e` | Puppeteer HMR session preservation e2e (CI uses port 8099) |
+| `KOTOR_DEV_PORT=8130 ./scripts/prove-dev-fs-smoke.sh` | Curl smoke test against live dev FS middleware |
+| `KOTOR_VERIFY_HMR=1 node scripts/verify-in-module.cjs` | In-module HMR proof with real assets (local only) |
 | `npm run webpack:dev` | One-shot development build (no watch) |
 | `npm run webpack:prod` | Production build (minified, no source maps) |
 | `npm run electron:compile` | Compile only the Electron main process TypeScript |

--- a/README.md
+++ b/README.md
@@ -116,6 +116,14 @@ npm run dev:hmr
 ```
 Runs `webpack:dev-kotor-watch` (engine + workers only) and a **webpack-dev-server** with HMR for the game client. Open **http://localhost:8080/game/?key=kotor**, load into the game, then edit TypeScript under `src/` — successful hot updates keep the live Three.js scene and `GameState` intact instead of forcing a full page reload.
 
+Point the dev server at a local KOTOR I install (Steam/GOG) so the browser can read `chitin.key` and game assets without the File System Access picker:
+
+```bash
+KOTOR_DEV_GAME_DIR=/path/to/swkotor KOTOR_DEV_PORT=8095 npm run dev:hmr
+```
+
+Then open **http://localhost:8095/game/?key=kotor** (port defaults to `8080` when `KOTOR_DEV_PORT` is unset). `webpack/dev-game-fs-middleware.js` serves files from `KOTOR_DEV_GAME_DIR` under `/__kotor_dev_fs`.
+
 > The HMR server inlines the engine module graph for hot-swap; `webpack:dev-kotor-watch` rebuilds `dist/KotOR.js` and workers without overwriting the HMR game bundle.
 
 > `npm run dev` remains the classic watch + static serve flow. Use `dev:hmr` when iterating on gameplay or engine logic in-browser.

--- a/README.md
+++ b/README.md
@@ -111,18 +111,26 @@ npm run dev
 Runs `webpack:dev-watch` and `serve` in parallel with a single command.
 
 **Option B2 — Hot reload while playing (preserves game session):**
+
+For **Linux** or when you have a local KOTOR I install, point the dev server at game assets so the browser reads `chitin.key` via HTTP middleware instead of the File System Access picker:
+
+```bash
+KOTOR_DEV_GAME_DIR=/path/to/swkotor KOTOR_DEV_PORT=8130 npm run dev:hmr
+```
+
+Then open **http://127.0.0.1:8130/game/?key=kotor**. `webpack/dev-game-fs-middleware.js` serves files from `KOTOR_DEV_GAME_DIR` under `/__kotor_dev_fs`.
+
+**Port map:** `8080` = default HMR (no local assets unless you use the picker); **`8130` = recommended manual dev with real assets**; `8099` = CI HMR E2E only (`KOTOR_HMR_E2E_PORT`).
+
+Without `KOTOR_DEV_GAME_DIR`, you can still run HMR and pick a folder in the browser:
+
 ```bash
 npm run dev:hmr
 ```
-Runs `webpack:dev-kotor-watch` (engine + workers only) and a **webpack-dev-server** with HMR for the game client. Open **http://localhost:8080/game/?key=kotor**, load into the game, then edit TypeScript under `src/` — successful hot updates keep the live Three.js scene and `GameState` intact instead of forcing a full page reload.
 
-Point the dev server at a local KOTOR I install (Steam/GOG) so the browser can read `chitin.key` and game assets without the File System Access picker:
+Open **http://localhost:8080/game/?key=kotor** (port defaults to `8080` when `KOTOR_DEV_PORT` is unset). Load into the game, then edit TypeScript under `src/` — successful hot updates keep the live Three.js scene and `GameState` intact instead of forcing a full page reload.
 
-```bash
-KOTOR_DEV_GAME_DIR=/path/to/swkotor KOTOR_DEV_PORT=8095 npm run dev:hmr
-```
-
-Then open **http://localhost:8095/game/?key=kotor** (port defaults to `8080` when `KOTOR_DEV_PORT` is unset). `webpack/dev-game-fs-middleware.js` serves files from `KOTOR_DEV_GAME_DIR` under `/__kotor_dev_fs`.
+Verify dev FS after starting with real assets: `KOTOR_DEV_PORT=8130 ./scripts/prove-dev-fs-smoke.sh`
 
 > The HMR server inlines the engine module graph for hot-swap; `webpack:dev-kotor-watch` rebuilds `dist/KotOR.js` and workers without overwriting the HMR game bundle.
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,16 @@ npm run dev
 ```
 Runs `webpack:dev-watch` and `serve` in parallel with a single command.
 
+**Option B2 — Hot reload while playing (preserves game session):**
+```bash
+npm run dev:hmr
+```
+Runs `webpack:dev-kotor-watch` (engine + workers only) and a **webpack-dev-server** with HMR for the game client. Open **http://localhost:8080/game/?key=kotor**, load into the game, then edit TypeScript under `src/` — successful hot updates keep the live Three.js scene and `GameState` intact instead of forcing a full page reload.
+
+> The HMR server inlines the engine module graph for hot-swap; `webpack:dev-kotor-watch` rebuilds `dist/KotOR.js` and workers without overwriting the HMR game bundle.
+
+> `npm run dev` remains the classic watch + static serve flow. Use `dev:hmr` when iterating on gameplay or engine logic in-browser.
+
 ---
 
 #### Option C — VS Code launch configurations

--- a/STRATEGY.md
+++ b/STRATEGY.md
@@ -1,0 +1,66 @@
+---
+name: KotOR.js
+last_updated: 2026-06-04
+---
+
+# KotOR.js Strategy
+
+> **Note:** Draft inferred from README and active HMR/dev-FS work. Run `/ce-strategy` for a full interview and user-validated revision.
+
+## Target problem
+
+Classic KotOR I & II run on a proprietary Odyssey engine that is no longer maintained. Players and modders who want to play or extend those games in modern environments (browser, desktop, tooling) lack a faithful, extensible engine they can run without reverse-engineering the originals from scratch.
+
+## Our approach
+
+Reimplement the Odyssey engine in TypeScript with THREE.js rendering, ship it as both Electron desktop and browser-capable builds, and prioritize **playable parity** with real game assets over speculative features. Dev workflows (HMR, Forge modding suite) must not regress the runtime path users actually play on.
+
+## Who it's for
+
+**Primary:** KotOR player-modder — They want to load their legally owned K1/K2 install, play in browser or Electron, and use Forge to inspect and edit game data without leaving the ecosystem.
+
+**Secondary:** Engine contributor — They need a fast dev loop (webpack HMR + local game dir) and CI that proves real-asset sessions still bootstrap after changes.
+
+## Key metrics
+
+- **Module bootstrap success rate** — Game reaches in-module state with expected creature/module counts; measured via HMR E2E and `scripts/verify-in-module.cjs` on real assets
+- **Dev FS read reliability** — Stat/read on `chitin.key` and representative assets succeed via `/__kotor_dev_fs` without NotFoundError or socket exhaustion; measured via unit tests + dev smoke curl + browser console on port with `KOTOR_DEV_GAME_DIR`
+- **CI green on PR** — Quality checks, bundle builds, and HMR session E2E pass on KobaltBlu/KotOR.js upstream; tracked in GitHub Actions on open PRs
+
+## Tracks
+
+### Runtime engine parity
+
+Faithful reimplementation of Odyssey systems (resources, modules, combat, dialogue, saves) so K1/K2 content loads and plays correctly.
+
+_Why it serves the approach:_ Without parity, the TypeScript rewrite is a demo, not a replacement engine.
+
+### Browser + Electron delivery
+
+Webpack builds, File System Access / dev middleware paths, and Electron packaging so the same codebase runs where users actually play.
+
+_Why it serves the approach:_ Multi-surface delivery is core to the project's web-compatibility goal; each surface must share one resource-loading truth.
+
+### KotOR Forge (modding suite)
+
+Editor and explorer tooling for GFF, modules, and assets integrated with the engine's parsers.
+
+_Why it serves the approach:_ Modders are a primary audience; Forge is the wedge that keeps contributors invested in the engine.
+
+### Dev experience (HMR, local assets)
+
+Fast iteration with `KOTOR_DEV_GAME_DIR`, dev FS middleware, and session-preserving HMR without breaking manual browser play.
+
+_Why it serves the approach:_ Contributors cannot sustain parity work if CI-green dev paths diverge from what developers run locally.
+
+## Not working on
+
+- Distributing copyrighted game assets (users must supply their own install)
+- Feature parity with unrelated remakes or total conversions outside K1/K2 Odyssey scope
+- Production-hardening dev FS middleware for untrusted networks (localhost-only dev aid)
+
+## Marketing
+
+**One-liner:** KotOR.js — a TypeScript remake of the Odyssey engine so you can play and mod Knights of the Old Republic in the browser or on desktop.
+
+**Key message:** Built on THREE.js and Electron, KotOR.js supports real K1/K2 installs, ships Forge for modding, and is developed in the open with the OpenKotOR community.

--- a/docs/solutions/developer-experience/engine-hmr-snapshot-reload-resume.md
+++ b/docs/solutions/developer-experience/engine-hmr-snapshot-reload-resume.md
@@ -1,0 +1,98 @@
+---
+title: Engine HMR = snapshot-reload-resume, not in-place swap
+date: 2026-06-12
+category: developer-experience
+module: DevSessionResume
+problem_type: architecture_decision
+component: development_workflow
+symptoms:
+  - "Editing engine source during HMR dev play silently does nothing (stale code keeps running)"
+  - "Entry self-accept re-executes a parallel engine world that nothing references, killing the test bridge"
+  - "Full reload (F5) drops the player back at the main menu, losing the in-module session"
+root_cause: design_limitation
+resolution_type: code_fix
+severity: high
+tags:
+  - hmr
+  - dev-session-resume
+  - webpack
+  - localStorage
+  - e2e
+---
+
+## Problem
+
+"HMR doesn't work" in KotOR.js had a precise meaning that took several
+debugging rounds to pin down: edits to **engine** source files (`src/module/**`,
+`src/managers/**`, `src/GameState.ts`, …) either silently did nothing or broke
+the page, and any full reload sent the developer back to the main menu —
+losing minutes of boot + module-load time per iteration.
+
+## Why in-place engine hot-swap is impossible here
+
+Three structural properties of the engine rule out webpack in-place hot
+replacement (and the usual class-prototype-patching tricks) for engine code:
+
+1. **Static singleton state** — `GameState`, managers, and loaders keep live
+   session state in static class fields. Re-executed modules create parallel
+   classes with empty statics → split-brain between old live world and new
+   code scope.
+2. **Native `#private` fields** — e.g. `ModuleObject.#computedPath`. Private
+   field brands are per-constructor; methods from a re-evaluated class throw
+   `TypeError` when applied to instances built by the old class.
+3. **`instanceof`-heavy logic** — object identity checks fail across class
+   generations in either patch direction.
+
+The pre-existing entry self-accept made this worse, not better: engine edits
+bubbled into the entry, webpack re-executed the whole import chain into a
+detached "new world" (module-scope side effects like `MenuManager.Init()`
+re-ran), while the render loop kept running old code. Observed live: the test
+bridge died and the edit never took effect.
+
+## Solution: three explicit HMR tiers
+
+| Tier | Mechanism | Files |
+|---|---|---|
+| React UI shell + probe | true in-place `module.hot.accept` boundaries | `src/apps/game/index.tsx` |
+| Engine edits | status handler (`abort`/`fail`) → synchronous localStorage snapshot → `location.reload()` → boot auto-resume | `index.tsx` + `src/dev/DevSessionResume.ts` |
+| Manual F5 | continuous 2 s autosave + `beforeunload` snapshot → same boot auto-resume | `src/dev/DevSessionResume.ts` |
+
+Key implementation points:
+
+- **Snapshot is tiny and synchronous** (module, position, facing →
+  `localStorage['kotor.devResumeSnapshot']`), so it works from `beforeunload`
+  and the HMR status handler without async hazards.
+- **Resume rides the quick-play path** (`startQuickPlayToModule` from
+  `HmrTestBridge`), then restores the player transform. It must wait for
+  `GameState.Ready` **and** `MenuManager.LoadScreen/MenuToolTip` before
+  quick-playing — racing the app's own menu init double-runs
+  `LoadMainGameMenus` and crashes on menu resources (observed:
+  `Resource not found: lplanet_03`).
+- **Crash-loop breaker**: attempts counter persisted *before* the risky load;
+  3 strikes clears the snapshot. `?devresume=0` disables resume entirely.
+- **Entry self-accept was removed** so engine edits deterministically hit the
+  `abort` path instead of re-executing a detached world.
+
+## Verified behavior (live, Chrome DevTools MCP, real assets)
+
+- Engine edit (`ModuleArea.update` marker) → auto reload → auto resume into
+  `end_m01aa` at the exact pre-edit position → marker counting every frame
+  (new code live).
+- F5 → resume to the centimeter (nudged position restored), never main menu.
+- Probe/UI in-place HMR unaffected (`pageLoadId` constant, `acceptCount`
+  increments).
+
+## Regression coverage
+
+- `src/dev/DevSessionResume.test.ts` — snapshot capture guards, URL kill
+  switch, attempts breaker, transform restore, idempotent install.
+- `scripts/hmr-session.e2e.cjs` — `runF5ResumePhase` +
+  `runEngineEditResumePhase` (real-asset in-module mode only; synthetic CI
+  mode skips them).
+
+## Known limitations
+
+- Resume replays module entry (intro dialogs restart); state fidelity is
+  module + player transform, not a full savegame. Layering
+  `SaveGame.SaveCurrentGame` onto the snapshot cadence is the upgrade path.
+- A resume costs a real module load (~60–80 s on an external drive).

--- a/docs/solutions/developer-experience/hmr-real-asset-in-module-e2e.md
+++ b/docs/solutions/developer-experience/hmr-real-asset-in-module-e2e.md
@@ -1,0 +1,72 @@
+---
+title: Real-asset and in-module HMR session e2e
+date: 2026-06-03
+category: developer-experience
+module: dev
+problem_type: developer_experience
+component: testing_framework
+severity: medium
+tags: [hmr, e2e, kotor-dev-game-dir, puppeteer, keymapper]
+applies_when:
+  - "Extending HMR e2e to exercise real KOTOR installs locally"
+  - "Game init crashes during real asset load in headless e2e"
+---
+
+# Real-asset and in-module HMR session e2e
+
+## Context
+
+CI HMR e2e used synthetic `activateSession()` and did not prove session preservation after real KEY/BIF loading or in-game module state. Local developers with `KOTOR_DEV_GAME_DIR` needed an automated gate matching manual HMR dev.
+
+## Guidance
+
+### Dual-mode e2e (`scripts/hmr-session.e2e.cjs`)
+
+- **`USE_REAL_ASSETS`**: when `KOTOR_DEV_GAME_DIR` exists on disk, pass it to webpack serve and poll `snapshotSession().ready` instead of calling `activateSession()`.
+- **`USE_IN_MODULE`**: when `KOTOR_HMR_E2E_MODULE` is also set (e.g. `end_m01aa`), call `window.__KOTOR_HMR_TEST__.startQuickPlayToModule()` after menu ready, then assert module + player position survive probe HMR.
+- Use Node-side polling (2s interval) rather than long `page.waitForFunction` to avoid Puppeteer protocol timeouts on multi-minute loads.
+- Set `protocolTimeout` and `--disable-dev-shm-usage` for headless Chromium on large asset loads.
+
+### HmrTestBridge quick-play
+
+`startQuickPlayToModule` mirrors CharGen quick-play: init CharGen template, save player template, init game-in-progress folder, `LoadModule(name)`. Snapshot uses `module.filename` (not `module.name`) for comparison with env module id.
+
+### KeyMapper guards
+
+Real load initializes gamepad and action processors before all `KeyMapAction` entries exist. Use helpers that skip missing entries:
+
+```typescript
+static setActionProcessor(action: KeyMapAction, callback: KeymapProcessorCallback) {
+  const entry = KeyMapper.Actions[action];
+  if (entry) entry.setProcessor(callback);
+}
+```
+
+Same pattern as `setGamepad` in `BindGamepad`.
+
+## Why This Matters
+
+Without guards, a single undefined `KeyMapAction` entry throws during init and blocks reaching `GameState.Ready` in real-asset e2e. Without quick-play bridge, in-module HMR proof required fragile canvas/menu automation.
+
+## When to Apply
+
+- Adding HMR or dev-FS test paths that load real game data locally.
+- Any init path that binds processors to sparse `KeyMapper.Actions` tables during partial startup.
+
+## Examples
+
+```bash
+# CI path (synthetic)
+npm run test:hmr-e2e
+
+# Local real assets to main menu
+KOTOR_DEV_GAME_DIR=/path/to/swkotor npm run test:hmr-e2e
+
+# Local in-module HMR preservation
+KOTOR_DEV_GAME_DIR=/path/to/swkotor KOTOR_HMR_E2E_MODULE=end_m01aa npm run test:hmr-e2e
+```
+
+## Related Issues
+
+- PR #101 — HMR dev stack and session preservation
+- Prior plan: in-game HMR verification (R6 partial → in-module e2e)

--- a/docs/solutions/performance-issues/dev-game-fs-range-reads-and-size-guards.md
+++ b/docs/solutions/performance-issues/dev-game-fs-range-reads-and-size-guards.md
@@ -1,0 +1,88 @@
+---
+title: Dev game FS must range-read large BIF archives and guard whole-file size
+date: 2026-06-03
+category: performance-issues
+module: dev-hmr
+problem_type: performance_issue
+component: development_workflow
+symptoms:
+  - "NotReadableError when loading RIM/BIF headers in browser dev with KOTOR_DEV_GAME_DIR"
+  - "Resource not found for lplanet_* MDL after failed archive reads"
+  - "Browser tab OOM or hang when opening models.bif (~954MB) via devGameOpen eager load"
+root_cause: memory_leak
+resolution_type: code_fix
+severity: high
+tags:
+  - hmr
+  - dev-game-fs
+  - range-read
+  - bif
+  - oom
+  - kotor-dev-game-dir
+---
+
+# Dev game FS must range-read large BIF archives and guard whole-file size
+
+## Problem
+
+Browser HMR dev with `KOTOR_DEV_GAME_DIR` failed to load past "Loading Keys" because the dev file backend eagerly buffered entire multi-hundred-megabyte archives (notably `data/models.bif` at ~954MB) into browser memory on every `open`/`readFile`, causing OOM and cascading resource-not-found errors.
+
+## Symptoms
+
+- `NotReadableError: The requested file could not be read` on RIM header reads
+- `Error: Resource not found: ResRef: lplanet_0X ResId: 2002`
+- `TypeError: Cannot read properties of undefined (reading 'Type')` during GFF/DLG parsing after partial loads
+- Dev server or browser tab memory spike when touching large BIFs
+
+## What Didn't Work
+
+- Fixing KEY lookup case sensitivity alone — assets still failed once BIF reads OOM'd
+- Assuming CI HMR e2e (`scripts/hmr-session.e2e.cjs`) proved real-asset loading — it uses synthetic `activateSession()` without `KOTOR_DEV_GAME_DIR`
+- Whole-file `fetch` + `fileByteCache` on every `devGameOpen` — reintroduces OOM for any code path that opens large archives
+
+## Solution
+
+1. **Range reads end-to-end:** `devGameRead` issues HTTP requests with `offset` and `length` query params. Middleware uses `fs.open` + `fs.read` to return only the requested byte window. `devGameOpen` stat-checks existence only — no eager load.
+
+2. **Whole-file size guard (64 MiB):** Middleware returns HTTP 413 for non-ranged reads of files larger than 64 MiB, and for ranged reads whose `length` exceeds the same cap (prevents `Buffer.alloc` abuse).
+
+3. **Client error surfacing:** `loadFileBytes` includes HTTP status and server message in thrown errors for actionable debugging.
+
+4. **Direct test coverage:** `src/dev/DevGameFileBackend.test.ts` and `webpack/dev-game-fs-middleware.test.ts` exercise virtual writes, cache, range URLs, traversal/symlink guards, and 413 paths without a real install.
+
+5. **Localhost-only access:** Middleware rejects non-loopback `remoteAddress` with 403 so `host: 0.0.0.0` can stay for Puppeteer while the install path is not LAN-exposed.
+
+### Key files
+
+- `src/dev/DevGameFileBackend.ts` — ranged `devGameRead`, virtual write store, cache fast paths
+- `webpack/dev-game-fs-middleware.js` — `/__kotor_dev_fs` actions, guards
+- `webpack/Game.hmr.js` — registers middleware when `KOTOR_DEV_GAME_DIR` is set
+
+### Runtime verification (real install)
+
+With `KOTOR_DEV_GAME_DIR=/path/to/swkotor`:
+
+- `stat chitin.key` → 200, size ~569239
+- ranged `chitin.key[0:8]` → `"KEY V1  "`
+- whole `models.bif` → 413
+- ranged `models.bif[0:16]` → 200, 16 bytes `"BIFFV1  ..."`
+
+## Why This Works
+
+KOTOR archives are designed for random access via KEY/BIF/RIM headers read in small windows. Eager whole-file loads defeat that model in a browser with finite heap. Range reads mirror native engine I/O: open handle, read header slice, seek/read resource windows. Server-side 413 prevents both Node and browser from allocating gigabyte buffers on accidental `readFile` paths.
+
+## Prevention
+
+- Never call `devGameReadFile` / whole-file middleware reads for paths under `data/*.bif` or other known large archives — use `devGameOpen` + `devGameRead` with explicit offsets.
+- When adding new dev FS actions, apply `resolveSafe` (path normalize + `realpathSync`) and localhost guard before disk access.
+- Extend `webpack/dev-game-fs-middleware.test.ts` for any new middleware behavior; keep Jest `testMatch` as `**/*.test.ts`.
+- HMR e2e proves hot-swap mechanics only; real-asset smoke requires `KOTOR_DEV_GAME_DIR` and manual or dedicated asset e2e.
+
+## Related Issues
+
+- PR #101 — HMR dev stack with real KOTOR install path
+- Origin plan: `docs/plans/2026-05-29-031-feat-in-game-hmr-verification-plan.md` (U5–U7)
+
+## Remaining gaps
+
+- Automated in-module HMR session preservation with real assets in CI — optional local run via `KOTOR_HMR_E2E_MODULE` (see `docs/solutions/developer-experience/hmr-real-asset-in-module-e2e.md`)

--- a/docs/solutions/runtime-errors/dev-fs-stale-handle-hmr-parity.md
+++ b/docs/solutions/runtime-errors/dev-fs-stale-handle-hmr-parity.md
@@ -1,0 +1,101 @@
+---
+title: HMR dev FS stale handle causes NotFoundError storms while CI stays green
+date: 2026-06-05
+category: runtime-errors
+module: DevGameFileBackend
+problem_type: runtime_error
+component: development_workflow
+symptoms:
+  - "NotFoundError storms from File System Access API during webpack HMR dev play"
+  - "WebSocket connection to ws://localhost:8099/ws failed when dev server runs on another port"
+  - "ERR_INSUFFICIENT_RESOURCES on parallel __kotor_dev_fs stat/read requests"
+  - "GFF modelname and BIK load failures cascading from incomplete resource bootstrap"
+root_cause: config_error
+resolution_type: code_fix
+severity: high
+tags:
+  - hmr
+  - dev-fs
+  - webpack
+  - directory-handle
+  - kotor-dev-game-dir
+related_components:
+  - GameFileSystem
+  - AppState
+  - dev-game-fs-middleware
+---
+
+# HMR dev FS stale handle causes NotFoundError storms while CI stays green
+
+## Problem
+
+Manual browser play on the HMR branch failed with console error storms and broken module bootstrap, while CI and HMR E2E stayed green. The failures looked like upstream game regressions but were caused by dev infrastructure: stale persisted File System Access handles and whole-file HTTP reads through the dev middleware.
+
+## Symptoms
+
+- Hundreds of `NotFoundError` from `showDirectoryPicker` / FS Access paths when game assets should load via `/__kotor_dev_fs`
+- `WebSocket connection to 'ws://localhost:8099/ws' failed` when the dev server was on a different port (8099 is the HMR E2E default, not manual dev)
+- `ERR_INSUFFICIENT_RESOURCES` on concurrent `stat` and `read` requests to the dev middleware
+- Downstream GFF parse errors (`modelname` undefined), missing BIK movies, empty 2DA tables after partial bootstrap
+
+## What Didn't Work
+
+- **Repeated `/lfg` validation-only passes** — CI always set `KOTOR_DEV_GAME_DIR` and used the correct port; manual tabs with stale IndexedDB profiles and wrong ports still failed
+- **Treating errors as upstream Odyssey engine regressions** — upstream master never exercised `DevGameFileBackend`; the HTTP dev FS path is branch-only
+- **Stat cache alone (`63a2fb12`)** — reduced socket pressure but did not stop FS Access fallback when a stale `directory_handle` remained in `ApplicationProfile`
+
+## Solution
+
+### 1. Clear stale handles when dev HTTP FS is active
+
+When the runtime probe finds middleware (or compile-time `KOTOR_DEV_GAME_DIR` is set), clear persisted FS Access state before bootstrap:
+
+```typescript
+// src/dev/DevGameFileBackend.ts
+export function clearDevBrowserDirectoryHandle(): void {
+  ApplicationProfile.directoryHandle = undefined as any;
+  if (ApplicationProfile.profile && typeof ApplicationProfile.profile === 'object') {
+    ApplicationProfile.profile.directory_handle = undefined;
+  }
+}
+```
+
+Called from `src/apps/game/index.tsx` and `src/apps/game/states/AppState.ts` after `probeDevGameFileBackend()`, plus `GameFileSystem.clearDirectoryHandleCache()`.
+
+### 2. Ranged reads with bounded cache
+
+Replace whole-file `devGameReadFile` fetches with stat + 4MB ranged chunks; cache only files ≤ 8MB:
+
+```typescript
+const MAX_FILE_BYTE_CACHE = 8 * 1024 * 1024;
+const RANGED_READ_CHUNK = 4 * 1024 * 1024;
+```
+
+### 3. Reproducible smoke check
+
+```bash
+KOTOR_DEV_GAME_DIR="/path/to/swkotor" KOTOR_DEV_PORT=8130 npm run webpack:serve-hmr
+KOTOR_DEV_PORT=8130 ./scripts/prove-dev-fs-smoke.sh
+```
+
+**Commits:** `2607fcf2` (core fix), `6074f710` (smoke script + STRATEGY draft)
+
+## Why This Works
+
+The HMR stack added an HTTP-backed dev filesystem (`/__kotor_dev_fs`) for browsers that cannot read native paths. When a user previously picked a game directory via File System Access API, that handle persisted in IndexedDB. If the dev middleware was active (or the user opened the wrong port without middleware), the game still tried FS Access paths → `NotFoundError` storms instead of HTTP reads.
+
+Whole-file reads of large BIF/ERF archives multiplied concurrent fetches and exhausted browser connection limits, causing `ERR_INSUFFICIENT_RESOURCES`. GFF and BIK failures were cascades from incomplete bootstrap after FS failures, not independent parser bugs.
+
+## Prevention
+
+- **Before claiming HMR dev parity**, run `./scripts/prove-dev-fs-smoke.sh` against a live `webpack:serve-hmr` instance with real assets — not only unit tests and CI
+- **Manual dev workflow:** use `KOTOR_DEV_PORT=8130` (or your chosen port) consistently; open `http://127.0.0.1:<port>/game/?key=kotor`, not port 8099 unless that server is running
+- **Clear site data** after switching between FS Access picker mode and `KOTOR_DEV_GAME_DIR` middleware mode
+- **Unit tests:** `clearDevBrowserDirectoryHandle` and large-file ranged read coverage in `src/dev/DevGameFileBackend.test.ts`
+- **Diagnostic in browser console:** `window.__KOTOR_HMR__?.getBootstrapStatus?.()`
+
+## Related Issues
+
+- PR [#101](https://github.com/KobaltBlu/KotOR.js/pull/101) — HMR / Forge explorer progress branch
+- Local analysis: `.hmr-investigation/upstream-vs-hmr-analysis.md`
+- Plan: `docs/plans/2026-06-04-004-fix-dev-fs-stale-handle-root-cause-plan.md`

--- a/docs/solutions/runtime-errors/dev-fs-stale-handle-hmr-parity.md
+++ b/docs/solutions/runtime-errors/dev-fs-stale-handle-hmr-parity.md
@@ -92,10 +92,9 @@ Whole-file reads of large BIF/ERF archives multiplied concurrent fetches and exh
 - **Manual dev workflow:** use `KOTOR_DEV_PORT=8130` (or your chosen port) consistently; open `http://127.0.0.1:<port>/game/?key=kotor`, not port 8099 unless that server is running
 - **Clear site data** after switching between FS Access picker mode and `KOTOR_DEV_GAME_DIR` middleware mode
 - **Unit tests:** `clearDevBrowserDirectoryHandle` and large-file ranged read coverage in `src/dev/DevGameFileBackend.test.ts`
-- **Diagnostic in browser console:** `window.__KOTOR_HMR__?.getBootstrapStatus?.()`
+- **Diagnostic in browser console:** `window.__KOTOR_HMR_TEST__?.getBootstrapStatus?.()`
 
 ## Related Issues
 
 - PR [#101](https://github.com/KobaltBlu/KotOR.js/pull/101) — HMR / Forge explorer progress branch
-- Local analysis: `.hmr-investigation/upstream-vs-hmr-analysis.md`
-- Plan: `docs/plans/2026-06-04-004-fix-dev-fs-stale-handle-root-cause-plan.md`
+- Local analysis: `.hmr-investigation/upstream-vs-hmr-analysis.md` (not committed; optional local artifact)

--- a/docs/solutions/runtime-errors/dev-fs-stale-handle-hmr-parity.md
+++ b/docs/solutions/runtime-errors/dev-fs-stale-handle-hmr-parity.md
@@ -74,7 +74,7 @@ const RANGED_READ_CHUNK = 4 * 1024 * 1024;
 ### 3. Reproducible smoke check
 
 ```bash
-KOTOR_DEV_GAME_DIR="/path/to/swkotor" KOTOR_DEV_PORT=8130 npm run webpack:serve-hmr
+KOTOR_DEV_GAME_DIR="/path/to/swkotor" KOTOR_DEV_PORT=8130 npm run dev:hmr
 KOTOR_DEV_PORT=8130 ./scripts/prove-dev-fs-smoke.sh
 ```
 
@@ -88,7 +88,7 @@ Whole-file reads of large BIF/ERF archives multiplied concurrent fetches and exh
 
 ## Prevention
 
-- **Before claiming HMR dev parity**, run `./scripts/prove-dev-fs-smoke.sh` against a live `webpack:serve-hmr` instance with real assets — not only unit tests and CI
+- **Before claiming HMR dev parity**, run `./scripts/prove-dev-fs-smoke.sh` against a live `npm run dev:hmr` server with real assets — not only unit tests and CI
 - **Manual dev workflow:** use `KOTOR_DEV_PORT=8130` (or your chosen port) consistently; open `http://127.0.0.1:<port>/game/?key=kotor`, not port 8099 unless that server is running
 - **Clear site data** after switching between FS Access picker mode and `KOTOR_DEV_GAME_DIR` middleware mode
 - **Unit tests:** `clearDevBrowserDirectoryHandle` and large-file ranged read coverage in `src/dev/DevGameFileBackend.test.ts`

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,7 +6,13 @@ module.exports = {
     '^@/(.*)$': '<rootDir>/src/$1',
   },
   transform: {
-    "^.+.ts?$": ["ts-jest", {}],
+    "^.+\\.ts?$": ["ts-jest", {
+      tsconfig: {
+        types: ['jest', 'node'],
+        lib: ['ES2021'],
+      },
+      isolatedModules: true,
+    }],
   },
   testMatch: ['**/*.test.ts'],
   coverageDirectory: './coverage',

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,7 +6,11 @@ module.exports = {
     '^@/(.*)$': '<rootDir>/src/$1',
   },
   transform: {
-    "^.+.ts?$": ["ts-jest", {}],
+    "^.+.ts?$": ["ts-jest", {
+      tsconfig: {
+        types: ['jest', 'node'],
+      },
+    }],
   },
   testMatch: ['**/*.test.ts'],
   coverageDirectory: './coverage',

--- a/jest.config.js
+++ b/jest.config.js
@@ -15,6 +15,7 @@ module.exports = {
     }],
   },
   testMatch: ['**/*.test.ts'],
+  testPathIgnorePatterns: ['/node_modules/', '<rootDir>/src/tests/'],
   coverageDirectory: './coverage',
   coverageReporters: ['text', 'lcov', 'html'],
   verbose: true

--- a/jest.config.js
+++ b/jest.config.js
@@ -12,7 +12,14 @@ module.exports = {
       },
     }],
   },
-  testMatch: ['**/*.test.ts'],
+  testPathIgnorePatterns: [
+    '/node_modules/',
+    '<rootDir>/src/tests/',
+    'test_rim\\.test\\.ts$',
+    'test_gff\\.test\\.ts$',
+    'test_erf\\.test\\.ts$',
+    'editorFindReferences\\.test\\.ts$',
+  ],
   coverageDirectory: './coverage',
   coverageReporters: ['text', 'lcov', 'html'],
   verbose: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
         "file-loader": "^6.2.0",
         "html-webpack-plugin": "^5.6.5",
         "idb-keyval": "^6.2.2",
+        "jest-util": "^30.3.0",
         "mini-css-extract-plugin": "^2.9.4",
         "monaco-editor-webpack-plugin": "^7.1.1",
         "npm-run-all": "^4.1.5",
@@ -1243,24 +1244,6 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
-    "node_modules/@jest/console/node_modules/@jest/types": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
-      "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
-      "license": "MIT",
-      "dependencies": {
-        "@jest/pattern": "30.0.1",
-        "@jest/schemas": "30.0.5",
-        "@types/istanbul-lib-coverage": "^2.0.6",
-        "@types/istanbul-reports": "^3.0.4",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.33",
-        "chalk": "^4.1.2"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
     "node_modules/@jest/console/node_modules/ansi-styles": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
@@ -1288,23 +1271,6 @@
         "pretty-format": "30.3.0",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.6"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/console/node_modules/jest-util": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
-      "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "30.3.0",
-        "@types/node": "*",
-        "chalk": "^4.1.2",
-        "ci-info": "^4.2.0",
-        "graceful-fs": "^4.2.11",
-        "picomatch": "^4.0.3"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -1370,24 +1336,6 @@
         }
       }
     },
-    "node_modules/@jest/core/node_modules/@jest/types": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
-      "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
-      "license": "MIT",
-      "dependencies": {
-        "@jest/pattern": "30.0.1",
-        "@jest/schemas": "30.0.5",
-        "@types/istanbul-lib-coverage": "^2.0.6",
-        "@types/istanbul-reports": "^3.0.4",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.33",
-        "chalk": "^4.1.2"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
     "node_modules/@jest/core/node_modules/ansi-styles": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
@@ -1415,23 +1363,6 @@
         "pretty-format": "30.3.0",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.6"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/core/node_modules/jest-util": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
-      "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "30.3.0",
-        "@types/node": "*",
-        "chalk": "^4.1.2",
-        "ci-info": "^4.2.0",
-        "graceful-fs": "^4.2.11",
-        "picomatch": "^4.0.3"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -1539,24 +1470,6 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
-    "node_modules/@jest/globals/node_modules/@jest/types": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
-      "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
-      "license": "MIT",
-      "dependencies": {
-        "@jest/pattern": "30.0.1",
-        "@jest/schemas": "30.0.5",
-        "@types/istanbul-lib-coverage": "^2.0.6",
-        "@types/istanbul-reports": "^3.0.4",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.33",
-        "chalk": "^4.1.2"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
     "node_modules/@jest/globals/node_modules/@sinonjs/fake-timers": {
       "version": "15.3.2",
       "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.3.2.tgz",
@@ -1607,23 +1520,6 @@
         "@jest/types": "30.3.0",
         "@types/node": "*",
         "jest-util": "30.3.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/globals/node_modules/jest-util": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
-      "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "30.3.0",
-        "@types/node": "*",
-        "chalk": "^4.1.2",
-        "ci-info": "^4.2.0",
-        "graceful-fs": "^4.2.11",
-        "picomatch": "^4.0.3"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -1696,24 +1592,6 @@
         }
       }
     },
-    "node_modules/@jest/reporters/node_modules/@jest/types": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
-      "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
-      "license": "MIT",
-      "dependencies": {
-        "@jest/pattern": "30.0.1",
-        "@jest/schemas": "30.0.5",
-        "@types/istanbul-lib-coverage": "^2.0.6",
-        "@types/istanbul-reports": "^3.0.4",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.33",
-        "chalk": "^4.1.2"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
     "node_modules/@jest/reporters/node_modules/ansi-styles": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
@@ -1776,23 +1654,6 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
-    "node_modules/@jest/reporters/node_modules/jest-util": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
-      "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "30.3.0",
-        "@types/node": "*",
-        "chalk": "^4.1.2",
-        "ci-info": "^4.2.0",
-        "graceful-fs": "^4.2.11",
-        "picomatch": "^4.0.3"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
     "node_modules/@jest/reporters/node_modules/minimatch": {
       "version": "9.0.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
@@ -1847,24 +1708,6 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
-    "node_modules/@jest/snapshot-utils/node_modules/@jest/types": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
-      "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
-      "license": "MIT",
-      "dependencies": {
-        "@jest/pattern": "30.0.1",
-        "@jest/schemas": "30.0.5",
-        "@types/istanbul-lib-coverage": "^2.0.6",
-        "@types/istanbul-reports": "^3.0.4",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.33",
-        "chalk": "^4.1.2"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
     "node_modules/@jest/source-map": {
       "version": "30.0.1",
       "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-30.0.1.tgz",
@@ -1889,24 +1732,6 @@
         "@jest/types": "30.3.0",
         "@types/istanbul-lib-coverage": "^2.0.6",
         "collect-v8-coverage": "^1.0.2"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/test-result/node_modules/@jest/types": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
-      "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
-      "license": "MIT",
-      "dependencies": {
-        "@jest/pattern": "30.0.1",
-        "@jest/schemas": "30.0.5",
-        "@types/istanbul-lib-coverage": "^2.0.6",
-        "@types/istanbul-reports": "^3.0.4",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.33",
-        "chalk": "^4.1.2"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -1952,7 +1777,7 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
-    "node_modules/@jest/transform/node_modules/@jest/types": {
+    "node_modules/@jest/types": {
       "version": "30.3.0",
       "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
       "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
@@ -1965,23 +1790,6 @@
         "@types/node": "*",
         "@types/yargs": "^17.0.33",
         "chalk": "^4.1.2"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/transform/node_modules/jest-util": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
-      "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "30.3.0",
-        "@types/node": "*",
-        "chalk": "^4.1.2",
-        "ci-info": "^4.2.0",
-        "graceful-fs": "^4.2.11",
-        "picomatch": "^4.0.3"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -5625,24 +5433,6 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
-    "node_modules/expect/node_modules/@jest/types": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
-      "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
-      "license": "MIT",
-      "dependencies": {
-        "@jest/pattern": "30.0.1",
-        "@jest/schemas": "30.0.5",
-        "@types/istanbul-lib-coverage": "^2.0.6",
-        "@types/istanbul-reports": "^3.0.4",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.33",
-        "chalk": "^4.1.2"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
     "node_modules/expect/node_modules/ansi-styles": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
@@ -5684,23 +5474,6 @@
         "@jest/types": "30.3.0",
         "@types/node": "*",
         "jest-util": "30.3.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/expect/node_modules/jest-util": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
-      "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "30.3.0",
-        "@types/node": "*",
-        "chalk": "^4.1.2",
-        "ci-info": "^4.2.0",
-        "graceful-fs": "^4.2.11",
-        "picomatch": "^4.0.3"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -7141,41 +6914,6 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
-    "node_modules/jest-changed-files/node_modules/@jest/types": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
-      "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
-      "license": "MIT",
-      "dependencies": {
-        "@jest/pattern": "30.0.1",
-        "@jest/schemas": "30.0.5",
-        "@types/istanbul-lib-coverage": "^2.0.6",
-        "@types/istanbul-reports": "^3.0.4",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.33",
-        "chalk": "^4.1.2"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-changed-files/node_modules/jest-util": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
-      "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "30.3.0",
-        "@types/node": "*",
-        "chalk": "^4.1.2",
-        "ci-info": "^4.2.0",
-        "graceful-fs": "^4.2.11",
-        "picomatch": "^4.0.3"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
     "node_modules/jest-changed-files/node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -7266,24 +7004,6 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
-    "node_modules/jest-circus/node_modules/@jest/types": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
-      "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
-      "license": "MIT",
-      "dependencies": {
-        "@jest/pattern": "30.0.1",
-        "@jest/schemas": "30.0.5",
-        "@types/istanbul-lib-coverage": "^2.0.6",
-        "@types/istanbul-reports": "^3.0.4",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.33",
-        "chalk": "^4.1.2"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
     "node_modules/jest-circus/node_modules/@sinonjs/fake-timers": {
       "version": "15.3.2",
       "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.3.2.tgz",
@@ -7334,23 +7054,6 @@
         "@jest/types": "30.3.0",
         "@types/node": "*",
         "jest-util": "30.3.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-circus/node_modules/jest-util": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
-      "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "30.3.0",
-        "@types/node": "*",
-        "chalk": "^4.1.2",
-        "ci-info": "^4.2.0",
-        "graceful-fs": "^4.2.11",
-        "picomatch": "^4.0.3"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -7429,41 +7132,6 @@
         }
       }
     },
-    "node_modules/jest-cli/node_modules/@jest/types": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
-      "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
-      "license": "MIT",
-      "dependencies": {
-        "@jest/pattern": "30.0.1",
-        "@jest/schemas": "30.0.5",
-        "@types/istanbul-lib-coverage": "^2.0.6",
-        "@types/istanbul-reports": "^3.0.4",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.33",
-        "chalk": "^4.1.2"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-cli/node_modules/jest-util": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
-      "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "30.3.0",
-        "@types/node": "*",
-        "chalk": "^4.1.2",
-        "ci-info": "^4.2.0",
-        "graceful-fs": "^4.2.11",
-        "picomatch": "^4.0.3"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
     "node_modules/jest-config": {
       "version": "30.3.0",
       "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.3.0.tgz",
@@ -7514,24 +7182,6 @@
         }
       }
     },
-    "node_modules/jest-config/node_modules/@jest/types": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
-      "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
-      "license": "MIT",
-      "dependencies": {
-        "@jest/pattern": "30.0.1",
-        "@jest/schemas": "30.0.5",
-        "@types/istanbul-lib-coverage": "^2.0.6",
-        "@types/istanbul-reports": "^3.0.4",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.33",
-        "chalk": "^4.1.2"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
     "node_modules/jest-config/node_modules/ansi-styles": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
@@ -7572,23 +7222,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/jest-config/node_modules/jest-util": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
-      "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "30.3.0",
-        "@types/node": "*",
-        "chalk": "^4.1.2",
-        "ci-info": "^4.2.0",
-        "graceful-fs": "^4.2.11",
-        "picomatch": "^4.0.3"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-config/node_modules/minimatch": {
@@ -7689,24 +7322,6 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
-    "node_modules/jest-each/node_modules/@jest/types": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
-      "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
-      "license": "MIT",
-      "dependencies": {
-        "@jest/pattern": "30.0.1",
-        "@jest/schemas": "30.0.5",
-        "@types/istanbul-lib-coverage": "^2.0.6",
-        "@types/istanbul-reports": "^3.0.4",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.33",
-        "chalk": "^4.1.2"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
     "node_modules/jest-each/node_modules/ansi-styles": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
@@ -7717,23 +7332,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/jest-each/node_modules/jest-util": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
-      "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "30.3.0",
-        "@types/node": "*",
-        "chalk": "^4.1.2",
-        "ci-info": "^4.2.0",
-        "graceful-fs": "^4.2.11",
-        "picomatch": "^4.0.3"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-each/node_modules/pretty-format": {
@@ -7800,24 +7398,6 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
-    "node_modules/jest-environment-node/node_modules/@jest/types": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
-      "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
-      "license": "MIT",
-      "dependencies": {
-        "@jest/pattern": "30.0.1",
-        "@jest/schemas": "30.0.5",
-        "@types/istanbul-lib-coverage": "^2.0.6",
-        "@types/istanbul-reports": "^3.0.4",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.33",
-        "chalk": "^4.1.2"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
     "node_modules/jest-environment-node/node_modules/@sinonjs/fake-timers": {
       "version": "15.3.2",
       "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.3.2.tgz",
@@ -7873,23 +7453,6 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
-    "node_modules/jest-environment-node/node_modules/jest-util": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
-      "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "30.3.0",
-        "@types/node": "*",
-        "chalk": "^4.1.2",
-        "ci-info": "^4.2.0",
-        "graceful-fs": "^4.2.11",
-        "picomatch": "^4.0.3"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
     "node_modules/jest-environment-node/node_modules/pretty-format": {
       "version": "30.3.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz",
@@ -7926,41 +7489,6 @@
       },
       "optionalDependencies": {
         "fsevents": "^2.3.3"
-      }
-    },
-    "node_modules/jest-haste-map/node_modules/@jest/types": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
-      "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
-      "license": "MIT",
-      "dependencies": {
-        "@jest/pattern": "30.0.1",
-        "@jest/schemas": "30.0.5",
-        "@types/istanbul-lib-coverage": "^2.0.6",
-        "@types/istanbul-reports": "^3.0.4",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.33",
-        "chalk": "^4.1.2"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-haste-map/node_modules/jest-util": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
-      "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "30.3.0",
-        "@types/node": "*",
-        "chalk": "^4.1.2",
-        "ci-info": "^4.2.0",
-        "graceful-fs": "^4.2.11",
-        "picomatch": "^4.0.3"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-leak-detector": {
@@ -8099,41 +7627,6 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
-    "node_modules/jest-resolve/node_modules/@jest/types": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
-      "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
-      "license": "MIT",
-      "dependencies": {
-        "@jest/pattern": "30.0.1",
-        "@jest/schemas": "30.0.5",
-        "@types/istanbul-lib-coverage": "^2.0.6",
-        "@types/istanbul-reports": "^3.0.4",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.33",
-        "chalk": "^4.1.2"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-resolve/node_modules/jest-util": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
-      "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "30.3.0",
-        "@types/node": "*",
-        "chalk": "^4.1.2",
-        "ci-info": "^4.2.0",
-        "graceful-fs": "^4.2.11",
-        "picomatch": "^4.0.3"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
     "node_modules/jest-runner": {
       "version": "30.3.0",
       "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.3.0.tgz",
@@ -8199,24 +7692,6 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
-    "node_modules/jest-runner/node_modules/@jest/types": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
-      "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
-      "license": "MIT",
-      "dependencies": {
-        "@jest/pattern": "30.0.1",
-        "@jest/schemas": "30.0.5",
-        "@types/istanbul-lib-coverage": "^2.0.6",
-        "@types/istanbul-reports": "^3.0.4",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.33",
-        "chalk": "^4.1.2"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
     "node_modules/jest-runner/node_modules/@sinonjs/fake-timers": {
       "version": "15.3.2",
       "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.3.2.tgz",
@@ -8267,23 +7742,6 @@
         "@jest/types": "30.3.0",
         "@types/node": "*",
         "jest-util": "30.3.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-runner/node_modules/jest-util": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
-      "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "30.3.0",
-        "@types/node": "*",
-        "chalk": "^4.1.2",
-        "ci-info": "^4.2.0",
-        "graceful-fs": "^4.2.11",
-        "picomatch": "^4.0.3"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -8395,24 +7853,6 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
-    "node_modules/jest-runtime/node_modules/@jest/types": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
-      "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
-      "license": "MIT",
-      "dependencies": {
-        "@jest/pattern": "30.0.1",
-        "@jest/schemas": "30.0.5",
-        "@types/istanbul-lib-coverage": "^2.0.6",
-        "@types/istanbul-reports": "^3.0.4",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.33",
-        "chalk": "^4.1.2"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
     "node_modules/jest-runtime/node_modules/@sinonjs/fake-timers": {
       "version": "15.3.2",
       "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.3.2.tgz",
@@ -8498,23 +7938,6 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
-    "node_modules/jest-runtime/node_modules/jest-util": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
-      "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "30.3.0",
-        "@types/node": "*",
-        "chalk": "^4.1.2",
-        "ci-info": "^4.2.0",
-        "graceful-fs": "^4.2.11",
-        "picomatch": "^4.0.3"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
     "node_modules/jest-runtime/node_modules/minimatch": {
       "version": "9.0.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
@@ -8576,24 +7999,6 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
-    "node_modules/jest-snapshot/node_modules/@jest/types": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
-      "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
-      "license": "MIT",
-      "dependencies": {
-        "@jest/pattern": "30.0.1",
-        "@jest/schemas": "30.0.5",
-        "@types/istanbul-lib-coverage": "^2.0.6",
-        "@types/istanbul-reports": "^3.0.4",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.33",
-        "chalk": "^4.1.2"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
     "node_modules/jest-snapshot/node_modules/ansi-styles": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
@@ -8626,7 +8031,21 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
-    "node_modules/jest-snapshot/node_modules/jest-util": {
+    "node_modules/jest-snapshot/node_modules/pretty-format": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz",
+      "integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.0.5",
+        "ansi-styles": "^5.2.0",
+        "react-is": "^18.3.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-util": {
       "version": "30.3.0",
       "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
       "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
@@ -8638,20 +8057,6 @@
         "ci-info": "^4.2.0",
         "graceful-fs": "^4.2.11",
         "picomatch": "^4.0.3"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-snapshot/node_modules/pretty-format": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz",
-      "integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@jest/schemas": "30.0.5",
-        "ansi-styles": "^5.2.0",
-        "react-is": "^18.3.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -8669,24 +8074,6 @@
         "chalk": "^4.1.2",
         "leven": "^3.1.0",
         "pretty-format": "30.3.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-validate/node_modules/@jest/types": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
-      "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
-      "license": "MIT",
-      "dependencies": {
-        "@jest/pattern": "30.0.1",
-        "@jest/schemas": "30.0.5",
-        "@types/istanbul-lib-coverage": "^2.0.6",
-        "@types/istanbul-reports": "^3.0.4",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.33",
-        "chalk": "^4.1.2"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -8749,41 +8136,6 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
-    "node_modules/jest-watcher/node_modules/@jest/types": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
-      "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
-      "license": "MIT",
-      "dependencies": {
-        "@jest/pattern": "30.0.1",
-        "@jest/schemas": "30.0.5",
-        "@types/istanbul-lib-coverage": "^2.0.6",
-        "@types/istanbul-reports": "^3.0.4",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.33",
-        "chalk": "^4.1.2"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-watcher/node_modules/jest-util": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
-      "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "30.3.0",
-        "@types/node": "*",
-        "chalk": "^4.1.2",
-        "ci-info": "^4.2.0",
-        "graceful-fs": "^4.2.11",
-        "picomatch": "^4.0.3"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
     "node_modules/jest-worker": {
       "version": "30.3.0",
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-30.3.0.tgz",
@@ -8795,41 +8147,6 @@
         "jest-util": "30.3.0",
         "merge-stream": "^2.0.0",
         "supports-color": "^8.1.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-worker/node_modules/@jest/types": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
-      "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
-      "license": "MIT",
-      "dependencies": {
-        "@jest/pattern": "30.0.1",
-        "@jest/schemas": "30.0.5",
-        "@types/istanbul-lib-coverage": "^2.0.6",
-        "@types/istanbul-reports": "^3.0.4",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.33",
-        "chalk": "^4.1.2"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-worker/node_modules/jest-util": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
-      "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "30.3.0",
-        "@types/node": "*",
-        "chalk": "^4.1.2",
-        "ci-info": "^4.2.0",
-        "graceful-fs": "^4.2.11",
-        "picomatch": "^4.0.3"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -8848,24 +8165,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
-    "node_modules/jest/node_modules/@jest/types": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
-      "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
-      "license": "MIT",
-      "dependencies": {
-        "@jest/pattern": "30.0.1",
-        "@jest/schemas": "30.0.5",
-        "@types/istanbul-lib-coverage": "^2.0.6",
-        "@types/istanbul-reports": "^3.0.4",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.33",
-        "chalk": "^4.1.2"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/js-cookie": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -86,8 +86,6 @@
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
-      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.27.1",
@@ -100,8 +98,6 @@
     },
     "node_modules/@babel/compat-data": {
       "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.5.tgz",
-      "integrity": "sha512-6uFXyCayocRbqhZOB+6XcuZbkMNimwfVGFji8CTZnCzOHVGvDqzvitu1re2AU5LROliz7eQPhB8CpAMvnx9EjA==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -109,8 +105,6 @@
     },
     "node_modules/@babel/core": {
       "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
-      "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
@@ -139,8 +133,6 @@
     },
     "node_modules/@babel/core/node_modules/semver": {
       "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -148,8 +140,6 @@
     },
     "node_modules/@babel/generator": {
       "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.5.tgz",
-      "integrity": "sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.28.5",
@@ -164,8 +154,6 @@
     },
     "node_modules/@babel/helper-compilation-targets": {
       "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
-      "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.27.2",
@@ -180,8 +168,6 @@
     },
     "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
       "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -189,8 +175,6 @@
     },
     "node_modules/@babel/helper-globals": {
       "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -198,8 +182,6 @@
     },
     "node_modules/@babel/helper-module-imports": {
       "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
-      "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
       "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.27.1",
@@ -211,8 +193,6 @@
     },
     "node_modules/@babel/helper-module-transforms": {
       "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
-      "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.27.1",
@@ -227,9 +207,9 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
-      "integrity": "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -237,8 +217,6 @@
     },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -246,8 +224,6 @@
     },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -255,8 +231,6 @@
     },
     "node_modules/@babel/helper-validator-option": {
       "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -264,8 +238,6 @@
     },
     "node_modules/@babel/helpers": {
       "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.4.tgz",
-      "integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.27.2",
@@ -277,8 +249,6 @@
     },
     "node_modules/@babel/parser": {
       "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
-      "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.28.5"
@@ -292,8 +262,6 @@
     },
     "node_modules/@babel/plugin-syntax-async-generators": {
       "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
-      "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -304,8 +272,6 @@
     },
     "node_modules/@babel/plugin-syntax-bigint": {
       "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
-      "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -316,8 +282,6 @@
     },
     "node_modules/@babel/plugin-syntax-class-properties": {
       "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
-      "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.12.13"
@@ -328,8 +292,6 @@
     },
     "node_modules/@babel/plugin-syntax-class-static-block": {
       "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
-      "integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
@@ -343,8 +305,6 @@
     },
     "node_modules/@babel/plugin-syntax-import-attributes": {
       "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.27.1.tgz",
-      "integrity": "sha512-oFT0FrKHgF53f4vOsZGi2Hh3I35PfSmVs4IBFLFj4dnafP+hIWDLg3VyKmUHfLoLHlyxY4C7DGtmHuJgn+IGww==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -358,8 +318,6 @@
     },
     "node_modules/@babel/plugin-syntax-import-meta": {
       "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
-      "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
@@ -370,8 +328,6 @@
     },
     "node_modules/@babel/plugin-syntax-json-strings": {
       "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
-      "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -381,12 +337,12 @@
       }
     },
     "node_modules/@babel/plugin-syntax-jsx": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.27.1.tgz",
-      "integrity": "sha512-y8YTNIeKoyhGd9O0Jiyzyyqk8gdjnumGTQPsz0xOZOQ2RmkVJeZ1vmmfIvFEKqucBG6axJGBZDE/7iI5suUI/w==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.28.6.tgz",
+      "integrity": "sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -397,8 +353,6 @@
     },
     "node_modules/@babel/plugin-syntax-logical-assignment-operators": {
       "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
-      "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
@@ -409,8 +363,6 @@
     },
     "node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
       "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
-      "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -421,8 +373,6 @@
     },
     "node_modules/@babel/plugin-syntax-numeric-separator": {
       "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
-      "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
@@ -433,8 +383,6 @@
     },
     "node_modules/@babel/plugin-syntax-object-rest-spread": {
       "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
-      "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -445,8 +393,6 @@
     },
     "node_modules/@babel/plugin-syntax-optional-catch-binding": {
       "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
-      "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -457,8 +403,6 @@
     },
     "node_modules/@babel/plugin-syntax-optional-chaining": {
       "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
-      "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -469,8 +413,6 @@
     },
     "node_modules/@babel/plugin-syntax-private-property-in-object": {
       "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
-      "integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
@@ -484,8 +426,6 @@
     },
     "node_modules/@babel/plugin-syntax-top-level-await": {
       "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
-      "integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
@@ -498,12 +438,12 @@
       }
     },
     "node_modules/@babel/plugin-syntax-typescript": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.27.1.tgz",
-      "integrity": "sha512-xfYCBMxveHrRMnAWl1ZlPXOZjzkN82THFvLhQhFXFt81Z5HnN+EtUkZhv/zcKpmT3fzmWZB0ywiBrbC3vogbwQ==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.28.6.tgz",
+      "integrity": "sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -514,8 +454,6 @@
     },
     "node_modules/@babel/runtime": {
       "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
-      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -524,8 +462,6 @@
     },
     "node_modules/@babel/template": {
       "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
-      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
@@ -538,8 +474,6 @@
     },
     "node_modules/@babel/traverse": {
       "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.5.tgz",
-      "integrity": "sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
@@ -556,8 +490,6 @@
     },
     "node_modules/@babel/types": {
       "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
-      "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -585,8 +517,6 @@
     },
     "node_modules/@electron/get": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@electron/get/-/get-2.0.3.tgz",
-      "integrity": "sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -607,8 +537,6 @@
     },
     "node_modules/@electron/get/node_modules/semver": {
       "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -616,20 +544,20 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.8.1.tgz",
-      "integrity": "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.1.0",
+        "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
-      "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -637,9 +565,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
-      "integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -648,15 +576,13 @@
     },
     "node_modules/@epic-web/invariant": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
-      "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.2.tgz",
-      "integrity": "sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
       "cpu": [
         "ppc64"
       ],
@@ -671,9 +597,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.2.tgz",
-      "integrity": "sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
       "cpu": [
         "arm"
       ],
@@ -688,9 +614,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.2.tgz",
-      "integrity": "sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
       "cpu": [
         "arm64"
       ],
@@ -705,9 +631,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.2.tgz",
-      "integrity": "sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
       "cpu": [
         "x64"
       ],
@@ -722,9 +648,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.2.tgz",
-      "integrity": "sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
       "cpu": [
         "arm64"
       ],
@@ -739,9 +665,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.2.tgz",
-      "integrity": "sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
       "cpu": [
         "x64"
       ],
@@ -756,9 +682,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.2.tgz",
-      "integrity": "sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
       "cpu": [
         "arm64"
       ],
@@ -773,9 +699,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.2.tgz",
-      "integrity": "sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
       "cpu": [
         "x64"
       ],
@@ -790,9 +716,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.2.tgz",
-      "integrity": "sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
       "cpu": [
         "arm"
       ],
@@ -807,9 +733,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.2.tgz",
-      "integrity": "sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
       "cpu": [
         "arm64"
       ],
@@ -824,9 +750,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.2.tgz",
-      "integrity": "sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
       "cpu": [
         "ia32"
       ],
@@ -841,9 +767,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.2.tgz",
-      "integrity": "sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
       "cpu": [
         "loong64"
       ],
@@ -858,9 +784,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.2.tgz",
-      "integrity": "sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
       "cpu": [
         "mips64el"
       ],
@@ -875,9 +801,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.2.tgz",
-      "integrity": "sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
       "cpu": [
         "ppc64"
       ],
@@ -892,9 +818,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.2.tgz",
-      "integrity": "sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
       "cpu": [
         "riscv64"
       ],
@@ -909,9 +835,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.2.tgz",
-      "integrity": "sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
       "cpu": [
         "s390x"
       ],
@@ -926,9 +852,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.2.tgz",
-      "integrity": "sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
       "cpu": [
         "x64"
       ],
@@ -943,9 +869,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.2.tgz",
-      "integrity": "sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
       "cpu": [
         "arm64"
       ],
@@ -960,9 +886,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.2.tgz",
-      "integrity": "sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
       "cpu": [
         "x64"
       ],
@@ -977,9 +903,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.2.tgz",
-      "integrity": "sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
       "cpu": [
         "arm64"
       ],
@@ -994,9 +920,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.2.tgz",
-      "integrity": "sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
       "cpu": [
         "x64"
       ],
@@ -1011,9 +937,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.2.tgz",
-      "integrity": "sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
       "cpu": [
         "arm64"
       ],
@@ -1028,9 +954,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.2.tgz",
-      "integrity": "sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
       "cpu": [
         "x64"
       ],
@@ -1045,9 +971,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.2.tgz",
-      "integrity": "sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
       "cpu": [
         "arm64"
       ],
@@ -1062,9 +988,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.2.tgz",
-      "integrity": "sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
       "cpu": [
         "ia32"
       ],
@@ -1079,9 +1005,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.2.tgz",
-      "integrity": "sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
       "cpu": [
         "x64"
       ],
@@ -1095,221 +1021,19 @@
         "node": ">=18"
       }
     },
-    "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
-      "integrity": "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "eslint-visitor-keys": "^3.4.3"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
-      }
-    },
-    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/@eslint-community/regexpp": {
-      "version": "4.12.2",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
-      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
-      }
-    },
-    "node_modules/@eslint/config-array": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.1.tgz",
-      "integrity": "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@eslint/object-schema": "^2.1.7",
-        "debug": "^4.3.1",
-        "minimatch": "^3.1.2"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@eslint/config-helpers": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
-      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@eslint/core": "^0.17.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@eslint/core": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
-      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@types/json-schema": "^7.0.15"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@eslint/eslintrc": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.3.tgz",
-      "integrity": "sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "ajv": "^6.12.4",
-        "debug": "^4.3.2",
-        "espree": "^10.0.1",
-        "globals": "^14.0.0",
-        "ignore": "^5.2.0",
-        "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.1",
-        "minimatch": "^3.1.2",
-        "strip-json-comments": "^3.1.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
-      "license": "Python-2.0",
-      "peer": true
-    },
-    "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@eslint/js": {
-      "version": "9.39.2",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.2.tgz",
-      "integrity": "sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://eslint.org/donate"
-      }
-    },
-    "node_modules/@eslint/object-schema": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
-      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@eslint/plugin-kit": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
-      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@eslint/core": "^0.17.0",
-        "levn": "^0.4.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
     "node_modules/@fortawesome/fontawesome-common-types": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-7.1.0.tgz",
-      "integrity": "sha512-l/BQM7fYntsCI//du+6sEnHOP6a74UixFyOYUyz2DLMXKx+6DEhfR3F2NYGE45XH1JJuIamacb4IZs9S0ZOWLA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-7.2.0.tgz",
+      "integrity": "sha512-IpR0bER9FY25p+e7BmFH25MZKEwFHTfRAfhOyJubgiDnoJNsSvJ7nigLraHtp4VOG/cy8D7uiV0dLkHOne5Fhw==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/@fortawesome/fontawesome-free": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-7.1.0.tgz",
-      "integrity": "sha512-+WxNld5ZCJHvPQCr/GnzCTVREyStrAJjisUPtUxG5ngDA8TMlPnKp6dddlTpai4+1GNmltAeuk1hJEkBohwZYA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-7.2.0.tgz",
+      "integrity": "sha512-3DguDv/oUE+7vjMeTSOjCSG+KeawgVQOHrKRnvUuqYh1mfArrh7s+s8hXW3e4RerBA1+Wh+hBqf8sJNpqNrBWg==",
       "dev": true,
       "license": "(CC-BY-4.0 AND OFL-1.1 AND MIT)",
       "engines": {
@@ -1317,57 +1041,57 @@
       }
     },
     "node_modules/@fortawesome/fontawesome-svg-core": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-7.1.0.tgz",
-      "integrity": "sha512-fNxRUk1KhjSbnbuBxlWSnBLKLBNun52ZBTcs22H/xEEzM6Ap81ZFTQ4bZBxVQGQgVY0xugKGoRcCbaKjLQ3XZA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-7.2.0.tgz",
+      "integrity": "sha512-6639htZMjEkwskf3J+e6/iar+4cTNM9qhoWuRfj9F3eJD6r7iCzV1SWnQr2Mdv0QT0suuqU8BoJCZUyCtP9R4Q==",
       "license": "MIT",
       "dependencies": {
-        "@fortawesome/fontawesome-common-types": "7.1.0"
+        "@fortawesome/fontawesome-common-types": "7.2.0"
       },
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/@fortawesome/free-brands-svg-icons": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-7.1.0.tgz",
-      "integrity": "sha512-9byUd9bgNfthsZAjBl6GxOu1VPHgBuRUP9juI7ZoM98h8xNPTCTagfwUFyYscdZq4Hr7gD1azMfM9s5tIWKZZA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-7.2.0.tgz",
+      "integrity": "sha512-VNG8xqOip1JuJcC3zsVsKRQ60oXG9+oYNDCosjoU/H9pgYmLTEwWw8pE0jhPz/JWdHeUuK6+NQ3qsM4gIbdbYQ==",
       "license": "(CC-BY-4.0 AND MIT)",
       "dependencies": {
-        "@fortawesome/fontawesome-common-types": "7.1.0"
+        "@fortawesome/fontawesome-common-types": "7.2.0"
       },
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/@fortawesome/free-regular-svg-icons": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-7.1.0.tgz",
-      "integrity": "sha512-0e2fdEyB4AR+e6kU4yxwA/MonnYcw/CsMEP9lH82ORFi9svA6/RhDyhxIv5mlJaldmaHLLYVTb+3iEr+PDSZuQ==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-7.2.0.tgz",
+      "integrity": "sha512-iycmlN51EULlQ4D/UU9WZnHiN0CvjJ2TuuCrAh+1MVdzD+4ViKYH2deNAll4XAAYlZa8WAefHR5taSK8hYmSMw==",
       "license": "(CC-BY-4.0 AND MIT)",
       "dependencies": {
-        "@fortawesome/fontawesome-common-types": "7.1.0"
+        "@fortawesome/fontawesome-common-types": "7.2.0"
       },
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/@fortawesome/free-solid-svg-icons": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-7.1.0.tgz",
-      "integrity": "sha512-Udu3K7SzAo9N013qt7qmm22/wo2hADdheXtBfxFTecp+ogsc0caQNRKEb7pkvvagUGOpG9wJC1ViH6WXs8oXIA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-7.2.0.tgz",
+      "integrity": "sha512-YTVITFGN0/24PxzXrwqCgnyd7njDuzp5ZvaCx5nq/jg55kUYd94Nj8UTchBdBofi/L0nwRfjGOg0E41d2u9T1w==",
       "license": "(CC-BY-4.0 AND MIT)",
       "dependencies": {
-        "@fortawesome/fontawesome-common-types": "7.1.0"
+        "@fortawesome/fontawesome-common-types": "7.2.0"
       },
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/@fortawesome/react-fontawesome": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-3.1.1.tgz",
-      "integrity": "sha512-EDllr9hpodc21odmUywHS1alXNiCd4E8sp5GJ5s7wYINz8vSmMiNWpALTiuYODb865YyQ/NlyiN4mbXp7HCNqg==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-3.3.1.tgz",
+      "integrity": "sha512-wGnAPhfzivDwBWYmEG8MSrEXPruoiMMo48NnsRkj1NZkoaawgOijPNAiSHKMYEoCsqTBSgLTzL6EqTTWGaUR4w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1379,79 +1103,21 @@
       }
     },
     "node_modules/@gerrit0/mini-shiki": {
-      "version": "3.20.0",
-      "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.20.0.tgz",
-      "integrity": "sha512-Wa57i+bMpK6PGJZ1f2myxo3iO+K/kZikcyvH8NIqNNZhQUbDav7V9LQmWOXhf946mz5c1NZ19WMsGYiDKTryzQ==",
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.23.0.tgz",
+      "integrity": "sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@shikijs/engine-oniguruma": "^3.20.0",
-        "@shikijs/langs": "^3.20.0",
-        "@shikijs/themes": "^3.20.0",
-        "@shikijs/types": "^3.20.0",
+        "@shikijs/engine-oniguruma": "^3.23.0",
+        "@shikijs/langs": "^3.23.0",
+        "@shikijs/themes": "^3.23.0",
+        "@shikijs/types": "^3.23.0",
         "@shikijs/vscode-textmate": "^10.0.2"
-      }
-    },
-    "node_modules/@humanfs/core": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "engines": {
-        "node": ">=18.18.0"
-      }
-    },
-    "node_modules/@humanfs/node": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
-      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@humanfs/core": "^0.19.1",
-        "@humanwhocodes/retry": "^0.4.0"
-      },
-      "engines": {
-        "node": ">=18.18.0"
-      }
-    },
-    "node_modules/@humanwhocodes/module-importer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
-      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "engines": {
-        "node": ">=12.22"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/nzakas"
-      }
-    },
-    "node_modules/@humanwhocodes/retry": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
-      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "engines": {
-        "node": ">=18.18"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
-      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
       "license": "ISC",
       "dependencies": {
         "string-width": "^5.1.2",
@@ -1467,8 +1133,6 @@
     },
     "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
       "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -1479,8 +1143,6 @@
     },
     "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
       "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -1491,14 +1153,10 @@
     },
     "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
       "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "license": "MIT"
     },
     "node_modules/@isaacs/cliui/node_modules/string-width": {
       "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
       "license": "MIT",
       "dependencies": {
         "eastasianwidth": "^0.2.0",
@@ -1514,8 +1172,6 @@
     },
     "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
       "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
@@ -1529,8 +1185,6 @@
     },
     "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
       "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.1.0",
@@ -1546,8 +1200,6 @@
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
-      "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
       "license": "ISC",
       "dependencies": {
         "camelcase": "^5.3.1",
@@ -1562,8 +1214,6 @@
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/resolve-from": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -1571,63 +1221,141 @@
     },
     "node_modules/@istanbuljs/schema": {
       "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
-      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
       "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@jest/console": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/@jest/console/-/console-30.2.0.tgz",
-      "integrity": "sha512-+O1ifRjkvYIkBqASKWgLxrpEhQAAE7hY77ALLUufSk5717KfOShg6IbqLmdsLMPdUiFvA2kTs0R7YZy+l0IzZQ==",
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-30.3.0.tgz",
+      "integrity": "sha512-PAwCvFJ4696XP2qZj+LAn1BWjZaJ6RjG6c7/lkMaUJnkyMS34ucuIsfqYvfskVNvUI27R/u4P1HMYFnlVXG/Ww==",
       "license": "MIT",
       "dependencies": {
-        "@jest/types": "30.2.0",
+        "@jest/types": "30.3.0",
         "@types/node": "*",
         "chalk": "^4.1.2",
-        "jest-message-util": "30.2.0",
-        "jest-util": "30.2.0",
+        "jest-message-util": "30.3.0",
+        "jest-util": "30.3.0",
         "slash": "^3.0.0"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
-    "node_modules/@jest/core": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/@jest/core/-/core-30.2.0.tgz",
-      "integrity": "sha512-03W6IhuhjqTlpzh/ojut/pDB2LPRygyWX8ExpgHtQA8H/3K7+1vKmcINx5UzeOX1se6YEsBsOHQ1CRzf3fOwTQ==",
+    "node_modules/@jest/console/node_modules/@jest/types": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
+      "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
       "license": "MIT",
       "dependencies": {
-        "@jest/console": "30.2.0",
         "@jest/pattern": "30.0.1",
-        "@jest/reporters": "30.2.0",
-        "@jest/test-result": "30.2.0",
-        "@jest/transform": "30.2.0",
-        "@jest/types": "30.2.0",
+        "@jest/schemas": "30.0.5",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/console/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@jest/console/node_modules/jest-message-util": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.3.0.tgz",
+      "integrity": "sha512-Z/j4Bo+4ySJ+JPJN3b2Qbl9hDq3VrXmnjjGEWD/x0BCXeOXPTV1iZYYzl2X8c1MaCOL+ewMyNBcm88sboE6YWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@jest/types": "30.3.0",
+        "@types/stack-utils": "^2.0.3",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3",
+        "pretty-format": "30.3.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.6"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/console/node_modules/jest-util": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
+      "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/console/node_modules/pretty-format": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz",
+      "integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.0.5",
+        "ansi-styles": "^5.2.0",
+        "react-is": "^18.3.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/core": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-30.3.0.tgz",
+      "integrity": "sha512-U5mVPsBxLSO6xYbf+tgkymLx+iAhvZX43/xI1+ej2ZOPnPdkdO1CzDmFKh2mZBn2s4XZixszHeQnzp1gm/DIxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "30.3.0",
+        "@jest/pattern": "30.0.1",
+        "@jest/reporters": "30.3.0",
+        "@jest/test-result": "30.3.0",
+        "@jest/transform": "30.3.0",
+        "@jest/types": "30.3.0",
         "@types/node": "*",
         "ansi-escapes": "^4.3.2",
         "chalk": "^4.1.2",
         "ci-info": "^4.2.0",
         "exit-x": "^0.2.2",
         "graceful-fs": "^4.2.11",
-        "jest-changed-files": "30.2.0",
-        "jest-config": "30.2.0",
-        "jest-haste-map": "30.2.0",
-        "jest-message-util": "30.2.0",
+        "jest-changed-files": "30.3.0",
+        "jest-config": "30.3.0",
+        "jest-haste-map": "30.3.0",
+        "jest-message-util": "30.3.0",
         "jest-regex-util": "30.0.1",
-        "jest-resolve": "30.2.0",
-        "jest-resolve-dependencies": "30.2.0",
-        "jest-runner": "30.2.0",
-        "jest-runtime": "30.2.0",
-        "jest-snapshot": "30.2.0",
-        "jest-util": "30.2.0",
-        "jest-validate": "30.2.0",
-        "jest-watcher": "30.2.0",
-        "micromatch": "^4.0.8",
-        "pretty-format": "30.2.0",
+        "jest-resolve": "30.3.0",
+        "jest-resolve-dependencies": "30.3.0",
+        "jest-runner": "30.3.0",
+        "jest-runtime": "30.3.0",
+        "jest-snapshot": "30.3.0",
+        "jest-util": "30.3.0",
+        "jest-validate": "30.3.0",
+        "jest-watcher": "30.3.0",
+        "pretty-format": "30.3.0",
         "slash": "^3.0.0"
       },
       "engines": {
@@ -1642,47 +1370,113 @@
         }
       }
     },
-    "node_modules/@jest/diff-sequences": {
-      "version": "30.0.1",
-      "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.0.1.tgz",
-      "integrity": "sha512-n5H8QLDJ47QqbCNn5SuFjCRDrOLEZ0h8vAHCK5RL9Ls7Xa8AQLa/YxAc9UjFqoEDM48muwtBGjtMY5cr0PLDCw==",
-      "license": "MIT",
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/environment": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.2.0.tgz",
-      "integrity": "sha512-/QPTL7OBJQ5ac09UDRa3EQes4gt1FTEG/8jZ/4v5IVzx+Cv7dLxlVIvfvSVRiiX2drWyXeBjkMSR8hvOWSog5g==",
+    "node_modules/@jest/core/node_modules/@jest/types": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
+      "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
       "license": "MIT",
       "dependencies": {
-        "@jest/fake-timers": "30.2.0",
-        "@jest/types": "30.2.0",
+        "@jest/pattern": "30.0.1",
+        "@jest/schemas": "30.0.5",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
         "@types/node": "*",
-        "jest-mock": "30.2.0"
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
-    "node_modules/@jest/expect": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.2.0.tgz",
-      "integrity": "sha512-V9yxQK5erfzx99Sf+7LbhBwNWEZ9eZay8qQ9+JSC0TrMR1pMDHLMY+BnVPacWU6Jamrh252/IKo4F1Xn/zfiqA==",
+    "node_modules/@jest/core/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@jest/core/node_modules/jest-message-util": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.3.0.tgz",
+      "integrity": "sha512-Z/j4Bo+4ySJ+JPJN3b2Qbl9hDq3VrXmnjjGEWD/x0BCXeOXPTV1iZYYzl2X8c1MaCOL+ewMyNBcm88sboE6YWw==",
       "license": "MIT",
       "dependencies": {
-        "expect": "30.2.0",
-        "jest-snapshot": "30.2.0"
+        "@babel/code-frame": "^7.27.1",
+        "@jest/types": "30.3.0",
+        "@types/stack-utils": "^2.0.3",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3",
+        "pretty-format": "30.3.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.6"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/core/node_modules/jest-util": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
+      "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/core/node_modules/pretty-format": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz",
+      "integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.0.5",
+        "ansi-styles": "^5.2.0",
+        "react-is": "^18.3.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/diff-sequences": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.3.0.tgz",
+      "integrity": "sha512-cG51MVnLq1ecVUaQ3fr6YuuAOitHK1S4WUJHnsPFE/quQr33ADUx1FfrTCpMCRxvy0Yr9BThKpDjSlcTi91tMA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/expect": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.3.0.tgz",
+      "integrity": "sha512-76Nlh4xJxk2D/9URCn3wFi98d2hb19uWE1idLsTt2ywhvdOldbw3S570hBgn25P4ICUZ/cBjybrBex2g17IDbg==",
+      "license": "MIT",
+      "dependencies": {
+        "expect": "30.3.0",
+        "jest-snapshot": "30.3.0"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/expect-utils": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.2.0.tgz",
-      "integrity": "sha512-1JnRfhqpD8HGpOmQp180Fo9Zt69zNtC+9lR+kT7NVL05tNXIi+QC8Csz7lfidMoVLPD3FnOtcmp0CEFnxExGEA==",
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.3.0.tgz",
+      "integrity": "sha512-j0+W5iQQ8hBh7tHZkTQv3q2Fh/M7Je72cIsYqC4OaktgtO7v1So9UTjp6uPBHIaB6beoF/RRsCgMJKvti0wADA==",
       "license": "MIT",
       "dependencies": {
         "@jest/get-type": "30.1.0"
@@ -1691,42 +1485,159 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
-    "node_modules/@jest/fake-timers": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.2.0.tgz",
-      "integrity": "sha512-HI3tRLjRxAbBy0VO8dqqm7Hb2mIa8d5bg/NJkyQcOk7V118ObQML8RC5luTF/Zsg4474a+gDvhce7eTnP4GhYw==",
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "30.2.0",
-        "@sinonjs/fake-timers": "^13.0.0",
-        "@types/node": "*",
-        "jest-message-util": "30.2.0",
-        "jest-mock": "30.2.0",
-        "jest-util": "30.2.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
     "node_modules/@jest/get-type": {
       "version": "30.1.0",
-      "resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.1.0.tgz",
-      "integrity": "sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==",
       "license": "MIT",
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/globals": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.2.0.tgz",
-      "integrity": "sha512-b63wmnKPaK+6ZZfpYhz9K61oybvbI1aMcIs80++JI1O1rR1vaxHUCNqo3ITu6NU0d4V34yZFoHMn/uoKr/Rwfw==",
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.3.0.tgz",
+      "integrity": "sha512-+owLCBBdfpgL3HU+BD5etr1SvbXpSitJK0is1kiYjJxAAJggYMRQz5hSdd5pq1sSggfxPbw2ld71pt4x5wwViA==",
       "license": "MIT",
       "dependencies": {
-        "@jest/environment": "30.2.0",
-        "@jest/expect": "30.2.0",
-        "@jest/types": "30.2.0",
-        "jest-mock": "30.2.0"
+        "@jest/environment": "30.3.0",
+        "@jest/expect": "30.3.0",
+        "@jest/types": "30.3.0",
+        "jest-mock": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/globals/node_modules/@jest/environment": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.3.0.tgz",
+      "integrity": "sha512-SlLSF4Be735yQXyh2+mctBOzNDx5s5uLv88/j8Qn1wH679PDcwy67+YdADn8NJnGjzlXtN62asGH/T4vWOkfaw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/fake-timers": "30.3.0",
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "jest-mock": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/globals/node_modules/@jest/fake-timers": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.3.0.tgz",
+      "integrity": "sha512-WUQDs8SOP9URStX1DzhD425CqbN/HxUYCTwVrT8sTVBfMvFqYt/s61EK5T05qnHu0po6RitXIvP9otZxYDzTGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@sinonjs/fake-timers": "^15.0.0",
+        "@types/node": "*",
+        "jest-message-util": "30.3.0",
+        "jest-mock": "30.3.0",
+        "jest-util": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/globals/node_modules/@jest/types": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
+      "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/pattern": "30.0.1",
+        "@jest/schemas": "30.0.5",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/globals/node_modules/@sinonjs/fake-timers": {
+      "version": "15.3.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.3.2.tgz",
+      "integrity": "sha512-mrn35Jl2pCpns+mE3HaZa1yPN5EYCRgiMI+135COjr2hr8Cls9DXqIZ57vZe2cz7y2XVSq92tcs6kGQcT1J8Rw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1"
+      }
+    },
+    "node_modules/@jest/globals/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@jest/globals/node_modules/jest-message-util": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.3.0.tgz",
+      "integrity": "sha512-Z/j4Bo+4ySJ+JPJN3b2Qbl9hDq3VrXmnjjGEWD/x0BCXeOXPTV1iZYYzl2X8c1MaCOL+ewMyNBcm88sboE6YWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@jest/types": "30.3.0",
+        "@types/stack-utils": "^2.0.3",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3",
+        "pretty-format": "30.3.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.6"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/globals/node_modules/jest-mock": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.3.0.tgz",
+      "integrity": "sha512-OTzICK8CpE+t4ndhKrwlIdbM6Pn8j00lvmSmq5ejiO+KxukbLjgOflKWMn3KE34EZdQm5RqTuKj+5RIEniYhog==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "jest-util": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/globals/node_modules/jest-util": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
+      "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/globals/node_modules/pretty-format": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz",
+      "integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.0.5",
+        "ansi-styles": "^5.2.0",
+        "react-is": "^18.3.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -1734,8 +1645,6 @@
     },
     "node_modules/@jest/pattern": {
       "version": "30.0.1",
-      "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.0.1.tgz",
-      "integrity": "sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -1746,31 +1655,31 @@
       }
     },
     "node_modules/@jest/reporters": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-30.2.0.tgz",
-      "integrity": "sha512-DRyW6baWPqKMa9CzeiBjHwjd8XeAyco2Vt8XbcLFjiwCOEKOvy82GJ8QQnJE9ofsxCMPjH4MfH8fCWIHHDKpAQ==",
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-30.3.0.tgz",
+      "integrity": "sha512-a09z89S+PkQnL055bVj8+pe2Caed2PBOaczHcXCykW5ngxX9EWx/1uAwncxc/HiU0oZqfwseMjyhxgRjS49qPw==",
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^0.2.3",
-        "@jest/console": "30.2.0",
-        "@jest/test-result": "30.2.0",
-        "@jest/transform": "30.2.0",
-        "@jest/types": "30.2.0",
+        "@jest/console": "30.3.0",
+        "@jest/test-result": "30.3.0",
+        "@jest/transform": "30.3.0",
+        "@jest/types": "30.3.0",
         "@jridgewell/trace-mapping": "^0.3.25",
         "@types/node": "*",
         "chalk": "^4.1.2",
         "collect-v8-coverage": "^1.0.2",
         "exit-x": "^0.2.2",
-        "glob": "^10.3.10",
+        "glob": "^10.5.0",
         "graceful-fs": "^4.2.11",
         "istanbul-lib-coverage": "^3.0.0",
         "istanbul-lib-instrument": "^6.0.0",
         "istanbul-lib-report": "^3.0.0",
         "istanbul-lib-source-maps": "^5.0.0",
         "istanbul-reports": "^3.1.3",
-        "jest-message-util": "30.2.0",
-        "jest-util": "30.2.0",
-        "jest-worker": "30.2.0",
+        "jest-message-util": "30.3.0",
+        "jest-util": "30.3.0",
+        "jest-worker": "30.3.0",
         "slash": "^3.0.0",
         "string-length": "^4.0.2",
         "v8-to-istanbul": "^9.0.1"
@@ -1787,10 +1696,40 @@
         }
       }
     },
+    "node_modules/@jest/reporters/node_modules/@jest/types": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
+      "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/pattern": "30.0.1",
+        "@jest/schemas": "30.0.5",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/@jest/reporters/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -1800,6 +1739,7 @@
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
       "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
@@ -1814,6 +1754,43 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/jest-message-util": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.3.0.tgz",
+      "integrity": "sha512-Z/j4Bo+4ySJ+JPJN3b2Qbl9hDq3VrXmnjjGEWD/x0BCXeOXPTV1iZYYzl2X8c1MaCOL+ewMyNBcm88sboE6YWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@jest/types": "30.3.0",
+        "@types/stack-utils": "^2.0.3",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3",
+        "pretty-format": "30.3.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.6"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/jest-util": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
+      "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/reporters/node_modules/minimatch": {
@@ -1831,10 +1808,22 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/@jest/reporters/node_modules/pretty-format": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz",
+      "integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.0.5",
+        "ansi-styles": "^5.2.0",
+        "react-is": "^18.3.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
     "node_modules/@jest/schemas": {
       "version": "30.0.5",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
-      "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
       "license": "MIT",
       "dependencies": {
         "@sinclair/typebox": "^0.34.0"
@@ -1844,15 +1833,33 @@
       }
     },
     "node_modules/@jest/snapshot-utils": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.2.0.tgz",
-      "integrity": "sha512-0aVxM3RH6DaiLcjj/b0KrIBZhSX1373Xci4l3cW5xiUWPctZ59zQ7jj4rqcJQ/Z8JuN/4wX3FpJSa3RssVvCug==",
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.3.0.tgz",
+      "integrity": "sha512-ORbRN9sf5PP82v3FXNSwmO1OTDR2vzR2YTaR+E3VkSBZ8zadQE6IqYdYEeFH1NIkeB2HIGdF02dapb6K0Mj05g==",
       "license": "MIT",
       "dependencies": {
-        "@jest/types": "30.2.0",
+        "@jest/types": "30.3.0",
         "chalk": "^4.1.2",
         "graceful-fs": "^4.2.11",
         "natural-compare": "^1.4.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/snapshot-utils/node_modules/@jest/types": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
+      "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/pattern": "30.0.1",
+        "@jest/schemas": "30.0.5",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -1873,13 +1880,13 @@
       }
     },
     "node_modules/@jest/test-result": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-30.2.0.tgz",
-      "integrity": "sha512-RF+Z+0CCHkARz5HT9mcQCBulb1wgCP3FBvl9VFokMX27acKphwyQsNuWH3c+ojd1LeWBLoTYoxF0zm6S/66mjg==",
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-30.3.0.tgz",
+      "integrity": "sha512-e/52nJGuD74AKTSe0P4y5wFRlaXP0qmrS17rqOMHeSwm278VyNyXE3gFO/4DTGF9w+65ra3lo3VKj0LBrzmgdQ==",
       "license": "MIT",
       "dependencies": {
-        "@jest/console": "30.2.0",
-        "@jest/types": "30.2.0",
+        "@jest/console": "30.3.0",
+        "@jest/types": "30.3.0",
         "@types/istanbul-lib-coverage": "^2.0.6",
         "collect-v8-coverage": "^1.0.2"
       },
@@ -1887,51 +1894,10 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
-    "node_modules/@jest/test-sequencer": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-30.2.0.tgz",
-      "integrity": "sha512-wXKgU/lk8fKXMu/l5Hog1R61bL4q5GCdT6OJvdAFz1P+QrpoFuLU68eoKuVc4RbrTtNnTL5FByhWdLgOPSph+Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@jest/test-result": "30.2.0",
-        "graceful-fs": "^4.2.11",
-        "jest-haste-map": "30.2.0",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/transform": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.2.0.tgz",
-      "integrity": "sha512-XsauDV82o5qXbhalKxD7p4TZYYdwcaEXC77PPD2HixEFF+6YGppjrAAQurTl2ECWcEomHBMMNS9AH3kcCFx8jA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.27.4",
-        "@jest/types": "30.2.0",
-        "@jridgewell/trace-mapping": "^0.3.25",
-        "babel-plugin-istanbul": "^7.0.1",
-        "chalk": "^4.1.2",
-        "convert-source-map": "^2.0.0",
-        "fast-json-stable-stringify": "^2.1.0",
-        "graceful-fs": "^4.2.11",
-        "jest-haste-map": "30.2.0",
-        "jest-regex-util": "30.0.1",
-        "jest-util": "30.2.0",
-        "micromatch": "^4.0.8",
-        "pirates": "^4.0.7",
-        "slash": "^3.0.0",
-        "write-file-atomic": "^5.0.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/types": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.2.0.tgz",
-      "integrity": "sha512-H9xg1/sfVvyfU7o3zMfBEjQ1gcsdeTMgqHoYdN79tuLqfTtuu7WckRA1R5whDwOzxaZAeMKTYWqP+WCAi0CHsg==",
+    "node_modules/@jest/test-result/node_modules/@jest/types": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
+      "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
       "license": "MIT",
       "dependencies": {
         "@jest/pattern": "30.0.1",
@@ -1946,10 +1912,83 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
+    "node_modules/@jest/test-sequencer": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-30.3.0.tgz",
+      "integrity": "sha512-dgbWy9b8QDlQeRZcv7LNF+/jFiiYHTKho1xirauZ7kVwY7avjFF6uTT0RqlgudB5OuIPagFdVtfFMosjVbk1eA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "30.3.0",
+        "graceful-fs": "^4.2.11",
+        "jest-haste-map": "30.3.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/transform": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.3.0.tgz",
+      "integrity": "sha512-TLKY33fSLVd/lKB2YI1pH69ijyUblO/BQvCj566YvnwuzoTNr648iE0j22vRvVNk2HsPwByPxATg3MleS3gf5A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.27.4",
+        "@jest/types": "30.3.0",
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "babel-plugin-istanbul": "^7.0.1",
+        "chalk": "^4.1.2",
+        "convert-source-map": "^2.0.0",
+        "fast-json-stable-stringify": "^2.1.0",
+        "graceful-fs": "^4.2.11",
+        "jest-haste-map": "30.3.0",
+        "jest-regex-util": "30.0.1",
+        "jest-util": "30.3.0",
+        "pirates": "^4.0.7",
+        "slash": "^3.0.0",
+        "write-file-atomic": "^5.0.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/transform/node_modules/@jest/types": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
+      "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/pattern": "30.0.1",
+        "@jest/schemas": "30.0.5",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/transform/node_modules/jest-util": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
+      "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
-      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -1958,8 +1997,6 @@
     },
     "node_modules/@jridgewell/remapping": {
       "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
-      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -1968,8 +2005,6 @@
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
-      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -1977,8 +2012,6 @@
     },
     "node_modules/@jridgewell/source-map": {
       "version": "0.3.11",
-      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
-      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1988,14 +2021,10 @@
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
-      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
-      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -2016,8 +2045,6 @@
     },
     "node_modules/@parcel/watcher": {
       "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.1.tgz",
-      "integrity": "sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -2305,8 +2332,6 @@
     },
     "node_modules/@parcel/watcher-win32-x64": {
       "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.1.tgz",
-      "integrity": "sha512-9lHBdJITeNR++EvSQVUcaZoWupyHfXe1jZvGZ06O/5MflPcuPLtEphScIBL+AiCWBO46tDSHzWyD0uDmmZqsgA==",
       "cpu": [
         "x64"
       ],
@@ -2326,8 +2351,6 @@
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
-      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -2348,8 +2371,7 @@
     },
     "node_modules/@popperjs/core": {
       "version": "2.11.8",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
-      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -2358,8 +2380,6 @@
     },
     "node_modules/@react-aria/ssr": {
       "version": "3.9.10",
-      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.9.10.tgz",
-      "integrity": "sha512-hvTm77Pf+pMBhuBm760Li0BVIO38jv1IBws1xFm1NoL26PU+fe+FMW5+VZWyANR6nYL65joaJKZqOdTQMkO9IQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2374,8 +2394,6 @@
     },
     "node_modules/@restart/hooks": {
       "version": "0.4.16",
-      "resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.4.16.tgz",
-      "integrity": "sha512-f7aCv7c+nU/3mF7NWLtVVr0Ra80RqsO89hO72r+Y/nvQr5+q0UFGkocElTH6MJApvReVh6JHUFYn2cw1WdHF3w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2387,8 +2405,6 @@
     },
     "node_modules/@restart/ui": {
       "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@restart/ui/-/ui-1.9.4.tgz",
-      "integrity": "sha512-N4C7haUc3vn4LTwVUPlkJN8Ach/+yIMvRuTVIhjilNHqegY60SGLrzud6errOMNJwSnmYFnt1J0H/k8FE3A4KA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2409,8 +2425,6 @@
     },
     "node_modules/@restart/ui/node_modules/@restart/hooks": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.5.1.tgz",
-      "integrity": "sha512-EMoH04NHS1pbn07iLTjIjgttuqb7qu4+/EyhAx27MHpoENcB2ZdSsLTNxmKD+WEPnZigo62Qc8zjGnNxoSE/5Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2422,8 +2436,6 @@
     },
     "node_modules/@restart/ui/node_modules/uncontrollable": {
       "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/uncontrollable/-/uncontrollable-8.0.4.tgz",
-      "integrity": "sha512-ulRWYWHvscPFc0QQXvyJjY6LIXU56f0h8pQFvhxiKk5V1fcI8gp9Ht9leVAhrVjzqMw0BgjspBINx9r6oyJUvQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -2432,46 +2444,44 @@
     },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
-      "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@shikijs/engine-oniguruma": {
-      "version": "3.20.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.20.0.tgz",
-      "integrity": "sha512-Yx3gy7xLzM0ZOjqoxciHjA7dAt5tyzJE3L4uQoM83agahy+PlW244XJSrmJRSBvGYELDhYXPacD4R/cauV5bzQ==",
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.23.0.tgz",
+      "integrity": "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.20.0",
+        "@shikijs/types": "3.23.0",
         "@shikijs/vscode-textmate": "^10.0.2"
       }
     },
     "node_modules/@shikijs/langs": {
-      "version": "3.20.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.20.0.tgz",
-      "integrity": "sha512-le+bssCxcSHrygCWuOrYJHvjus6zhQ2K7q/0mgjiffRbkhM4o1EWu2m+29l0yEsHDbWaWPNnDUTRVVBvBBeKaA==",
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.23.0.tgz",
+      "integrity": "sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.20.0"
+        "@shikijs/types": "3.23.0"
       }
     },
     "node_modules/@shikijs/themes": {
-      "version": "3.20.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.20.0.tgz",
-      "integrity": "sha512-U1NSU7Sl26Q7ErRvJUouArxfM2euWqq1xaSrbqMu2iqa+tSp0D1Yah8216sDYbdDHw4C8b75UpE65eWorm2erQ==",
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.23.0.tgz",
+      "integrity": "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.20.0"
+        "@shikijs/types": "3.23.0"
       }
     },
     "node_modules/@shikijs/types": {
-      "version": "3.20.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.20.0.tgz",
-      "integrity": "sha512-lhYAATn10nkZcBQ0BlzSbJA3wcmL5MXUUF8d2Zzon6saZDlToKaiRX60n2+ZaHJCmXEcZRWNzn+k9vplr8Jhsw==",
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.23.0.tgz",
+      "integrity": "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2488,14 +2498,10 @@
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.34.46",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.46.tgz",
-      "integrity": "sha512-kiW7CtS/NkdvTUjkjUJo7d5JsFfbJ14YjdhDk9KoEgK6nFjKNXZPrX0jfLA8ZlET4cFLHxOZ/0vFKOP+bOxIOQ==",
       "license": "MIT"
     },
     "node_modules/@sindresorhus/is": {
       "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
-      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2507,26 +2513,13 @@
     },
     "node_modules/@sinonjs/commons": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
-      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "type-detect": "4.0.8"
       }
     },
-    "node_modules/@sinonjs/fake-timers": {
-      "version": "13.0.5",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-13.0.5.tgz",
-      "integrity": "sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@sinonjs/commons": "^3.0.1"
-      }
-    },
     "node_modules/@swc/helpers": {
       "version": "0.5.18",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
-      "integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2535,8 +2528,6 @@
     },
     "node_modules/@szmarczak/http-timer": {
       "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
-      "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2599,15 +2590,11 @@
     },
     "node_modules/@types/blueimp-md5": {
       "version": "2.18.2",
-      "resolved": "https://registry.npmjs.org/@types/blueimp-md5/-/blueimp-md5-2.18.2.tgz",
-      "integrity": "sha512-dJ9yRry9Olt5GAWlgCtE5dK9d/Dfhn/V7hna86eEO2Pn76+E8Y0S0n61iEUEGhWXXgtKtHxtZLVNwL8X+vLHzg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/bootstrap": {
       "version": "5.2.10",
-      "resolved": "https://registry.npmjs.org/@types/bootstrap/-/bootstrap-5.2.10.tgz",
-      "integrity": "sha512-F2X+cd6551tep0MvVZ6nM8v7XgGN/twpdNDjqS1TUM7YFNEtQYWk+dKAnH+T1gr6QgCoGMPl487xw/9hXooa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2616,8 +2603,6 @@
     },
     "node_modules/@types/cacheable-request": {
       "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
-      "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2629,15 +2614,11 @@
     },
     "node_modules/@types/escodegen": {
       "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/@types/escodegen/-/escodegen-0.0.10.tgz",
-      "integrity": "sha512-IVvcNLEFbiL17qiGRGzyfx/u9K6lA5w6wcQSIgv2h4JG3ZAFIY1Be9ITTSPuARIxRpzW54s8OvcF6PdonBbDzg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/eslint": {
       "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
-      "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2647,8 +2628,6 @@
     },
     "node_modules/@types/eslint-scope": {
       "version": "3.7.7",
-      "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
-      "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2658,8 +2637,6 @@
     },
     "node_modules/@types/esprima": {
       "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@types/esprima/-/esprima-4.0.6.tgz",
-      "integrity": "sha512-lIk+kSt9lGv5hxK6aZNjiUEGZqKmOTpmg0tKiJQI+Ow98fLillxsiZNik5+RcP7mXL929KiTH/D9jGtpDlMbVw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2668,8 +2645,6 @@
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
       "license": "MIT"
     },
@@ -2685,28 +2660,20 @@
     },
     "node_modules/@types/html-minifier-terser": {
       "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
-      "integrity": "sha512-oh/6byDPnL1zeNXFrDXFLyZjkr1MsBG667IM792caf1L2UPOOMf65NFzjUH/ltyfwjAGfs1rsX1eftK0jC/KIg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/http-cache-semantics": {
       "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
-      "integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
-      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
       "license": "MIT"
     },
     "node_modules/@types/istanbul-lib-report": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
-      "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
       "license": "MIT",
       "dependencies": {
         "@types/istanbul-lib-coverage": "*"
@@ -2714,8 +2681,6 @@
     },
     "node_modules/@types/istanbul-reports": {
       "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
-      "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
       "license": "MIT",
       "dependencies": {
         "@types/istanbul-lib-report": "*"
@@ -2723,8 +2688,6 @@
     },
     "node_modules/@types/jest": {
       "version": "30.0.0",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-30.0.0.tgz",
-      "integrity": "sha512-XTYugzhuwqWjws0CVz8QpM36+T+Dz5mTEBKhNs/esGLnCIlGdRy+Dq78NRjd7ls7r8BC8ZRMOrKlkO1hU0JOwA==",
       "license": "MIT",
       "dependencies": {
         "expect": "^30.0.0",
@@ -2733,29 +2696,21 @@
     },
     "node_modules/@types/js-cookie": {
       "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-2.2.7.tgz",
-      "integrity": "sha512-aLkWa0C0vO5b4Sr798E26QgOkss68Un0bLjs7u9qxzPT5CG+8DuNTffWES58YzJs3hrVAOs1wonycqEBqNJubA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
-      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
-      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
-      "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/keyv": {
       "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
-      "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2779,22 +2734,18 @@
     },
     "node_modules/@types/offscreencanvas": {
       "version": "2019.7.3",
-      "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.3.tgz",
-      "integrity": "sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
-      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
-      "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2803,8 +2754,6 @@
     },
     "node_modules/@types/react-dom": {
       "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
-      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -2813,8 +2762,6 @@
     },
     "node_modules/@types/react-transition-group": {
       "version": "4.4.12",
-      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.12.tgz",
-      "integrity": "sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -2823,8 +2770,6 @@
     },
     "node_modules/@types/responselike": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
-      "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2833,15 +2778,11 @@
     },
     "node_modules/@types/signals": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@types/signals/-/signals-1.0.4.tgz",
-      "integrity": "sha512-6Nfcw0msIx3Srr0bz7u6v+y3mj7uy5Lh6fEbkPazaMr4qz+CtyKjfb7SX+8pq7a2TV710k0pm0Qxj5ClTB4YCA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
-      "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "license": "MIT"
     },
     "node_modules/@types/three": {
@@ -2863,29 +2804,21 @@
     },
     "node_modules/@types/warning": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/warning/-/warning-3.0.3.tgz",
-      "integrity": "sha512-D1XC7WK8K+zZEveUPY+cf4+kgauk8N4eHr/XIHXGlGYkHLud6hK9lYfZk1ry1TNh798cZUCgb6MqGEG8DkJt6Q==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/webxr": {
       "version": "0.5.24",
-      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
-      "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/wicg-file-system-access": {
       "version": "2023.10.7",
-      "resolved": "https://registry.npmjs.org/@types/wicg-file-system-access/-/wicg-file-system-access-2023.10.7.tgz",
-      "integrity": "sha512-g49ijasEJvCd7ifmAY2D0wdEtt1xRjBbA33PJTiv8mKBr7DoMsPeISoJ8oQOTopSRi+FBWPpPW5ouDj2QPKtGA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/yargs": {
       "version": "17.0.35",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
-      "integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
       "license": "MIT",
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -2893,14 +2826,10 @@
     },
     "node_modules/@types/yargs-parser": {
       "version": "21.0.3",
-      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
-      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
       "license": "MIT"
     },
     "node_modules/@types/yauzl": {
       "version": "2.10.3",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
-      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -2910,8 +2839,6 @@
     },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
-      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "license": "ISC"
     },
     "node_modules/@unrs/resolver-binding-android-arm-eabi": {
@@ -3153,8 +3080,6 @@
     },
     "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
       "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz",
-      "integrity": "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==",
       "cpu": [
         "x64"
       ],
@@ -3166,8 +3091,6 @@
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
-      "integrity": "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3177,29 +3100,21 @@
     },
     "node_modules/@webassemblyjs/floating-point-hex-parser": {
       "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
-      "integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-api-error": {
       "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
-      "integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-buffer": {
       "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
-      "integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-numbers": {
       "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.13.2.tgz",
-      "integrity": "sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3210,15 +3125,11 @@
     },
     "node_modules/@webassemblyjs/helper-wasm-bytecode": {
       "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
-      "integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-wasm-section": {
       "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.14.1.tgz",
-      "integrity": "sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3230,8 +3141,6 @@
     },
     "node_modules/@webassemblyjs/ieee754": {
       "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.13.2.tgz",
-      "integrity": "sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3240,8 +3149,6 @@
     },
     "node_modules/@webassemblyjs/leb128": {
       "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.13.2.tgz",
-      "integrity": "sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3250,15 +3157,11 @@
     },
     "node_modules/@webassemblyjs/utf8": {
       "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
-      "integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@webassemblyjs/wasm-edit": {
       "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.14.1.tgz",
-      "integrity": "sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3274,8 +3177,6 @@
     },
     "node_modules/@webassemblyjs/wasm-gen": {
       "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.14.1.tgz",
-      "integrity": "sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3288,8 +3189,6 @@
     },
     "node_modules/@webassemblyjs/wasm-opt": {
       "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.14.1.tgz",
-      "integrity": "sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3301,8 +3200,6 @@
     },
     "node_modules/@webassemblyjs/wasm-parser": {
       "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.14.1.tgz",
-      "integrity": "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3316,8 +3213,6 @@
     },
     "node_modules/@webassemblyjs/wast-printer": {
       "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.14.1.tgz",
-      "integrity": "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3374,22 +3269,16 @@
     },
     "node_modules/@xobotyi/scrollbar-width": {
       "version": "1.9.5",
-      "resolved": "https://registry.npmjs.org/@xobotyi/scrollbar-width/-/scrollbar-width-1.9.5.tgz",
-      "integrity": "sha512-N8tkAACJx2ww8vFMneJmaAgmjAG1tnVBZJRLRcx061tmsLRZHSEZSLuGWnwPtunsSLvSqXQ2wfp7Mgqg1I+2dQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
-      "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
       "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@xtuc/long": {
       "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
-      "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
       "dev": true,
       "license": "Apache-2.0"
     },
@@ -3402,9 +3291,6 @@
     },
     "node_modules/abstract-leveldown": {
       "version": "0.12.4",
-      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-0.12.4.tgz",
-      "integrity": "sha512-TOod9d5RDExo6STLMGa+04HGkl+TlMfbDnTyN93/ETJ9DpQ0DaYLqcMZlbXvdc4W3vVo1Qrl+WhSp8zvDsJ+jA==",
-      "deprecated": "Superseded by abstract-level (https://github.com/Level/community#faq)",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3413,17 +3299,15 @@
     },
     "node_modules/abstract-leveldown/node_modules/xtend": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
-      "integrity": "sha512-sp/sT9OALMjRW1fKDlPeuSZlDQpkqReA0pyJukniWbTGoEKefHxhGJynE3PNhUMlcM8qWIjPwecwCw4LArS5Eg==",
       "dev": true,
       "engines": {
         "node": ">=0.4"
       }
     },
     "node_modules/acorn": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -3435,8 +3319,6 @@
     },
     "node_modules/acorn-import-phases": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
-      "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3446,21 +3328,8 @@
         "acorn": "^8.14.0"
       }
     },
-    "node_modules/acorn-jsx": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
-      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
     "node_modules/adjust-sourcemap-loader": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/adjust-sourcemap-loader/-/adjust-sourcemap-loader-4.0.0.tgz",
-      "integrity": "sha512-OXwN5b9pCUXNQHJpwwD2qP40byEmSgzj8B4ydSN0uMNYWiFmJ6x6KwUllMmfk8Rwu/HJDFR7U8ubsWBoN0Xp0A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3490,8 +3359,6 @@
     },
     "node_modules/ajv-formats": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
-      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3508,8 +3375,6 @@
     },
     "node_modules/ajv-keywords": {
       "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
-      "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3546,8 +3411,6 @@
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3555,8 +3418,6 @@
     },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -3570,8 +3431,6 @@
     },
     "node_modules/ansis": {
       "version": "3.17.0",
-      "resolved": "https://registry.npmjs.org/ansis/-/ansis-3.17.0.tgz",
-      "integrity": "sha512-0qWUglt9JEqLFr3w1I1pbrChn1grhaiAR2ocX1PP/flRmxgtwTzPFFFnfIlD6aMOLQZgSuCRlidD70lvx8yhzg==",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -3580,8 +3439,6 @@
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
-      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
       "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
@@ -3592,9 +3449,7 @@
       }
     },
     "node_modules/anymatch/node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "version": "2.3.1",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -3624,10 +3479,15 @@
       ],
       "license": "MIT"
     },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/argparse": {
       "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "license": "MIT",
       "dependencies": {
         "sprintf-js": "~1.0.2"
@@ -3635,8 +3495,6 @@
     },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
-      "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3652,8 +3510,6 @@
     },
     "node_modules/array-includes": {
       "version": "3.1.9",
-      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.9.tgz",
-      "integrity": "sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3675,8 +3531,6 @@
     },
     "node_modules/array.prototype.findlastindex": {
       "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.6.tgz",
-      "integrity": "sha512-F/TKATkzseUExPlfvmwQKGITM3DGTK+vkAsCZoDc5daVygbJBnjEUCbgkAvVFsgfXfX4YIqZ/27G3k3tdXrTxQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3697,8 +3551,6 @@
     },
     "node_modules/array.prototype.flat": {
       "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz",
-      "integrity": "sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3716,8 +3568,6 @@
     },
     "node_modules/array.prototype.flatmap": {
       "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz",
-      "integrity": "sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3735,8 +3585,6 @@
     },
     "node_modules/arraybuffer.prototype.slice": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
-      "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3755,17 +3603,8 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/asn1.js/node_modules/bn.js": {
-      "version": "4.12.2",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
-      "integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
-      "extraneous": true,
-      "license": "MIT"
-    },
     "node_modules/async-function": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
-      "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3774,8 +3613,6 @@
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
-      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3789,15 +3626,15 @@
       }
     },
     "node_modules/babel-jest": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.2.0.tgz",
-      "integrity": "sha512-0YiBEOxWqKkSQWL9nNGGEgndoeL0ZpWrbLMNL5u/Kaxrli3Eaxlt3ZtIDktEvXt4L/R9r3ODr2zKwGM/2BjxVw==",
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.3.0.tgz",
+      "integrity": "sha512-gRpauEU2KRrCox5Z296aeVHR4jQ98BCnu0IO332D/xpHNOsIH/bgSRk9k6GbKIbBw8vFeN6ctuu6tV8WOyVfYQ==",
       "license": "MIT",
       "dependencies": {
-        "@jest/transform": "30.2.0",
+        "@jest/transform": "30.3.0",
         "@types/babel__core": "^7.20.5",
         "babel-plugin-istanbul": "^7.0.1",
-        "babel-preset-jest": "30.2.0",
+        "babel-preset-jest": "30.3.0",
         "chalk": "^4.1.2",
         "graceful-fs": "^4.2.11",
         "slash": "^3.0.0"
@@ -3811,8 +3648,6 @@
     },
     "node_modules/babel-plugin-istanbul": {
       "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-7.0.1.tgz",
-      "integrity": "sha512-D8Z6Qm8jCvVXtIRkBnqNHX0zJ37rQcFJ9u8WOS6tkYOsRdHBzypCstaxWiu5ZIlqQtviRYbgnRLSoCEvjqcqbA==",
       "license": "BSD-3-Clause",
       "workspaces": [
         "test/babel-8"
@@ -3829,9 +3664,9 @@
       }
     },
     "node_modules/babel-plugin-jest-hoist": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-30.2.0.tgz",
-      "integrity": "sha512-ftzhzSGMUnOzcCXd6WHdBGMyuwy15Wnn0iyyWGKgBDLxf9/s5ABuraCSpBX2uG0jUg4rqJnxsLc5+oYBqoxVaA==",
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-30.3.0.tgz",
+      "integrity": "sha512-+TRkByhsws6sfPjVaitzadk1I0F5sPvOVUH5tyTSzhePpsGIVrdeunHSw/C36QeocS95OOk8lunc4rlu5Anwsg==",
       "license": "MIT",
       "dependencies": {
         "@types/babel__core": "^7.20.5"
@@ -3842,8 +3677,6 @@
     },
     "node_modules/babel-preset-current-node-syntax": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.2.0.tgz",
-      "integrity": "sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==",
       "license": "MIT",
       "dependencies": {
         "@babel/plugin-syntax-async-generators": "^7.8.4",
@@ -3867,12 +3700,12 @@
       }
     },
     "node_modules/babel-preset-jest": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-30.2.0.tgz",
-      "integrity": "sha512-US4Z3NOieAQumwFnYdUWKvUKh8+YSnS/gB3t6YBiz0bskpu7Pine8pPCheNxlPEW4wnUkma2a94YuW2q3guvCQ==",
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-30.3.0.tgz",
+      "integrity": "sha512-6ZcUbWHC+dMz2vfzdNwi87Z1gQsLNK2uLuK1Q89R11xdvejcivlYYwDlEv0FHX3VwEXpbBQ9uufB/MUNpZGfhQ==",
       "license": "MIT",
       "dependencies": {
-        "babel-plugin-jest-hoist": "30.2.0",
+        "babel-plugin-jest-hoist": "30.3.0",
         "babel-preset-current-node-syntax": "^1.2.0"
       },
       "engines": {
@@ -3884,14 +3717,10 @@
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.9.11",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.11.tgz",
-      "integrity": "sha512-Sg0xJUNDU1sJNGdfGWhVHX0kkZ+HWcvmVymJbj6NSgZZmW/8S9Y2HQ5euytnIgakgxN6papOAWiwDo1ctFDcoQ==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
@@ -3899,8 +3728,6 @@
     },
     "node_modules/big.js": {
       "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
-      "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3909,8 +3736,6 @@
     },
     "node_modules/bl": {
       "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-0.8.2.tgz",
-      "integrity": "sha512-pfqikmByp+lifZCS0p6j6KreV6kNU6Apzpm2nKOk+94cZb/jvle55+JxWiByUQ0Wo/+XnDXEy5MxxKMb6r0VIw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3919,15 +3744,11 @@
     },
     "node_modules/bl/node_modules/isarray": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/bl/node_modules/readable-stream": {
       "version": "1.0.34",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-      "integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3939,31 +3760,22 @@
     },
     "node_modules/bl/node_modules/string_decoder": {
       "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/boolbase": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/boolean": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
-      "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
       "dev": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/bootstrap": {
       "version": "5.3.8",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.8.tgz",
-      "integrity": "sha512-HP1SZDqaLDPwsNiqRqi5NcP0SSXciX2s9E+RyqJIIqGo+vJeN5AJVM98CXmW/Wux0nQ5L7jeWUdplCEf0Ee+tg==",
       "funding": [
         {
           "type": "github",
@@ -4128,8 +3940,6 @@
     },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -4138,8 +3948,7 @@
     },
     "node_modules/braces": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
-      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -4150,8 +3959,6 @@
     },
     "node_modules/browserify-fs": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/browserify-fs/-/browserify-fs-1.0.0.tgz",
-      "integrity": "sha512-8LqHRPuAEKvyTX34R6tsw4bO2ro6j9DmlYBhiYWHRM26Zv2cBw1fJOU0NeUQ0RkXkPn/PFBjhA0dm4AgaBurTg==",
       "dev": true,
       "dependencies": {
         "level-filesystem": "^1.0.1",
@@ -4159,20 +3966,8 @@
         "levelup": "^0.18.2"
       }
     },
-    "node_modules/browserify/node_modules/xtend": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-      "extraneous": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4"
-      }
-    },
     "node_modules/browserslist": {
       "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
       "funding": [
         {
           "type": "opencollective",
@@ -4204,8 +3999,6 @@
     },
     "node_modules/bs-logger": {
       "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
-      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
       "license": "MIT",
       "dependencies": {
         "fast-json-stable-stringify": "2.x"
@@ -4216,8 +4009,6 @@
     },
     "node_modules/bser": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
-      "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "node-int64": "^0.4.0"
@@ -4225,8 +4016,6 @@
     },
     "node_modules/buffer-crc32": {
       "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4235,14 +4024,10 @@
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "license": "MIT"
     },
     "node_modules/bytes": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
-      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4251,8 +4036,6 @@
     },
     "node_modules/cacheable-lookup": {
       "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
-      "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4261,8 +4044,6 @@
     },
     "node_modules/cacheable-request": {
       "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
-      "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4280,8 +4061,6 @@
     },
     "node_modules/call-bind": {
       "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
-      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4299,8 +4078,6 @@
     },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4313,8 +4090,6 @@
     },
     "node_modules/call-bound": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
-      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4339,8 +4114,6 @@
     },
     "node_modules/camel-case": {
       "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
-      "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4350,8 +4123,6 @@
     },
     "node_modules/camelcase": {
       "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -4359,8 +4130,6 @@
     },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001762",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001762.tgz",
-      "integrity": "sha512-PxZwGNvH7Ak8WX5iXzoK1KPZttBXNPuaOvI2ZYU7NrlM+d9Ov+TUvlLOBNGzVXAntMSMMlJPd+jY6ovrVjSmUw==",
       "funding": [
         {
           "type": "opencollective",
@@ -4379,8 +4148,6 @@
     },
     "node_modules/chalk": {
       "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -4420,8 +4187,6 @@
     },
     "node_modules/chokidar": {
       "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4436,8 +4201,6 @@
     },
     "node_modules/chrome-trace-event": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
-      "integrity": "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4446,8 +4209,6 @@
     },
     "node_modules/ci-info": {
       "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.1.tgz",
-      "integrity": "sha512-Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA==",
       "funding": [
         {
           "type": "github",
@@ -4461,8 +4222,6 @@
     },
     "node_modules/circular-dependency-plugin": {
       "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/circular-dependency-plugin/-/circular-dependency-plugin-5.2.2.tgz",
-      "integrity": "sha512-g38K9Cm5WRwlaH6g03B9OEz/0qRizI+2I7n+Gz+L5DxXJAPAiWQvwlYNm1V1jkdpUv95bOe/ASm2vfi/G560jQ==",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -4480,15 +4239,11 @@
     },
     "node_modules/classnames": {
       "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
-      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/clean-css": {
       "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.3.tgz",
-      "integrity": "sha512-D5J+kHaVb/wKSFcyyV75uCn8fiY4sV38XJoe4CUyGQ+mOU/fMVYUdH1hJC+CJQ5uY3EnW27SbJYS4X8BiLrAFg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4529,10 +4284,37 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/clipboardy/node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/clipboardy/node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/cliui": {
       "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
       "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
@@ -4545,8 +4327,6 @@
     },
     "node_modules/clone": {
       "version": "0.1.19",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-0.1.19.tgz",
-      "integrity": "sha512-IO78I0y6JcSpEPHzK4obKdsL7E7oLdRVDVOLwr2Hkbjsb+Eoz0dxW6tef0WizoKu0gLC4oZSZuEF4U2K6w1WQw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4555,8 +4335,6 @@
     },
     "node_modules/clone-deep": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
-      "integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4570,8 +4348,6 @@
     },
     "node_modules/clone-response": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
-      "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4583,8 +4359,6 @@
     },
     "node_modules/clsx": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
-      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4609,8 +4383,6 @@
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -4621,21 +4393,15 @@
     },
     "node_modules/color-name": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
     "node_modules/colorette": {
       "version": "2.0.20",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
-      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/commander": {
       "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4644,8 +4410,6 @@
     },
     "node_modules/compressible": {
       "version": "2.0.18",
-      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
-      "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4657,8 +4421,6 @@
     },
     "node_modules/compression": {
       "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.1.tgz",
-      "integrity": "sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4676,8 +4438,6 @@
     },
     "node_modules/compression/node_modules/debug": {
       "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4686,15 +4446,19 @@
     },
     "node_modules/compression/node_modules/ms": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/compression/node_modules/negotiator": {
+      "version": "0.6.4",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/compression/node_modules/safe-buffer": {
       "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
       "dev": true,
       "funding": [
         {
@@ -4714,14 +4478,10 @@
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "license": "MIT"
     },
     "node_modules/concat-stream": {
       "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "dev": true,
       "engines": [
         "node >= 0.8"
@@ -4736,34 +4496,18 @@
     },
     "node_modules/consola": {
       "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
-      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^14.18.0 || >=16.10.0"
       }
     },
-    "node_modules/content-disposition": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
-      "integrity": "sha512-kRGRZw3bLlFISDBgwTSA1TMBFN6J6GWDeubmDE3AF+3+yXL8hTWv8r5rkLbqYXY4RjPk/EzHnClI3zQf1cFmHA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
-      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "license": "MIT"
     },
     "node_modules/copy-to-clipboard": {
       "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.3.tgz",
-      "integrity": "sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4796,15 +4540,11 @@
     },
     "node_modules/core-util-is": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/cross-env": {
       "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
-      "integrity": "sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4821,8 +4561,6 @@
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
-      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -4835,8 +4573,6 @@
     },
     "node_modules/css-in-js-utils": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-3.1.0.tgz",
-      "integrity": "sha512-fJAcud6B3rRu+KHYk+Bwf+WFL2MDCJJ1XG9x137tJQ0xYxor7XziQtuGFbWNdqrvF4Tk26O3H73nfVqXt/fW1A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4844,20 +4580,20 @@
       }
     },
     "node_modules/css-loader": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-7.1.2.tgz",
-      "integrity": "sha512-6WvYYn7l/XEGN8Xu2vWFt9nVzrCn39vKyTEFf/ExEyoksJjjSZV/0/35XPlMbpnr6VGhZIUg5yJrL8tGfes/FA==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-7.1.4.tgz",
+      "integrity": "sha512-vv3J9tlOl04WjiMvHQI/9tmIrCxVrj6PFbHemBB1iihpeRbi/I4h033eoFIhwxBBqLhI0KYFS7yvynBFhIZfTw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "icss-utils": "^5.1.0",
-        "postcss": "^8.4.33",
+        "postcss": "^8.4.40",
         "postcss-modules-extract-imports": "^3.1.0",
         "postcss-modules-local-by-default": "^4.0.5",
         "postcss-modules-scope": "^3.2.0",
         "postcss-modules-values": "^4.0.0",
         "postcss-value-parser": "^4.2.0",
-        "semver": "^7.5.4"
+        "semver": "^7.6.3"
       },
       "engines": {
         "node": ">= 18.12.0"
@@ -4867,7 +4603,7 @@
         "url": "https://opencollective.com/webpack"
       },
       "peerDependencies": {
-        "@rspack/core": "0.x || 1.x",
+        "@rspack/core": "0.x || ^1.0.0 || ^2.0.0-0",
         "webpack": "^5.27.0"
       },
       "peerDependenciesMeta": {
@@ -4881,8 +4617,6 @@
     },
     "node_modules/css-select": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
-      "integrity": "sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -4898,8 +4632,6 @@
     },
     "node_modules/css-tree": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
-      "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4912,8 +4644,6 @@
     },
     "node_modules/css-what": {
       "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
-      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -4925,8 +4655,6 @@
     },
     "node_modules/cssesc": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
-      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -4938,15 +4666,11 @@
     },
     "node_modules/csstype": {
       "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
-      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
-      "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4963,8 +4687,6 @@
     },
     "node_modules/data-view-byte-length": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
-      "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4981,8 +4703,6 @@
     },
     "node_modules/data-view-byte-offset": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
-      "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4999,8 +4719,6 @@
     },
     "node_modules/debug": {
       "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -5016,8 +4734,6 @@
     },
     "node_modules/decompress-response": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5032,8 +4748,6 @@
     },
     "node_modules/decompress-response/node_modules/mimic-response": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5044,9 +4758,9 @@
       }
     },
     "node_modules/dedent": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.1.tgz",
-      "integrity": "sha512-9JmrhGZpOlEgOLdQgSm0zxFaYoQon408V1v49aqTWuXENVlnCuY9JBZcXZiCsZQWDjTm5Qf/nIvAy77mXDAjEg==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
+      "integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
       "license": "MIT",
       "peerDependencies": {
         "babel-plugin-macros": "^3.1.0"
@@ -5067,14 +4781,6 @@
         "node": ">=4.0.0"
       }
     },
-    "node_modules/deep-is": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
-      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/deepmerge": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
@@ -5086,8 +4792,6 @@
     },
     "node_modules/defer-to-connect": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
-      "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5096,9 +4800,6 @@
     },
     "node_modules/deferred-leveldown": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-0.2.0.tgz",
-      "integrity": "sha512-+WCbb4+ez/SZ77Sdy1iadagFiVzMB89IKOBhglgnUkVxOxRWmmFsz8UDSNWh4Rhq+3wr/vMFlYj+rdEwWUDdng==",
-      "deprecated": "Superseded by abstract-level (https://github.com/Level/community#faq)",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5107,8 +4808,6 @@
     },
     "node_modules/define-data-property": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
-      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5125,8 +4824,6 @@
     },
     "node_modules/define-properties": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
-      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5143,8 +4840,6 @@
     },
     "node_modules/dequal": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
-      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5153,8 +4848,6 @@
     },
     "node_modules/detect-libc": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-      "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
       "dev": true,
       "license": "Apache-2.0",
       "optional": true,
@@ -5176,16 +4869,12 @@
     },
     "node_modules/detect-node": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
-      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
       "dev": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/doctrine": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -5197,8 +4886,6 @@
     },
     "node_modules/dom-converter": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/dom-converter/-/dom-converter-0.2.0.tgz",
-      "integrity": "sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5207,8 +4894,6 @@
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
-      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5218,8 +4903,6 @@
     },
     "node_modules/dom-serializer": {
       "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
-      "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5233,8 +4916,6 @@
     },
     "node_modules/domelementtype": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
       "dev": true,
       "funding": [
         {
@@ -5246,8 +4927,6 @@
     },
     "node_modules/domhandler": {
       "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
-      "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -5262,8 +4941,6 @@
     },
     "node_modules/domutils": {
       "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
-      "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -5277,8 +4954,6 @@
     },
     "node_modules/dot-case": {
       "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
-      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5288,8 +4963,6 @@
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5303,15 +4976,11 @@
     },
     "node_modules/duplexer": {
       "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
-      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/dxt-js": {
       "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/dxt-js/-/dxt-js-0.0.3.tgz",
-      "integrity": "sha512-qNBx0i5/ICyNFO7rs5ZothChgfFD408dg/ZBBfWFXDy0xeDQ86t91QUZxj5WqeUzZQ/+PPtjTUC0w3mS+198jg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -5319,14 +4988,12 @@
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "license": "MIT"
     },
     "node_modules/electron": {
-      "version": "41.1.1",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-41.1.1.tgz",
-      "integrity": "sha512-8bgvDhBjli+3Z2YCKgzzoBPh6391pr7Xv2h/tTJG4ETgvPvUxZomObbZLs31mUzYb6VrlcDDd9cyWyNKtPm3tA==",
+      "version": "41.3.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-41.3.0.tgz",
+      "integrity": "sha512-2Q5aeocmFdeheZGDUTrAvSR3t+n0c3d104AJWWEnt7syJU0tE4VdibMYaPtQ47QuXSoUf0/xSsfUUvu/uSXIfg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -5344,14 +5011,10 @@
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.267",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.267.tgz",
-      "integrity": "sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==",
       "license": "ISC"
     },
     "node_modules/electron/node_modules/@types/node": {
-      "version": "24.12.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
-      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
+      "version": "24.10.13",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5372,14 +5035,10 @@
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "license": "MIT"
     },
     "node_modules/emojis-list": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
-      "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5388,8 +5047,6 @@
     },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
-      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5398,8 +5055,6 @@
     },
     "node_modules/enhanced-resolve": {
       "version": "5.18.4",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.4.tgz",
-      "integrity": "sha512-LgQMM4WXU3QI+SYgEc2liRgznaD5ojbmY3sb8LxyguVkIg5FxdpTkvk72te2R38/TGKxH634oLxXRGY6d7AP+Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5412,8 +5067,6 @@
     },
     "node_modules/entities": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
       "dev": true,
       "license": "BSD-2-Clause",
       "funding": {
@@ -5422,8 +5075,6 @@
     },
     "node_modules/env-paths": {
       "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
-      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5432,8 +5083,6 @@
     },
     "node_modules/envinfo": {
       "version": "7.21.0",
-      "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.21.0.tgz",
-      "integrity": "sha512-Lw7I8Zp5YKHFCXL7+Dz95g4CcbMEpgvqZNNq3AmlT5XAV6CgAAk6gyAMqn2zjw08K9BHfcNuKrMiCPLByGafow==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -5445,8 +5094,6 @@
     },
     "node_modules/errno": {
       "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.8.tgz",
-      "integrity": "sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5458,8 +5105,6 @@
     },
     "node_modules/error-ex": {
       "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
-      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
@@ -5467,8 +5112,6 @@
     },
     "node_modules/error-stack-parser": {
       "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.1.4.tgz",
-      "integrity": "sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5477,8 +5120,6 @@
     },
     "node_modules/es-abstract": {
       "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.1.tgz",
-      "integrity": "sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5546,8 +5187,6 @@
     },
     "node_modules/es-define-property": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5556,8 +5195,6 @@
     },
     "node_modules/es-errors": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5566,15 +5203,11 @@
     },
     "node_modules/es-module-lexer": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
-      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5586,8 +5219,6 @@
     },
     "node_modules/es-set-tostringtag": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
-      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5602,8 +5233,6 @@
     },
     "node_modules/es-shim-unscopables": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz",
-      "integrity": "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5615,8 +5244,6 @@
     },
     "node_modules/es-to-primitive": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
-      "integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5633,16 +5260,14 @@
     },
     "node_modules/es6-error": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
-      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
       "dev": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/esbuild": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.2.tgz",
-      "integrity": "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -5653,45 +5278,45 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.2",
-        "@esbuild/android-arm": "0.27.2",
-        "@esbuild/android-arm64": "0.27.2",
-        "@esbuild/android-x64": "0.27.2",
-        "@esbuild/darwin-arm64": "0.27.2",
-        "@esbuild/darwin-x64": "0.27.2",
-        "@esbuild/freebsd-arm64": "0.27.2",
-        "@esbuild/freebsd-x64": "0.27.2",
-        "@esbuild/linux-arm": "0.27.2",
-        "@esbuild/linux-arm64": "0.27.2",
-        "@esbuild/linux-ia32": "0.27.2",
-        "@esbuild/linux-loong64": "0.27.2",
-        "@esbuild/linux-mips64el": "0.27.2",
-        "@esbuild/linux-ppc64": "0.27.2",
-        "@esbuild/linux-riscv64": "0.27.2",
-        "@esbuild/linux-s390x": "0.27.2",
-        "@esbuild/linux-x64": "0.27.2",
-        "@esbuild/netbsd-arm64": "0.27.2",
-        "@esbuild/netbsd-x64": "0.27.2",
-        "@esbuild/openbsd-arm64": "0.27.2",
-        "@esbuild/openbsd-x64": "0.27.2",
-        "@esbuild/openharmony-arm64": "0.27.2",
-        "@esbuild/sunos-x64": "0.27.2",
-        "@esbuild/win32-arm64": "0.27.2",
-        "@esbuild/win32-ia32": "0.27.2",
-        "@esbuild/win32-x64": "0.27.2"
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
       }
     },
     "node_modules/esbuild-loader": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/esbuild-loader/-/esbuild-loader-4.4.2.tgz",
-      "integrity": "sha512-8LdoT9sC7fzfvhxhsIAiWhzLJr9yT3ggmckXxsgvM07wgrRxhuT98XhLn3E7VczU5W5AFsPKv9DdWcZIubbWkQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/esbuild-loader/-/esbuild-loader-4.4.3.tgz",
+      "integrity": "sha512-Wpui03EzqC151xFteKlgJQhbyZl5CgnBpUHXVuao02nItULlkaTeiLdEMPTmR2zdwpEBWkXVNoT5dDOYJluUzg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.27.1",
         "get-tsconfig": "^4.10.1",
         "loader-utils": "^2.0.4",
-        "webpack-sources": "^1.4.3"
+        "webpack-sources": "^3.3.4"
       },
       "funding": {
         "url": "https://github.com/privatenumber/esbuild-loader?sponsor=1"
@@ -5702,8 +5327,6 @@
     },
     "node_modules/escalade": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
-      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -5711,10 +5334,9 @@
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=10"
       },
@@ -5724,8 +5346,6 @@
     },
     "node_modules/escodegen": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
-      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -5744,71 +5364,8 @@
         "source-map": "~0.6.1"
       }
     },
-    "node_modules/eslint": {
-      "version": "9.39.2",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.2.tgz",
-      "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@eslint-community/eslint-utils": "^4.8.0",
-        "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.21.1",
-        "@eslint/config-helpers": "^0.4.2",
-        "@eslint/core": "^0.17.0",
-        "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.39.2",
-        "@eslint/plugin-kit": "^0.4.1",
-        "@humanfs/node": "^0.16.6",
-        "@humanwhocodes/module-importer": "^1.0.1",
-        "@humanwhocodes/retry": "^0.4.2",
-        "@types/estree": "^1.0.6",
-        "ajv": "^6.12.4",
-        "chalk": "^4.0.0",
-        "cross-spawn": "^7.0.6",
-        "debug": "^4.3.2",
-        "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^8.4.0",
-        "eslint-visitor-keys": "^4.2.1",
-        "espree": "^10.4.0",
-        "esquery": "^1.5.0",
-        "esutils": "^2.0.2",
-        "fast-deep-equal": "^3.1.3",
-        "file-entry-cache": "^8.0.0",
-        "find-up": "^5.0.0",
-        "glob-parent": "^6.0.2",
-        "ignore": "^5.2.0",
-        "imurmurhash": "^0.1.4",
-        "is-glob": "^4.0.0",
-        "json-stable-stringify-without-jsonify": "^1.0.1",
-        "lodash.merge": "^4.6.2",
-        "minimatch": "^3.1.2",
-        "natural-compare": "^1.4.0",
-        "optionator": "^0.9.3"
-      },
-      "bin": {
-        "eslint": "bin/eslint.js"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://eslint.org/donate"
-      },
-      "peerDependencies": {
-        "jiti": "*"
-      },
-      "peerDependenciesMeta": {
-        "jiti": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/eslint-import-resolver-node": {
       "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz",
-      "integrity": "sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5819,8 +5376,6 @@
     },
     "node_modules/eslint-import-resolver-node/node_modules/debug": {
       "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5829,8 +5384,6 @@
     },
     "node_modules/eslint-module-utils": {
       "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.12.1.tgz",
-      "integrity": "sha512-L8jSWTze7K2mTg0vos/RuLRS5soomksDPoJLXIslC7c8Wmut3bx7CPpJijDcBZtxQ5lrbUdM+s0OlNbz0DCDNw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5847,8 +5400,6 @@
     },
     "node_modules/eslint-module-utils/node_modules/debug": {
       "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5857,8 +5408,6 @@
     },
     "node_modules/eslint-plugin-import": {
       "version": "2.32.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
-      "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5891,28 +5440,52 @@
     },
     "node_modules/eslint-plugin-import/node_modules/debug": {
       "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.1"
       }
     },
+    "node_modules/eslint-plugin-import/node_modules/json5": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "json5": "lib/cli.js"
+      }
+    },
     "node_modules/eslint-plugin-import/node_modules/semver": {
       "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/eslint-plugin-import/node_modules/strip-bom": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/tsconfig-paths": {
+      "version": "3.15.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/json5": "^0.0.29",
+        "json5": "^1.0.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      }
+    },
     "node_modules/eslint-scope": {
       "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -5925,178 +5498,14 @@
     },
     "node_modules/eslint-scope/node_modules/estraverse": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
       }
     },
-    "node_modules/eslint-visitor-keys": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint/node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/eslint/node_modules/eslint-scope": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
-      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "peer": true,
-      "dependencies": {
-        "esrecurse": "^4.3.0",
-        "estraverse": "^5.2.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint/node_modules/find-up": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "locate-path": "^6.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/eslint/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/eslint/node_modules/locate-path": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "p-locate": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/eslint/node_modules/p-limit": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "yocto-queue": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/eslint/node_modules/p-locate": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "p-limit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/eslint/node_modules/yocto-queue": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/espree": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
-      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "peer": true,
-      "dependencies": {
-        "acorn": "^8.15.0",
-        "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^4.2.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
     "node_modules/esprima": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "license": "BSD-2-Clause",
       "bin": {
         "esparse": "bin/esparse.js",
@@ -6106,24 +5515,8 @@
         "node": ">=4"
       }
     },
-    "node_modules/esquery": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
-      "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "estraverse": "^5.1.0"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
     "node_modules/esrecurse": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
-      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -6135,8 +5528,6 @@
     },
     "node_modules/estraverse": {
       "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -6145,8 +5536,6 @@
     },
     "node_modules/esutils": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -6155,8 +5544,6 @@
     },
     "node_modules/event-stream": {
       "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
-      "integrity": "sha512-QHpkERcGsR0T7Qm3HNJSyXKEEj8AHNxkY3PK8TS2KJvQ7NiSHe3DDpwVKKtoYprL/AreyzFBeIkBIWChAqn60g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6171,8 +5558,6 @@
     },
     "node_modules/events": {
       "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6224,17 +5609,112 @@
       }
     },
     "node_modules/expect": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-30.2.0.tgz",
-      "integrity": "sha512-u/feCi0GPsI+988gU2FLcsHyAHTU0MX1Wg68NhAnN7z/+C5wqG+CY8J53N9ioe8RXgaoz0nBR/TYMf3AycUuPw==",
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-30.3.0.tgz",
+      "integrity": "sha512-1zQrciTiQfRdo7qJM1uG4navm8DayFa2TgCSRlzUyNkhcJ6XUZF3hjnpkyr3VhAqPH7i/9GkG7Tv5abz6fqz0Q==",
       "license": "MIT",
       "dependencies": {
-        "@jest/expect-utils": "30.2.0",
+        "@jest/expect-utils": "30.3.0",
         "@jest/get-type": "30.1.0",
-        "jest-matcher-utils": "30.2.0",
-        "jest-message-util": "30.2.0",
-        "jest-mock": "30.2.0",
-        "jest-util": "30.2.0"
+        "jest-matcher-utils": "30.3.0",
+        "jest-message-util": "30.3.0",
+        "jest-mock": "30.3.0",
+        "jest-util": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/expect/node_modules/@jest/types": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
+      "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/pattern": "30.0.1",
+        "@jest/schemas": "30.0.5",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/expect/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/expect/node_modules/jest-message-util": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.3.0.tgz",
+      "integrity": "sha512-Z/j4Bo+4ySJ+JPJN3b2Qbl9hDq3VrXmnjjGEWD/x0BCXeOXPTV1iZYYzl2X8c1MaCOL+ewMyNBcm88sboE6YWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@jest/types": "30.3.0",
+        "@types/stack-utils": "^2.0.3",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3",
+        "pretty-format": "30.3.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.6"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/expect/node_modules/jest-mock": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.3.0.tgz",
+      "integrity": "sha512-OTzICK8CpE+t4ndhKrwlIdbM6Pn8j00lvmSmq5ejiO+KxukbLjgOflKWMn3KE34EZdQm5RqTuKj+5RIEniYhog==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "jest-util": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/expect/node_modules/jest-util": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
+      "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/expect/node_modules/pretty-format": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz",
+      "integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.0.5",
+        "ansi-styles": "^5.2.0",
+        "react-is": "^18.3.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -6242,8 +5722,6 @@
     },
     "node_modules/extract-zip": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
-      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -6263,35 +5741,19 @@
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "license": "MIT"
-    },
-    "node_modules/fast-levenshtein": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/fast-shallow-equal": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fast-shallow-equal/-/fast-shallow-equal-1.0.0.tgz",
-      "integrity": "sha512-HPtaa38cPgWvaCFmRNhlc6NG7pv6NUHqjPgVAkWGoB9mQMwYB27/K0CvOM5Czy+qpT3e8XJ6Q4aPAnzpNpzNaw==",
       "dev": true
     },
     "node_modules/fast-uri": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
       "dev": true,
       "funding": [
         {
@@ -6307,8 +5769,6 @@
     },
     "node_modules/fastest-levenshtein": {
       "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
-      "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6317,15 +5777,11 @@
     },
     "node_modules/fastest-stable-stringify": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/fastest-stable-stringify/-/fastest-stable-stringify-2.0.2.tgz",
-      "integrity": "sha512-bijHueCGd0LqqNK9b5oCMHc0MluJAx0cwqASgbWMvkO01lCYgIhacVRLcaDz3QnyYIRNJRDwMb41VuT6pHJ91Q==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
-      "integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
       "license": "Apache-2.0",
       "dependencies": {
         "bser": "2.1.1"
@@ -6333,8 +5789,6 @@
     },
     "node_modules/fd-slicer": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6343,8 +5797,6 @@
     },
     "node_modules/fdir": {
       "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6361,29 +5813,11 @@
     },
     "node_modules/fft.js": {
       "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/fft.js/-/fft.js-4.0.4.tgz",
-      "integrity": "sha512-f9c00hphOgeQTlDyavwTtu6RiK8AIFjD6+jvXkNkpeQ7rirK3uFWVpalkoS4LAwbdX7mfZ8aoBfFVQX1Re/8aw==",
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/file-entry-cache": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
-      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "flat-cache": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/file-loader": {
       "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-6.2.0.tgz",
-      "integrity": "sha512-qo3glqyTa61Ytg4u73GultjHGjdRyig3tG6lPtyX/jOEJvHif9uB0/OCI2Kif6ctF3caQTW2G5gym21oAsI4pw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6403,8 +5837,6 @@
     },
     "node_modules/file-loader/node_modules/ajv": {
       "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6420,8 +5852,6 @@
     },
     "node_modules/file-loader/node_modules/ajv-keywords": {
       "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -6430,15 +5860,11 @@
     },
     "node_modules/file-loader/node_modules/json-schema-traverse": {
       "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/file-loader/node_modules/schema-utils": {
       "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
-      "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6456,8 +5882,7 @@
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
-      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -6468,8 +5893,6 @@
     },
     "node_modules/find-up": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
       "license": "MIT",
       "dependencies": {
         "locate-path": "^5.0.0",
@@ -6481,41 +5904,14 @@
     },
     "node_modules/flat": {
       "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
-      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "bin": {
         "flat": "cli.js"
       }
     },
-    "node_modules/flat-cache": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
-      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "flatted": "^3.2.9",
-        "keyv": "^4.5.4"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/flatted": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
-      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
-      "dev": true,
-      "license": "ISC",
-      "peer": true
-    },
     "node_modules/for-each": {
       "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
-      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6530,15 +5926,11 @@
     },
     "node_modules/foreach": {
       "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.6.tgz",
-      "integrity": "sha512-k6GAGDyqLe9JaebCsFCoudPPWfihKu8pylYXRlqP1J7ms39iPoTtk2fviNglIeQEwdh0bQeKJ01ZPyuyQvKzwg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/foreground-child": {
       "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
-      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
       "license": "ISC",
       "dependencies": {
         "cross-spawn": "^7.0.6",
@@ -6553,8 +5945,6 @@
     },
     "node_modules/foreground-child/node_modules/signal-exit": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -6565,15 +5955,11 @@
     },
     "node_modules/from": {
       "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
-      "integrity": "sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/fs-extra": {
       "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6587,8 +5973,6 @@
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "license": "ISC"
     },
     "node_modules/fsevents": {
@@ -6607,8 +5991,6 @@
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -6617,8 +5999,6 @@
     },
     "node_modules/function.prototype.name": {
       "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
-      "integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6638,8 +6018,6 @@
     },
     "node_modules/functions-have-names": {
       "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
-      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -6648,8 +6026,6 @@
     },
     "node_modules/fwd-stream": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/fwd-stream/-/fwd-stream-1.0.4.tgz",
-      "integrity": "sha512-q2qaK2B38W07wfPSQDKMiKOD5Nzv2XyuvQlrmh1q0pxyHNanKHq8lwQ6n9zHucAwA5EbzRJKEgds2orn88rYTg==",
       "dev": true,
       "dependencies": {
         "readable-stream": "~1.0.26-4"
@@ -6657,15 +6033,11 @@
     },
     "node_modules/fwd-stream/node_modules/isarray": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/fwd-stream/node_modules/readable-stream": {
       "version": "1.0.34",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-      "integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6677,15 +6049,11 @@
     },
     "node_modules/fwd-stream/node_modules/string_decoder": {
       "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/generator-function": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
-      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6694,8 +6062,6 @@
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
-      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -6703,8 +6069,6 @@
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -6712,8 +6076,6 @@
     },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6737,8 +6099,6 @@
     },
     "node_modules/get-package-type": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
-      "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
@@ -6746,8 +6106,6 @@
     },
     "node_modules/get-proto": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6760,8 +6118,6 @@
     },
     "node_modules/get-stream": {
       "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6776,8 +6132,6 @@
     },
     "node_modules/get-symbol-description": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
-      "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6794,8 +6148,6 @@
     },
     "node_modules/get-tsconfig": {
       "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.0.tgz",
-      "integrity": "sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6807,9 +6159,6 @@
     },
     "node_modules/glob": {
       "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -6828,8 +6177,6 @@
     },
     "node_modules/glob-parent": {
       "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
-      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -6841,15 +6188,11 @@
     },
     "node_modules/glob-to-regexp": {
       "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
-      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
       "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/global-agent": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
-      "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
       "dev": true,
       "license": "BSD-3-Clause",
       "optional": true,
@@ -6865,24 +6208,8 @@
         "node": ">=10.0"
       }
     },
-    "node_modules/globals": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
-      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/globalthis": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
-      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6898,8 +6225,6 @@
     },
     "node_modules/gopd": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6911,8 +6236,6 @@
     },
     "node_modules/got": {
       "version": "11.8.6",
-      "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
-      "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6937,8 +6260,6 @@
     },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
     },
     "node_modules/handlebars": {
@@ -6964,8 +6285,6 @@
     },
     "node_modules/has-bigints": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
-      "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6977,8 +6296,6 @@
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6986,8 +6303,6 @@
     },
     "node_modules/has-property-descriptors": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
-      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6999,8 +6314,6 @@
     },
     "node_modules/has-proto": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
-      "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7015,8 +6328,6 @@
     },
     "node_modules/has-symbols": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7028,8 +6339,6 @@
     },
     "node_modules/has-tostringtag": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7044,8 +6353,6 @@
     },
     "node_modules/hasown": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7057,8 +6364,6 @@
     },
     "node_modules/he": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -7067,8 +6372,6 @@
     },
     "node_modules/hosted-git-info": {
       "version": "2.8.9",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
-      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true,
       "license": "ISC"
     },
@@ -7080,8 +6383,6 @@
     },
     "node_modules/html-minifier-terser": {
       "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
-      "integrity": "sha512-YXxSlJBZTP7RS3tWnQw74ooKa6L9b9i9QYXY21eUEvhZ3u9XLfv6OnFsQq6RxkhHygsaUMvYsZRV5rU/OVNZxw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7101,9 +6402,9 @@
       }
     },
     "node_modules/html-webpack-plugin": {
-      "version": "5.6.5",
-      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.6.5.tgz",
-      "integrity": "sha512-4xynFbKNNk+WlzXeQQ+6YYsH2g7mpfPszQZUi3ovKlj+pDmngQ7vRXjrrmGROabmKwyQkcgcX5hqfOwHbFmK5g==",
+      "version": "5.6.7",
+      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.6.7.tgz",
+      "integrity": "sha512-md+vXtdCAe60s1k6AU3dUyMJnDxUyQAwfwPKoLisvgUF1IXjtlLsk2se54+qfL9Mdm26bbwvjJybpNx48NKRLw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7135,8 +6436,6 @@
     },
     "node_modules/htmlparser2": {
       "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
-      "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
       "dev": true,
       "funding": [
         "https://github.com/fb55/htmlparser2?sponsor=1",
@@ -7155,15 +6454,11 @@
     },
     "node_modules/http-cache-semantics": {
       "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
-      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
       "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/http2-wrapper": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
-      "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7185,15 +6480,11 @@
     },
     "node_modules/hyphenate-style-name": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.1.0.tgz",
-      "integrity": "sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw==",
       "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/icss-utils": {
       "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
-      "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -7205,28 +6496,13 @@
     },
     "node_modules/idb-keyval": {
       "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.2.tgz",
-      "integrity": "sha512-yjD9nARJ/jb1g+CvD0tlhUHOrJ9Sy0P8T9MF3YaLlHnSRpwPfpTX0XIvpmw3gAJUmEu3FiICLBDPXVwyEvrleg==",
       "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/idb-wrapper": {
       "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/idb-wrapper/-/idb-wrapper-1.7.2.tgz",
-      "integrity": "sha512-zfNREywMuf0NzDo9mVsL0yegjsirJxHpKHvWcyRozIqQy89g0a3U+oBPOCN4cc0oCiOuYgZHimzaW/R46G1Mpg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/ignore": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
-      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">= 4"
-      }
     },
     "node_modules/immutable": {
       "version": "5.1.5",
@@ -7235,28 +6511,8 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/import-fresh": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
-      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "parent-module": "^1.0.0",
-        "resolve-from": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/import-local": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
-      "integrity": "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==",
       "license": "MIT",
       "dependencies": {
         "pkg-dir": "^4.2.0",
@@ -7274,8 +6530,6 @@
     },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
@@ -7283,15 +6537,10 @@
     },
     "node_modules/indexof": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
-      "integrity": "sha512-i0G7hLJ1z0DE8dsqJa2rycj9dBmNKgXBvotXtZYXakU9oivfB9Uj2ZBC27qqef2U58/ZLwalxa1X/RDCdkHtVg==",
       "dev": true
     },
     "node_modules/inflight": {
       "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
       "license": "ISC",
       "dependencies": {
         "once": "^1.3.0",
@@ -7300,8 +6549,6 @@
     },
     "node_modules/inherits": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
     "node_modules/ini": {
@@ -7313,8 +6560,6 @@
     },
     "node_modules/inline-style-prefixer": {
       "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-7.0.1.tgz",
-      "integrity": "sha512-lhYo5qNTQp3EvSSp3sRvXMbVQTLrvGV6DycRMJ5dm2BLMiJ30wpXKdDdgX+GmJZ5uQMucwRKHamXSst3Sj/Giw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7323,8 +6568,6 @@
     },
     "node_modules/internal-slot": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
-      "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7338,8 +6581,6 @@
     },
     "node_modules/interpret": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-3.1.1.tgz",
-      "integrity": "sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7348,8 +6589,6 @@
     },
     "node_modules/invariant": {
       "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7358,8 +6597,6 @@
     },
     "node_modules/is": {
       "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/is/-/is-0.2.7.tgz",
-      "integrity": "sha512-ajQCouIvkcSnl2iRdK70Jug9mohIHVX9uKpoWnl115ov0R5mzBvRrXxrnHbsA+8AdwCwc/sfw7HXmd4I5EJBdQ==",
       "dev": true,
       "engines": {
         "node": "*"
@@ -7367,8 +6604,6 @@
     },
     "node_modules/is-array-buffer": {
       "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
-      "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7385,14 +6620,10 @@
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "license": "MIT"
     },
     "node_modules/is-async-function": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
-      "integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7411,8 +6642,6 @@
     },
     "node_modules/is-bigint": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
-      "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7427,8 +6656,6 @@
     },
     "node_modules/is-boolean-object": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
-      "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7444,8 +6671,6 @@
     },
     "node_modules/is-callable": {
       "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
-      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7457,8 +6682,6 @@
     },
     "node_modules/is-core-module": {
       "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
-      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7473,8 +6696,6 @@
     },
     "node_modules/is-data-view": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
-      "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7491,8 +6712,6 @@
     },
     "node_modules/is-date-object": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
-      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7506,26 +6725,8 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-docker": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
-      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "is-docker": "cli.js"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7534,8 +6735,6 @@
     },
     "node_modules/is-finalizationregistry": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
-      "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7550,8 +6749,6 @@
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7568,8 +6765,6 @@
     },
     "node_modules/is-generator-function": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
-      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7588,8 +6783,6 @@
     },
     "node_modules/is-glob": {
       "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7601,8 +6794,6 @@
     },
     "node_modules/is-map": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
-      "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7614,8 +6805,6 @@
     },
     "node_modules/is-negative-zero": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
-      "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7627,8 +6816,7 @@
     },
     "node_modules/is-number": {
       "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -7636,8 +6824,6 @@
     },
     "node_modules/is-number-object": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
-      "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7653,14 +6839,10 @@
     },
     "node_modules/is-object": {
       "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/is-object/-/is-object-0.1.2.tgz",
-      "integrity": "sha512-GkfZZlIZtpkFrqyAXPQSRBMsaHAw+CgoKe2HXAkjd/sfoI9+hS8PT4wg2rJxdQyUKr7N2vHJbg7/jQtE5l5vBQ==",
       "dev": true
     },
     "node_modules/is-plain-object": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7685,8 +6867,6 @@
     },
     "node_modules/is-regex": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
-      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7704,8 +6884,6 @@
     },
     "node_modules/is-set": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
-      "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7717,8 +6895,6 @@
     },
     "node_modules/is-shared-array-buffer": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
-      "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7745,8 +6921,6 @@
     },
     "node_modules/is-string": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
-      "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7762,8 +6936,6 @@
     },
     "node_modules/is-symbol": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
-      "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7780,8 +6952,6 @@
     },
     "node_modules/is-typed-array": {
       "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
-      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7796,8 +6966,6 @@
     },
     "node_modules/is-weakmap": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
-      "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7809,8 +6977,6 @@
     },
     "node_modules/is-weakref": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz",
-      "integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7825,8 +6991,6 @@
     },
     "node_modules/is-weakset": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
-      "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7840,43 +7004,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-wsl": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
-      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-docker": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/isarray": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/isbuffer": {
       "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/isbuffer/-/isbuffer-0.0.0.tgz",
-      "integrity": "sha512-xU+NoHp+YtKQkaM2HsQchYn0sltxMxew0HavMfHbjnucBoTSGbw745tL+Z7QBANleWM1eEQMenEpi174mIeS4g==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
     "node_modules/isobject": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7885,8 +7028,6 @@
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
-      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=8"
@@ -7894,8 +7035,6 @@
     },
     "node_modules/istanbul-lib-instrument": {
       "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
-      "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/core": "^7.23.9",
@@ -7951,8 +7090,6 @@
     },
     "node_modules/jackspeak": {
       "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
@@ -7965,15 +7102,15 @@
       }
     },
     "node_modules/jest": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-30.2.0.tgz",
-      "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-30.3.0.tgz",
+      "integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
       "license": "MIT",
       "dependencies": {
-        "@jest/core": "30.2.0",
-        "@jest/types": "30.2.0",
+        "@jest/core": "30.3.0",
+        "@jest/types": "30.3.0",
         "import-local": "^3.2.0",
-        "jest-cli": "30.2.0"
+        "jest-cli": "30.3.0"
       },
       "bin": {
         "jest": "bin/jest.js"
@@ -7991,14 +7128,49 @@
       }
     },
     "node_modules/jest-changed-files": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-30.2.0.tgz",
-      "integrity": "sha512-L8lR1ChrRnSdfeOvTrwZMlnWV8G/LLjQ0nG9MBclwWZidA2N5FviRki0Bvh20WRMOX31/JYvzdqTJrk5oBdydQ==",
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-30.3.0.tgz",
+      "integrity": "sha512-B/7Cny6cV5At6M25EWDgf9S617lHivamL8vl6KEpJqkStauzcG4e+WPfDgMMF+H4FVH4A2PLRyvgDJan4441QA==",
       "license": "MIT",
       "dependencies": {
         "execa": "^5.1.1",
-        "jest-util": "30.2.0",
+        "jest-util": "30.3.0",
         "p-limit": "^3.1.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-changed-files/node_modules/@jest/types": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
+      "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/pattern": "30.0.1",
+        "@jest/schemas": "30.0.5",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-changed-files/node_modules/jest-util": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
+      "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -8032,31 +7204,153 @@
       }
     },
     "node_modules/jest-circus": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.2.0.tgz",
-      "integrity": "sha512-Fh0096NC3ZkFx05EP2OXCxJAREVxj1BcW/i6EWqqymcgYKWjyyDpral3fMxVcHXg6oZM7iULer9wGRFvfpl+Tg==",
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.3.0.tgz",
+      "integrity": "sha512-PyXq5szeSfR/4f1lYqCmmQjh0vqDkURUYi9N6whnHjlRz4IUQfMcXkGLeEoiJtxtyPqgUaUUfyQlApXWBSN1RA==",
       "license": "MIT",
       "dependencies": {
-        "@jest/environment": "30.2.0",
-        "@jest/expect": "30.2.0",
-        "@jest/test-result": "30.2.0",
-        "@jest/types": "30.2.0",
+        "@jest/environment": "30.3.0",
+        "@jest/expect": "30.3.0",
+        "@jest/test-result": "30.3.0",
+        "@jest/types": "30.3.0",
         "@types/node": "*",
         "chalk": "^4.1.2",
         "co": "^4.6.0",
         "dedent": "^1.6.0",
         "is-generator-fn": "^2.1.0",
-        "jest-each": "30.2.0",
-        "jest-matcher-utils": "30.2.0",
-        "jest-message-util": "30.2.0",
-        "jest-runtime": "30.2.0",
-        "jest-snapshot": "30.2.0",
-        "jest-util": "30.2.0",
+        "jest-each": "30.3.0",
+        "jest-matcher-utils": "30.3.0",
+        "jest-message-util": "30.3.0",
+        "jest-runtime": "30.3.0",
+        "jest-snapshot": "30.3.0",
+        "jest-util": "30.3.0",
         "p-limit": "^3.1.0",
-        "pretty-format": "30.2.0",
+        "pretty-format": "30.3.0",
         "pure-rand": "^7.0.0",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.6"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-circus/node_modules/@jest/environment": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.3.0.tgz",
+      "integrity": "sha512-SlLSF4Be735yQXyh2+mctBOzNDx5s5uLv88/j8Qn1wH679PDcwy67+YdADn8NJnGjzlXtN62asGH/T4vWOkfaw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/fake-timers": "30.3.0",
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "jest-mock": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-circus/node_modules/@jest/fake-timers": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.3.0.tgz",
+      "integrity": "sha512-WUQDs8SOP9URStX1DzhD425CqbN/HxUYCTwVrT8sTVBfMvFqYt/s61EK5T05qnHu0po6RitXIvP9otZxYDzTGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@sinonjs/fake-timers": "^15.0.0",
+        "@types/node": "*",
+        "jest-message-util": "30.3.0",
+        "jest-mock": "30.3.0",
+        "jest-util": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-circus/node_modules/@jest/types": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
+      "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/pattern": "30.0.1",
+        "@jest/schemas": "30.0.5",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-circus/node_modules/@sinonjs/fake-timers": {
+      "version": "15.3.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.3.2.tgz",
+      "integrity": "sha512-mrn35Jl2pCpns+mE3HaZa1yPN5EYCRgiMI+135COjr2hr8Cls9DXqIZ57vZe2cz7y2XVSq92tcs6kGQcT1J8Rw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1"
+      }
+    },
+    "node_modules/jest-circus/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-circus/node_modules/jest-message-util": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.3.0.tgz",
+      "integrity": "sha512-Z/j4Bo+4ySJ+JPJN3b2Qbl9hDq3VrXmnjjGEWD/x0BCXeOXPTV1iZYYzl2X8c1MaCOL+ewMyNBcm88sboE6YWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@jest/types": "30.3.0",
+        "@types/stack-utils": "^2.0.3",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3",
+        "pretty-format": "30.3.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.6"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-circus/node_modules/jest-mock": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.3.0.tgz",
+      "integrity": "sha512-OTzICK8CpE+t4ndhKrwlIdbM6Pn8j00lvmSmq5ejiO+KxukbLjgOflKWMn3KE34EZdQm5RqTuKj+5RIEniYhog==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "jest-util": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-circus/node_modules/jest-util": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
+      "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -8077,6 +7371,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/jest-circus/node_modules/pretty-format": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz",
+      "integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.0.5",
+        "ansi-styles": "^5.2.0",
+        "react-is": "^18.3.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
     "node_modules/jest-circus/node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -8090,20 +7398,20 @@
       }
     },
     "node_modules/jest-cli": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.2.0.tgz",
-      "integrity": "sha512-Os9ukIvADX/A9sLt6Zse3+nmHtHaE6hqOsjQtNiugFTbKRHYIYtZXNGNK9NChseXy7djFPjndX1tL0sCTlfpAA==",
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.3.0.tgz",
+      "integrity": "sha512-l6Tqx+j1fDXJEW5bqYykDQQ7mQg+9mhWXtnj+tQZrTWYHyHoi6Be8HPumDSA+UiX2/2buEgjA58iJzdj146uCw==",
       "license": "MIT",
       "dependencies": {
-        "@jest/core": "30.2.0",
-        "@jest/test-result": "30.2.0",
-        "@jest/types": "30.2.0",
+        "@jest/core": "30.3.0",
+        "@jest/test-result": "30.3.0",
+        "@jest/types": "30.3.0",
         "chalk": "^4.1.2",
         "exit-x": "^0.2.2",
         "import-local": "^3.2.0",
-        "jest-config": "30.2.0",
-        "jest-util": "30.2.0",
-        "jest-validate": "30.2.0",
+        "jest-config": "30.3.0",
+        "jest-util": "30.3.0",
+        "jest-validate": "30.3.0",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -8121,34 +7429,68 @@
         }
       }
     },
+    "node_modules/jest-cli/node_modules/@jest/types": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
+      "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/pattern": "30.0.1",
+        "@jest/schemas": "30.0.5",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-cli/node_modules/jest-util": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
+      "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
     "node_modules/jest-config": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.2.0.tgz",
-      "integrity": "sha512-g4WkyzFQVWHtu6uqGmQR4CQxz/CH3yDSlhzXMWzNjDx843gYjReZnMRanjRCq5XZFuQrGDxgUaiYWE8BRfVckA==",
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.3.0.tgz",
+      "integrity": "sha512-WPMAkMAtNDY9P/oKObtsRG/6KTrhtgPJoBTmk20uDn4Uy6/3EJnnaZJre/FMT1KVRx8cve1r7/FlMIOfRVWL4w==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.27.4",
         "@jest/get-type": "30.1.0",
         "@jest/pattern": "30.0.1",
-        "@jest/test-sequencer": "30.2.0",
-        "@jest/types": "30.2.0",
-        "babel-jest": "30.2.0",
+        "@jest/test-sequencer": "30.3.0",
+        "@jest/types": "30.3.0",
+        "babel-jest": "30.3.0",
         "chalk": "^4.1.2",
         "ci-info": "^4.2.0",
         "deepmerge": "^4.3.1",
-        "glob": "^10.3.10",
+        "glob": "^10.5.0",
         "graceful-fs": "^4.2.11",
-        "jest-circus": "30.2.0",
+        "jest-circus": "30.3.0",
         "jest-docblock": "30.2.0",
-        "jest-environment-node": "30.2.0",
+        "jest-environment-node": "30.3.0",
         "jest-regex-util": "30.0.1",
-        "jest-resolve": "30.2.0",
-        "jest-runner": "30.2.0",
-        "jest-util": "30.2.0",
-        "jest-validate": "30.2.0",
-        "micromatch": "^4.0.8",
+        "jest-resolve": "30.3.0",
+        "jest-runner": "30.3.0",
+        "jest-util": "30.3.0",
+        "jest-validate": "30.3.0",
         "parse-json": "^5.2.0",
-        "pretty-format": "30.2.0",
+        "pretty-format": "30.3.0",
         "slash": "^3.0.0",
         "strip-json-comments": "^3.1.1"
       },
@@ -8172,10 +7514,40 @@
         }
       }
     },
+    "node_modules/jest-config/node_modules/@jest/types": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
+      "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/pattern": "30.0.1",
+        "@jest/schemas": "30.0.5",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-config/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/jest-config/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -8185,6 +7557,7 @@
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
       "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
@@ -8199,6 +7572,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/jest-config/node_modules/jest-util": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
+      "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-config/node_modules/minimatch": {
@@ -8216,16 +7606,56 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/jest-diff": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.2.0.tgz",
-      "integrity": "sha512-dQHFo3Pt4/NLlG5z4PxZ/3yZTZ1C7s9hveiOj+GCN+uT109NC2QgsoVZsVOAvbJ3RgKkvyLGXZV9+piDpWbm6A==",
+    "node_modules/jest-config/node_modules/pretty-format": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz",
+      "integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
       "license": "MIT",
       "dependencies": {
-        "@jest/diff-sequences": "30.0.1",
+        "@jest/schemas": "30.0.5",
+        "ansi-styles": "^5.2.0",
+        "react-is": "^18.3.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-diff": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.3.0.tgz",
+      "integrity": "sha512-n3q4PDQjS4LrKxfWB3Z5KNk1XjXtZTBwQp71OP0Jo03Z6V60x++K5L8k6ZrW8MY8pOFylZvHM0zsjS1RqlHJZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/diff-sequences": "30.3.0",
         "@jest/get-type": "30.1.0",
         "chalk": "^4.1.2",
-        "pretty-format": "30.2.0"
+        "pretty-format": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-diff/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-diff/node_modules/pretty-format": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz",
+      "integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.0.5",
+        "ansi-styles": "^5.2.0",
+        "react-is": "^18.3.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -8244,54 +7674,251 @@
       }
     },
     "node_modules/jest-each": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-30.2.0.tgz",
-      "integrity": "sha512-lpWlJlM7bCUf1mfmuqTA8+j2lNURW9eNafOy99knBM01i5CQeY5UH1vZjgT9071nDJac1M4XsbyI44oNOdhlDQ==",
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-30.3.0.tgz",
+      "integrity": "sha512-V8eMndg/aZ+3LnCJgSm13IxS5XSBM22QSZc9BtPK8Dek6pm+hfUNfwBdvsB3d342bo1q7wnSkC38zjX259qZNA==",
       "license": "MIT",
       "dependencies": {
         "@jest/get-type": "30.1.0",
-        "@jest/types": "30.2.0",
+        "@jest/types": "30.3.0",
         "chalk": "^4.1.2",
-        "jest-util": "30.2.0",
-        "pretty-format": "30.2.0"
+        "jest-util": "30.3.0",
+        "pretty-format": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-each/node_modules/@jest/types": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
+      "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/pattern": "30.0.1",
+        "@jest/schemas": "30.0.5",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-each/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-each/node_modules/jest-util": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
+      "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-each/node_modules/pretty-format": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz",
+      "integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.0.5",
+        "ansi-styles": "^5.2.0",
+        "react-is": "^18.3.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-environment-node": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-30.2.0.tgz",
-      "integrity": "sha512-ElU8v92QJ9UrYsKrxDIKCxu6PfNj4Hdcktcn0JX12zqNdqWHB0N+hwOnnBBXvjLd2vApZtuLUGs1QSY+MsXoNA==",
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-30.3.0.tgz",
+      "integrity": "sha512-4i6HItw/JSiJVsC5q0hnKIe/hbYfZLVG9YJ/0pU9Hz2n/9qZe3Rhn5s5CUZA5ORZlcdT/vmAXRMyONXJwPrmYQ==",
       "license": "MIT",
       "dependencies": {
-        "@jest/environment": "30.2.0",
-        "@jest/fake-timers": "30.2.0",
-        "@jest/types": "30.2.0",
+        "@jest/environment": "30.3.0",
+        "@jest/fake-timers": "30.3.0",
+        "@jest/types": "30.3.0",
         "@types/node": "*",
-        "jest-mock": "30.2.0",
-        "jest-util": "30.2.0",
-        "jest-validate": "30.2.0"
+        "jest-mock": "30.3.0",
+        "jest-util": "30.3.0",
+        "jest-validate": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-environment-node/node_modules/@jest/environment": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.3.0.tgz",
+      "integrity": "sha512-SlLSF4Be735yQXyh2+mctBOzNDx5s5uLv88/j8Qn1wH679PDcwy67+YdADn8NJnGjzlXtN62asGH/T4vWOkfaw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/fake-timers": "30.3.0",
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "jest-mock": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-environment-node/node_modules/@jest/fake-timers": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.3.0.tgz",
+      "integrity": "sha512-WUQDs8SOP9URStX1DzhD425CqbN/HxUYCTwVrT8sTVBfMvFqYt/s61EK5T05qnHu0po6RitXIvP9otZxYDzTGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@sinonjs/fake-timers": "^15.0.0",
+        "@types/node": "*",
+        "jest-message-util": "30.3.0",
+        "jest-mock": "30.3.0",
+        "jest-util": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-environment-node/node_modules/@jest/types": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
+      "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/pattern": "30.0.1",
+        "@jest/schemas": "30.0.5",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-environment-node/node_modules/@sinonjs/fake-timers": {
+      "version": "15.3.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.3.2.tgz",
+      "integrity": "sha512-mrn35Jl2pCpns+mE3HaZa1yPN5EYCRgiMI+135COjr2hr8Cls9DXqIZ57vZe2cz7y2XVSq92tcs6kGQcT1J8Rw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1"
+      }
+    },
+    "node_modules/jest-environment-node/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-environment-node/node_modules/jest-message-util": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.3.0.tgz",
+      "integrity": "sha512-Z/j4Bo+4ySJ+JPJN3b2Qbl9hDq3VrXmnjjGEWD/x0BCXeOXPTV1iZYYzl2X8c1MaCOL+ewMyNBcm88sboE6YWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@jest/types": "30.3.0",
+        "@types/stack-utils": "^2.0.3",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3",
+        "pretty-format": "30.3.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.6"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-environment-node/node_modules/jest-mock": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.3.0.tgz",
+      "integrity": "sha512-OTzICK8CpE+t4ndhKrwlIdbM6Pn8j00lvmSmq5ejiO+KxukbLjgOflKWMn3KE34EZdQm5RqTuKj+5RIEniYhog==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "jest-util": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-environment-node/node_modules/jest-util": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
+      "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-environment-node/node_modules/pretty-format": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz",
+      "integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.0.5",
+        "ansi-styles": "^5.2.0",
+        "react-is": "^18.3.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-haste-map": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.2.0.tgz",
-      "integrity": "sha512-sQA/jCb9kNt+neM0anSj6eZhLZUIhQgwDt7cPGjumgLM4rXsfb9kpnlacmvZz3Q5tb80nS+oG/if+NBKrHC+Xw==",
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.3.0.tgz",
+      "integrity": "sha512-mMi2oqG4KRU0R9QEtscl87JzMXfUhbKaFqOxmjb2CKcbHcUGFrJCBWHmnTiUqi6JcnzoBlO4rWfpdl2k/RfLCA==",
       "license": "MIT",
       "dependencies": {
-        "@jest/types": "30.2.0",
+        "@jest/types": "30.3.0",
         "@types/node": "*",
         "anymatch": "^3.1.3",
         "fb-watchman": "^2.0.2",
         "graceful-fs": "^4.2.11",
         "jest-regex-util": "30.0.1",
-        "jest-util": "30.2.0",
-        "jest-worker": "30.2.0",
-        "micromatch": "^4.0.8",
+        "jest-util": "30.3.0",
+        "jest-worker": "30.3.0",
+        "picomatch": "^4.0.3",
         "walker": "^1.0.8"
       },
       "engines": {
@@ -8301,63 +7928,116 @@
         "fsevents": "^2.3.3"
       }
     },
+    "node_modules/jest-haste-map/node_modules/@jest/types": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
+      "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/pattern": "30.0.1",
+        "@jest/schemas": "30.0.5",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-haste-map/node_modules/jest-util": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
+      "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
     "node_modules/jest-leak-detector": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-30.2.0.tgz",
-      "integrity": "sha512-M6jKAjyzjHG0SrQgwhgZGy9hFazcudwCNovY/9HPIicmNSBuockPSedAP9vlPK6ONFJ1zfyH/M2/YYJxOz5cdQ==",
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-30.3.0.tgz",
+      "integrity": "sha512-cuKmUUGIjfXZAiGJ7TbEMx0bcqNdPPI6P1V+7aF+m/FUJqFDxkFR4JqkTu8ZOiU5AaX/x0hZ20KaaIPXQzbMGQ==",
       "license": "MIT",
       "dependencies": {
         "@jest/get-type": "30.1.0",
-        "pretty-format": "30.2.0"
+        "pretty-format": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-leak-detector/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-leak-detector/node_modules/pretty-format": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz",
+      "integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.0.5",
+        "ansi-styles": "^5.2.0",
+        "react-is": "^18.3.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-matcher-utils": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.2.0.tgz",
-      "integrity": "sha512-dQ94Nq4dbzmUWkQ0ANAWS9tBRfqCrn0bV9AMYdOi/MHW726xn7eQmMeRTpX2ViC00bpNaWXq+7o4lIQ3AX13Hg==",
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.3.0.tgz",
+      "integrity": "sha512-HEtc9uFQgaUHkC7nLSlQL3Tph4Pjxt/yiPvkIrrDCt9jhoLIgxaubo1G+CFOnmHYMxHwwdaSN7mkIFs6ZK8OhA==",
       "license": "MIT",
       "dependencies": {
         "@jest/get-type": "30.1.0",
         "chalk": "^4.1.2",
-        "jest-diff": "30.2.0",
-        "pretty-format": "30.2.0"
+        "jest-diff": "30.3.0",
+        "pretty-format": "30.3.0"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
-    "node_modules/jest-message-util": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.2.0.tgz",
-      "integrity": "sha512-y4DKFLZ2y6DxTWD4cDe07RglV88ZiNEdlRfGtqahfbIjfsw1nMCPx49Uev4IA/hWn3sDKyAnSPwoYSsAEdcimw==",
+    "node_modules/jest-matcher-utils/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@jest/types": "30.2.0",
-        "@types/stack-utils": "^2.0.3",
-        "chalk": "^4.1.2",
-        "graceful-fs": "^4.2.11",
-        "micromatch": "^4.0.8",
-        "pretty-format": "30.2.0",
-        "slash": "^3.0.0",
-        "stack-utils": "^2.0.6"
-      },
       "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/jest-mock": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.2.0.tgz",
-      "integrity": "sha512-JNNNl2rj4b5ICpmAcq+WbLH83XswjPbjH4T7yvGzfAGCPh1rw+xVNbtk+FnRslvt9lkCcdn9i1oAoKUuFsOxRw==",
+    "node_modules/jest-matcher-utils/node_modules/pretty-format": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz",
+      "integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
       "license": "MIT",
       "dependencies": {
-        "@jest/types": "30.2.0",
-        "@types/node": "*",
-        "jest-util": "30.2.0"
+        "@jest/schemas": "30.0.5",
+        "ansi-styles": "^5.2.0",
+        "react-is": "^18.3.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -8382,25 +8062,23 @@
     },
     "node_modules/jest-regex-util": {
       "version": "30.0.1",
-      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.0.1.tgz",
-      "integrity": "sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==",
       "license": "MIT",
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-resolve": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.2.0.tgz",
-      "integrity": "sha512-TCrHSxPlx3tBY3hWNtRQKbtgLhsXa1WmbJEqBlTBrGafd5fiQFByy2GNCEoGR+Tns8d15GaL9cxEzKOO3GEb2A==",
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.3.0.tgz",
+      "integrity": "sha512-NRtTAHQlpd15F9rUR36jqwelbrDV/dY4vzNte3S2kxCKUJRYNd5/6nTSbYiak1VX5g8IoFF23Uj5TURkUW8O5g==",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",
         "graceful-fs": "^4.2.11",
-        "jest-haste-map": "30.2.0",
+        "jest-haste-map": "30.3.0",
         "jest-pnp-resolver": "^1.2.3",
-        "jest-util": "30.2.0",
-        "jest-validate": "30.2.0",
+        "jest-util": "30.3.0",
+        "jest-validate": "30.3.0",
         "slash": "^3.0.0",
         "unrs-resolver": "^1.7.11"
       },
@@ -8409,46 +8087,203 @@
       }
     },
     "node_modules/jest-resolve-dependencies": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.2.0.tgz",
-      "integrity": "sha512-xTOIGug/0RmIe3mmCqCT95yO0vj6JURrn1TKWlNbhiAefJRWINNPgwVkrVgt/YaerPzY3iItufd80v3lOrFJ2w==",
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.3.0.tgz",
+      "integrity": "sha512-9ev8s3YN6Hsyz9LV75XUwkCVFlwPbaFn6Wp75qnI0wzAINYWY8Fb3+6y59Rwd3QaS3kKXffHXsZMziMavfz/nw==",
       "license": "MIT",
       "dependencies": {
         "jest-regex-util": "30.0.1",
-        "jest-snapshot": "30.2.0"
+        "jest-snapshot": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-resolve/node_modules/@jest/types": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
+      "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/pattern": "30.0.1",
+        "@jest/schemas": "30.0.5",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-resolve/node_modules/jest-util": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
+      "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-runner": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.2.0.tgz",
-      "integrity": "sha512-PqvZ2B2XEyPEbclp+gV6KO/F1FIFSbIwewRgmROCMBo/aZ6J1w8Qypoj2pEOcg3G2HzLlaP6VUtvwCI8dM3oqQ==",
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.3.0.tgz",
+      "integrity": "sha512-gDv6C9LGKWDPLia9TSzZwf4h3kMQCqyTpq+95PODnTRDO0g9os48XIYYkS6D236vjpBir2fF63YmJFtqkS5Duw==",
       "license": "MIT",
       "dependencies": {
-        "@jest/console": "30.2.0",
-        "@jest/environment": "30.2.0",
-        "@jest/test-result": "30.2.0",
-        "@jest/transform": "30.2.0",
-        "@jest/types": "30.2.0",
+        "@jest/console": "30.3.0",
+        "@jest/environment": "30.3.0",
+        "@jest/test-result": "30.3.0",
+        "@jest/transform": "30.3.0",
+        "@jest/types": "30.3.0",
         "@types/node": "*",
         "chalk": "^4.1.2",
         "emittery": "^0.13.1",
         "exit-x": "^0.2.2",
         "graceful-fs": "^4.2.11",
         "jest-docblock": "30.2.0",
-        "jest-environment-node": "30.2.0",
-        "jest-haste-map": "30.2.0",
-        "jest-leak-detector": "30.2.0",
-        "jest-message-util": "30.2.0",
-        "jest-resolve": "30.2.0",
-        "jest-runtime": "30.2.0",
-        "jest-util": "30.2.0",
-        "jest-watcher": "30.2.0",
-        "jest-worker": "30.2.0",
+        "jest-environment-node": "30.3.0",
+        "jest-haste-map": "30.3.0",
+        "jest-leak-detector": "30.3.0",
+        "jest-message-util": "30.3.0",
+        "jest-resolve": "30.3.0",
+        "jest-runtime": "30.3.0",
+        "jest-util": "30.3.0",
+        "jest-watcher": "30.3.0",
+        "jest-worker": "30.3.0",
         "p-limit": "^3.1.0",
         "source-map-support": "0.5.13"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-runner/node_modules/@jest/environment": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.3.0.tgz",
+      "integrity": "sha512-SlLSF4Be735yQXyh2+mctBOzNDx5s5uLv88/j8Qn1wH679PDcwy67+YdADn8NJnGjzlXtN62asGH/T4vWOkfaw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/fake-timers": "30.3.0",
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "jest-mock": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-runner/node_modules/@jest/fake-timers": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.3.0.tgz",
+      "integrity": "sha512-WUQDs8SOP9URStX1DzhD425CqbN/HxUYCTwVrT8sTVBfMvFqYt/s61EK5T05qnHu0po6RitXIvP9otZxYDzTGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@sinonjs/fake-timers": "^15.0.0",
+        "@types/node": "*",
+        "jest-message-util": "30.3.0",
+        "jest-mock": "30.3.0",
+        "jest-util": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-runner/node_modules/@jest/types": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
+      "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/pattern": "30.0.1",
+        "@jest/schemas": "30.0.5",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-runner/node_modules/@sinonjs/fake-timers": {
+      "version": "15.3.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.3.2.tgz",
+      "integrity": "sha512-mrn35Jl2pCpns+mE3HaZa1yPN5EYCRgiMI+135COjr2hr8Cls9DXqIZ57vZe2cz7y2XVSq92tcs6kGQcT1J8Rw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1"
+      }
+    },
+    "node_modules/jest-runner/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-runner/node_modules/jest-message-util": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.3.0.tgz",
+      "integrity": "sha512-Z/j4Bo+4ySJ+JPJN3b2Qbl9hDq3VrXmnjjGEWD/x0BCXeOXPTV1iZYYzl2X8c1MaCOL+ewMyNBcm88sboE6YWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@jest/types": "30.3.0",
+        "@types/stack-utils": "^2.0.3",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3",
+        "pretty-format": "30.3.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.6"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-runner/node_modules/jest-mock": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.3.0.tgz",
+      "integrity": "sha512-OTzICK8CpE+t4ndhKrwlIdbM6Pn8j00lvmSmq5ejiO+KxukbLjgOflKWMn3KE34EZdQm5RqTuKj+5RIEniYhog==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "jest-util": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-runner/node_modules/jest-util": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
+      "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -8469,6 +8304,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/jest-runner/node_modules/pretty-format": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz",
+      "integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.0.5",
+        "ansi-styles": "^5.2.0",
+        "react-is": "^18.3.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
     "node_modules/jest-runner/node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -8482,31 +8331,31 @@
       }
     },
     "node_modules/jest-runtime": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.2.0.tgz",
-      "integrity": "sha512-p1+GVX/PJqTucvsmERPMgCPvQJpFt4hFbM+VN3n8TMo47decMUcJbt+rgzwrEme0MQUA/R+1de2axftTHkKckg==",
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.3.0.tgz",
+      "integrity": "sha512-CgC+hIBJbuh78HEffkhNKcbXAytQViplcl8xupqeIWyKQF50kCQA8J7GeJCkjisC6hpnC9Muf8jV5RdtdFbGng==",
       "license": "MIT",
       "dependencies": {
-        "@jest/environment": "30.2.0",
-        "@jest/fake-timers": "30.2.0",
-        "@jest/globals": "30.2.0",
+        "@jest/environment": "30.3.0",
+        "@jest/fake-timers": "30.3.0",
+        "@jest/globals": "30.3.0",
         "@jest/source-map": "30.0.1",
-        "@jest/test-result": "30.2.0",
-        "@jest/transform": "30.2.0",
-        "@jest/types": "30.2.0",
+        "@jest/test-result": "30.3.0",
+        "@jest/transform": "30.3.0",
+        "@jest/types": "30.3.0",
         "@types/node": "*",
         "chalk": "^4.1.2",
         "cjs-module-lexer": "^2.1.0",
         "collect-v8-coverage": "^1.0.2",
-        "glob": "^10.3.10",
+        "glob": "^10.5.0",
         "graceful-fs": "^4.2.11",
-        "jest-haste-map": "30.2.0",
-        "jest-message-util": "30.2.0",
-        "jest-mock": "30.2.0",
+        "jest-haste-map": "30.3.0",
+        "jest-message-util": "30.3.0",
+        "jest-mock": "30.3.0",
         "jest-regex-util": "30.0.1",
-        "jest-resolve": "30.2.0",
-        "jest-snapshot": "30.2.0",
-        "jest-util": "30.2.0",
+        "jest-resolve": "30.3.0",
+        "jest-snapshot": "30.3.0",
+        "jest-util": "30.3.0",
         "slash": "^3.0.0",
         "strip-bom": "^4.0.0"
       },
@@ -8514,10 +8363,81 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
+    "node_modules/jest-runtime/node_modules/@jest/environment": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.3.0.tgz",
+      "integrity": "sha512-SlLSF4Be735yQXyh2+mctBOzNDx5s5uLv88/j8Qn1wH679PDcwy67+YdADn8NJnGjzlXtN62asGH/T4vWOkfaw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/fake-timers": "30.3.0",
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "jest-mock": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/@jest/fake-timers": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.3.0.tgz",
+      "integrity": "sha512-WUQDs8SOP9URStX1DzhD425CqbN/HxUYCTwVrT8sTVBfMvFqYt/s61EK5T05qnHu0po6RitXIvP9otZxYDzTGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@sinonjs/fake-timers": "^15.0.0",
+        "@types/node": "*",
+        "jest-message-util": "30.3.0",
+        "jest-mock": "30.3.0",
+        "jest-util": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/@jest/types": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
+      "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/pattern": "30.0.1",
+        "@jest/schemas": "30.0.5",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/@sinonjs/fake-timers": {
+      "version": "15.3.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.3.2.tgz",
+      "integrity": "sha512-mrn35Jl2pCpns+mE3HaZa1yPN5EYCRgiMI+135COjr2hr8Cls9DXqIZ57vZe2cz7y2XVSq92tcs6kGQcT1J8Rw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/jest-runtime/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -8527,6 +8447,7 @@
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
       "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
@@ -8541,6 +8462,57 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/jest-message-util": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.3.0.tgz",
+      "integrity": "sha512-Z/j4Bo+4ySJ+JPJN3b2Qbl9hDq3VrXmnjjGEWD/x0BCXeOXPTV1iZYYzl2X8c1MaCOL+ewMyNBcm88sboE6YWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@jest/types": "30.3.0",
+        "@types/stack-utils": "^2.0.3",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3",
+        "pretty-format": "30.3.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.6"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/jest-mock": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.3.0.tgz",
+      "integrity": "sha512-OTzICK8CpE+t4ndhKrwlIdbM6Pn8j00lvmSmq5ejiO+KxukbLjgOflKWMn3KE34EZdQm5RqTuKj+5RIEniYhog==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "jest-util": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/jest-util": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
+      "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-runtime/node_modules/minimatch": {
@@ -8558,10 +8530,24 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/jest-runtime/node_modules/pretty-format": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz",
+      "integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.0.5",
+        "ansi-styles": "^5.2.0",
+        "react-is": "^18.3.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
     "node_modules/jest-snapshot": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.2.0.tgz",
-      "integrity": "sha512-5WEtTy2jXPFypadKNpbNkZ72puZCa6UjSr/7djeecHWOu7iYhSXSnHScT8wBz3Rn8Ena5d5RYRcsyKIeqG1IyA==",
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.3.0.tgz",
+      "integrity": "sha512-f14c7atpb4O2DeNhwcvS810Y63wEn8O1HqK/luJ4F6M4NjvxmAKQwBUWjbExUtMxWJQ0wVgmCKymeJK6NZMnfQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.27.4",
@@ -8569,20 +8555,20 @@
         "@babel/plugin-syntax-jsx": "^7.27.1",
         "@babel/plugin-syntax-typescript": "^7.27.1",
         "@babel/types": "^7.27.3",
-        "@jest/expect-utils": "30.2.0",
+        "@jest/expect-utils": "30.3.0",
         "@jest/get-type": "30.1.0",
-        "@jest/snapshot-utils": "30.2.0",
-        "@jest/transform": "30.2.0",
-        "@jest/types": "30.2.0",
+        "@jest/snapshot-utils": "30.3.0",
+        "@jest/transform": "30.3.0",
+        "@jest/types": "30.3.0",
         "babel-preset-current-node-syntax": "^1.2.0",
         "chalk": "^4.1.2",
-        "expect": "30.2.0",
+        "expect": "30.3.0",
         "graceful-fs": "^4.2.11",
-        "jest-diff": "30.2.0",
-        "jest-matcher-utils": "30.2.0",
-        "jest-message-util": "30.2.0",
-        "jest-util": "30.2.0",
-        "pretty-format": "30.2.0",
+        "jest-diff": "30.3.0",
+        "jest-matcher-utils": "30.3.0",
+        "jest-message-util": "30.3.0",
+        "jest-util": "30.3.0",
+        "pretty-format": "30.3.0",
         "semver": "^7.7.2",
         "synckit": "^0.11.8"
       },
@@ -8590,38 +8576,132 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
-    "node_modules/jest-util": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
-      "integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
+    "node_modules/jest-snapshot/node_modules/@jest/types": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
+      "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
       "license": "MIT",
       "dependencies": {
-        "@jest/types": "30.2.0",
+        "@jest/pattern": "30.0.1",
+        "@jest/schemas": "30.0.5",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/jest-message-util": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.3.0.tgz",
+      "integrity": "sha512-Z/j4Bo+4ySJ+JPJN3b2Qbl9hDq3VrXmnjjGEWD/x0BCXeOXPTV1iZYYzl2X8c1MaCOL+ewMyNBcm88sboE6YWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@jest/types": "30.3.0",
+        "@types/stack-utils": "^2.0.3",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3",
+        "pretty-format": "30.3.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.6"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/jest-util": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
+      "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.3.0",
         "@types/node": "*",
         "chalk": "^4.1.2",
         "ci-info": "^4.2.0",
         "graceful-fs": "^4.2.11",
-        "picomatch": "^4.0.2"
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/pretty-format": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz",
+      "integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.0.5",
+        "ansi-styles": "^5.2.0",
+        "react-is": "^18.3.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-validate": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-30.2.0.tgz",
-      "integrity": "sha512-FBGWi7dP2hpdi8nBoWxSsLvBFewKAg0+uSQwBaof4Y4DPgBabXgpSYC5/lR7VmnIlSpASmCi/ntRWPbv7089Pw==",
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-30.3.0.tgz",
+      "integrity": "sha512-I/xzC8h5G+SHCb2P2gWkJYrNiTbeL47KvKeW5EzplkyxzBRBw1ssSHlI/jXec0ukH2q7x2zAWQm7015iusg62Q==",
       "license": "MIT",
       "dependencies": {
         "@jest/get-type": "30.1.0",
-        "@jest/types": "30.2.0",
+        "@jest/types": "30.3.0",
         "camelcase": "^6.3.0",
         "chalk": "^4.1.2",
         "leven": "^3.1.0",
-        "pretty-format": "30.2.0"
+        "pretty-format": "30.3.0"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-validate/node_modules/@jest/types": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
+      "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/pattern": "30.0.1",
+        "@jest/schemas": "30.0.5",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-validate/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest-validate/node_modules/camelcase": {
@@ -8636,36 +8716,120 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/jest-watcher": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.2.0.tgz",
-      "integrity": "sha512-PYxa28dxJ9g777pGm/7PrbnMeA0Jr7osHP9bS7eJy9DuAjMgdGtxgf0uKMyoIsTWAkIbUW5hSDdJ3urmgXBqxg==",
+    "node_modules/jest-validate/node_modules/pretty-format": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz",
+      "integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
       "license": "MIT",
       "dependencies": {
-        "@jest/test-result": "30.2.0",
-        "@jest/types": "30.2.0",
+        "@jest/schemas": "30.0.5",
+        "ansi-styles": "^5.2.0",
+        "react-is": "^18.3.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-watcher": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.3.0.tgz",
+      "integrity": "sha512-PJ1d9ThtTR8aMiBWUdcownq9mDdLXsQzJayTk4kmaBRHKvwNQn+ANveuhEBUyNI2hR1TVhvQ8D5kHubbzBHR/w==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "30.3.0",
+        "@jest/types": "30.3.0",
         "@types/node": "*",
         "ansi-escapes": "^4.3.2",
         "chalk": "^4.1.2",
         "emittery": "^0.13.1",
-        "jest-util": "30.2.0",
+        "jest-util": "30.3.0",
         "string-length": "^4.0.2"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
+    "node_modules/jest-watcher/node_modules/@jest/types": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
+      "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/pattern": "30.0.1",
+        "@jest/schemas": "30.0.5",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-watcher/node_modules/jest-util": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
+      "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
     "node_modules/jest-worker": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-30.2.0.tgz",
-      "integrity": "sha512-0Q4Uk8WF7BUwqXHuAjc23vmopWJw5WH7w2tqBoUOZpOjW/ZnR44GXXd1r82RvnmI2GZge3ivrYXk/BE2+VtW2g==",
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-30.3.0.tgz",
+      "integrity": "sha512-DrCKkaQwHexjRUFTmPzs7sHQe0TSj9nvDALKGdwmK5mW9v7j90BudWirKAJHt3QQ9Dhrg1F7DogPzhChppkJpQ==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
         "@ungap/structured-clone": "^1.3.0",
-        "jest-util": "30.2.0",
+        "jest-util": "30.3.0",
         "merge-stream": "^2.0.0",
         "supports-color": "^8.1.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-worker/node_modules/@jest/types": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
+      "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/pattern": "30.0.1",
+        "@jest/schemas": "30.0.5",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-worker/node_modules/jest-util": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
+      "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -8686,23 +8850,35 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/jest/node_modules/@jest/types": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
+      "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/pattern": "30.0.1",
+        "@jest/schemas": "30.0.5",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
     "node_modules/js-cookie": {
       "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
-      "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
     },
     "node_modules/js-yaml": {
       "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -8714,8 +8890,6 @@
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
-      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
       "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
@@ -8726,51 +8900,31 @@
     },
     "node_modules/json-buffer": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/json-parse-better-errors": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/json-stable-stringify-without-jsonify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
       "dev": true,
       "license": "ISC",
       "optional": true
     },
     "node_modules/json5": {
       "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"
@@ -8781,8 +8935,6 @@
     },
     "node_modules/jsonfile": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
       "dev": true,
       "license": "MIT",
       "optionalDependencies": {
@@ -8791,8 +8943,6 @@
     },
     "node_modules/keyv": {
       "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
-      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8801,8 +8951,6 @@
     },
     "node_modules/kind-of": {
       "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8811,8 +8959,6 @@
     },
     "node_modules/level-blobs": {
       "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/level-blobs/-/level-blobs-0.1.7.tgz",
-      "integrity": "sha512-n0iYYCGozLd36m/Pzm206+brIgXP8mxPZazZ6ZvgKr+8YwOZ8/PPpYC5zMUu2qFygRN8RO6WC/HH3XWMW7RMVg==",
       "dev": true,
       "dependencies": {
         "level-peek": "1.0.6",
@@ -8822,15 +8968,11 @@
     },
     "node_modules/level-blobs/node_modules/isarray": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/level-blobs/node_modules/readable-stream": {
       "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-      "integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8842,15 +8984,11 @@
     },
     "node_modules/level-blobs/node_modules/string_decoder": {
       "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/level-filesystem": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/level-filesystem/-/level-filesystem-1.2.0.tgz",
-      "integrity": "sha512-PhXDuCNYpngpxp3jwMT9AYBMgOvB6zxj3DeuIywNKmZqFj2djj9XfT2XDVslfqmo0Ip79cAd3SBy3FsfOZPJ1g==",
       "dev": true,
       "dependencies": {
         "concat-stream": "^1.4.4",
@@ -8866,15 +9004,11 @@
     },
     "node_modules/level-fix-range": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/level-fix-range/-/level-fix-range-1.0.2.tgz",
-      "integrity": "sha512-9llaVn6uqBiSlBP+wKiIEoBa01FwEISFgHSZiyec2S0KpyLUkGR4afW/FCZ/X8y+QJvzS0u4PGOlZDdh1/1avQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/level-hooks": {
       "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/level-hooks/-/level-hooks-4.5.0.tgz",
-      "integrity": "sha512-fxLNny/vL/G4PnkLhWsbHnEaRi+A/k8r5EH/M77npZwYL62RHi2fV0S824z3QdpAk6VTgisJwIRywzBHLK4ZVA==",
       "dev": true,
       "dependencies": {
         "string-range": "~1.2"
@@ -8882,9 +9016,6 @@
     },
     "node_modules/level-js": {
       "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/level-js/-/level-js-2.2.4.tgz",
-      "integrity": "sha512-lZtjt4ZwHE00UMC1vAb271p9qzg8vKlnDeXfIesH3zL0KxhHRDjClQLGLWhyR0nK4XARnd4wc/9eD1ffd4PshQ==",
-      "deprecated": "Superseded by browser-level (https://github.com/Level/community#faq)",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -8898,15 +9029,11 @@
     },
     "node_modules/level-js/node_modules/object-keys": {
       "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
-      "integrity": "sha512-ncrLw+X55z7bkl5PnUvHwFK9FcGuFYo9gtjws2XtSzL+aZ8tm830P60WJ0dSmFVaSalWieW5MD7kEdnXda9yJw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/level-js/node_modules/xtend": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-      "integrity": "sha512-vMNKzr2rHP9Dp/e1NQFnLQlwlhp9L/LfvnsVdHxN1f+uggyVI3i08uD14GPvCToPkdsRfyPqIyYGmIk58V98ZQ==",
       "dev": true,
       "dependencies": {
         "object-keys": "~0.4.0"
@@ -8917,8 +9044,6 @@
     },
     "node_modules/level-peek": {
       "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/level-peek/-/level-peek-1.0.6.tgz",
-      "integrity": "sha512-TKEzH5TxROTjQxWMczt9sizVgnmJ4F3hotBI48xCTYvOKd/4gA/uY0XjKkhJFo6BMic8Tqjf6jFMLWeg3MAbqQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8927,8 +9052,6 @@
     },
     "node_modules/level-sublevel": {
       "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/level-sublevel/-/level-sublevel-5.2.3.tgz",
-      "integrity": "sha512-tO8jrFp+QZYrxx/Gnmjawuh1UBiifpvKNAcm4KCogesWr1Nm2+ckARitf+Oo7xg4OHqMW76eAqQ204BoIlscjA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8940,8 +9063,6 @@
     },
     "node_modules/level-sublevel/node_modules/level-fix-range": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/level-fix-range/-/level-fix-range-2.0.0.tgz",
-      "integrity": "sha512-WrLfGWgwWbYPrHsYzJau+5+te89dUbENBg3/lsxOs4p2tYOhCHjbgXxBAj4DFqp3k/XBwitcRXoCh8RoCogASA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8950,9 +9071,6 @@
     },
     "node_modules/level-sublevel/node_modules/object-keys": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.2.0.tgz",
-      "integrity": "sha512-XODjdR2pBh/1qrjPcbSeSgEtKbYo7LqYNq64/TPuCf7j9SfDD3i21yatKoIy39yIWNvVM59iutfQQpCv1RfFzA==",
-      "deprecated": "Please update to the latest object-keys",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8963,8 +9081,6 @@
     },
     "node_modules/level-sublevel/node_modules/xtend": {
       "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.0.6.tgz",
-      "integrity": "sha512-fOZg4ECOlrMl+A6Msr7EIFcON1L26mb4NY5rurSkOex/TWhazOrg6eXD/B0XkuiYcYhQDWLXzQxLMVJ7LXwokg==",
       "dev": true,
       "dependencies": {
         "is-object": "~0.1.2",
@@ -8976,9 +9092,6 @@
     },
     "node_modules/levelup": {
       "version": "0.18.6",
-      "resolved": "https://registry.npmjs.org/levelup/-/levelup-0.18.6.tgz",
-      "integrity": "sha512-uB0auyRqIVXx+hrpIUtol4VAPhLRcnxcOsd2i2m6rbFIDarO5dnrupLOStYYpEcu8ZT087Z9HEuYw1wjr6RL6Q==",
-      "deprecated": "Superseded by abstract-level (https://github.com/Level/community#faq)",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8993,22 +9106,16 @@
     },
     "node_modules/levelup/node_modules/isarray": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/levelup/node_modules/prr": {
       "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
-      "integrity": "sha512-LmUECmrW7RVj6mDWKjTXfKug7TFGdiz9P18HMcO4RHL+RW7MCOGNvpj5j47Rnp6ne6r4fZ2VzyUWEpKbg+tsjQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/levelup/node_modules/readable-stream": {
       "version": "1.0.34",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-      "integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9020,8 +9127,6 @@
     },
     "node_modules/levelup/node_modules/semver": {
       "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz",
-      "integrity": "sha512-abLdIKCosKfpnmhS52NCTjO4RiLspDfsn37prjzGrp9im5DPJOgh82Os92vtwGh6XdQryKI/7SREZnV+aqiXrA==",
       "dev": true,
       "license": "BSD",
       "bin": {
@@ -9030,15 +9135,11 @@
     },
     "node_modules/levelup/node_modules/string_decoder": {
       "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/levelup/node_modules/xtend": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
-      "integrity": "sha512-sp/sT9OALMjRW1fKDlPeuSZlDQpkqReA0pyJukniWbTGoEKefHxhGJynE3PNhUMlcM8qWIjPwecwCw4LArS5Eg==",
       "dev": true,
       "engines": {
         "node": ">=0.4"
@@ -9051,21 +9152,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/levn": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
-      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "prelude-ls": "^1.2.1",
-        "type-check": "~0.4.0"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
       }
     },
     "node_modules/lines-and-columns": {
@@ -9086,8 +9172,6 @@
     },
     "node_modules/load-json-file": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
-      "integrity": "sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9102,8 +9186,6 @@
     },
     "node_modules/load-json-file/node_modules/parse-json": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-      "integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9116,8 +9198,6 @@
     },
     "node_modules/load-json-file/node_modules/strip-bom": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9126,8 +9206,6 @@
     },
     "node_modules/loader-runner": {
       "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.1.tgz",
-      "integrity": "sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9140,8 +9218,6 @@
     },
     "node_modules/loader-utils": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
-      "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9155,8 +9231,6 @@
     },
     "node_modules/locate-path": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
       "license": "MIT",
       "dependencies": {
         "p-locate": "^4.1.0"
@@ -9166,30 +9240,16 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.17.23",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
-      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
       "license": "MIT"
-    },
-    "node_modules/lodash.merge": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9201,8 +9261,6 @@
     },
     "node_modules/lower-case": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
-      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9211,8 +9269,6 @@
     },
     "node_modules/lowercase-keys": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
-      "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9221,8 +9277,6 @@
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
@@ -9230,15 +9284,11 @@
     },
     "node_modules/ltgt": {
       "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
-      "integrity": "sha512-AI2r85+4MquTw9ZYqabu4nMwy9Oftlfa/e/52t9IjtfG+mGBbTNdAoZ3RQKLHR6r0wQnwZnPIEh/Ya6XTWAKNA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/lunr": {
       "version": "2.3.9",
-      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
-      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
       "dev": true,
       "license": "MIT"
     },
@@ -9259,14 +9309,10 @@
     },
     "node_modules/make-error": {
       "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "license": "ISC"
     },
     "node_modules/makeerror": {
       "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
-      "integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "tmpl": "1.0.5"
@@ -9274,14 +9320,12 @@
     },
     "node_modules/map-stream": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
-      "integrity": "sha512-CkYQrPYZfWnu/DAmVCpTSX/xHpKZ80eKh2lAkyA6AJTef6bW+6JpbQZN5rofum7da+SyN1bi5ctTm+lTfcCW3g==",
       "dev": true
     },
     "node_modules/markdown-it": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
-      "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
+      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9318,8 +9362,6 @@
     },
     "node_modules/matcher": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
-      "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -9332,8 +9374,6 @@
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9342,8 +9382,6 @@
     },
     "node_modules/mdn-data": {
       "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
-      "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
       "dev": true,
       "license": "CC0-1.0"
     },
@@ -9356,8 +9394,6 @@
     },
     "node_modules/memorystream": {
       "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
-      "integrity": "sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==",
       "dev": true,
       "engines": {
         "node": ">= 0.10.0"
@@ -9365,14 +9401,11 @@
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
-      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -9383,9 +9416,8 @@
       }
     },
     "node_modules/micromatch/node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "version": "2.3.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -9396,8 +9428,6 @@
     },
     "node_modules/mime-db": {
       "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9406,8 +9436,6 @@
     },
     "node_modules/mime-types": {
       "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9419,8 +9447,6 @@
     },
     "node_modules/mimic-fn": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -9428,8 +9454,6 @@
     },
     "node_modules/mimic-response": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9437,9 +9461,9 @@
       }
     },
     "node_modules/mini-css-extract-plugin": {
-      "version": "2.9.4",
-      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.9.4.tgz",
-      "integrity": "sha512-ZWYT7ln73Hptxqxk2DxPU9MmapXRhxkJD6tkSR04dnQxm8BGu2hzgKLugK5yySD97u/8yy7Ma7E76k9ZdvtjkQ==",
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.10.2.tgz",
+      "integrity": "sha512-AOSS0IdEB95ayVkxn5oGzNQwqAi2J0Jb/kKm43t7H73s8+f5873g0yuj0PNvK4dO75mu5DHg4nlgp4k6Kga8eg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9471,8 +9495,6 @@
     },
     "node_modules/minimist": {
       "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -9480,8 +9502,6 @@
     },
     "node_modules/minipass": {
       "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
       "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -9489,14 +9509,10 @@
     },
     "node_modules/monaco-editor": {
       "version": "0.52.2",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.2.tgz",
-      "integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==",
       "license": "MIT"
     },
     "node_modules/monaco-editor-webpack-plugin": {
       "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/monaco-editor-webpack-plugin/-/monaco-editor-webpack-plugin-7.1.1.tgz",
-      "integrity": "sha512-WxdbFHS3Wtz4V9hzhe/Xog5hQRSMxmDLkEEYZwqMDHgJlkZo00HVFZR0j5d0nKypjTUkkygH3dDSXERLG4757A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9509,14 +9525,10 @@
     },
     "node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
     "node_modules/nano-css": {
       "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/nano-css/-/nano-css-5.6.2.tgz",
-      "integrity": "sha512-+6bHaC8dSDGALM1HJjOHVXpuastdu2xFoZlC77Jh4cg+33Zcgm+Gxd+1xsnpZK14eyHObSp82+ll5y3SX75liw==",
       "dev": true,
       "license": "Unlicense",
       "dependencies": {
@@ -9536,8 +9548,6 @@
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
       "dev": true,
       "funding": [
         {
@@ -9555,8 +9565,6 @@
     },
     "node_modules/napi-postinstall": {
       "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.4.tgz",
-      "integrity": "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==",
       "license": "MIT",
       "bin": {
         "napi-postinstall": "lib/cli.js"
@@ -9570,37 +9578,19 @@
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "license": "MIT"
-    },
-    "node_modules/negotiator": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
-      "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
     },
     "node_modules/neo-async": {
       "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "license": "MIT"
     },
     "node_modules/nice-try": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/no-case": {
       "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
-      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9610,35 +9600,25 @@
     },
     "node_modules/node-addon-api": {
       "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
-      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
       "dev": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/node-cleanup": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/node-cleanup/-/node-cleanup-2.1.2.tgz",
-      "integrity": "sha512-qN8v/s2PAJwGUtr1/hYTpNKlD6Y9rc4p8KSmJXyGdYGZsDGKXrGThikLFP9OCHFeLeEpQzPwiAtdIvBLqm//Hw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/node-int64": {
       "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
-      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
       "license": "MIT"
     },
     "node_modules/node-releases": {
       "version": "2.0.27",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
-      "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
       "license": "MIT"
     },
     "node_modules/normalize-package-data": {
       "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
-      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -9650,8 +9630,6 @@
     },
     "node_modules/normalize-package-data/node_modules/semver": {
       "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -9660,8 +9638,6 @@
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -9669,8 +9645,6 @@
     },
     "node_modules/normalize-url": {
       "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
-      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9682,8 +9656,6 @@
     },
     "node_modules/npm-run-all": {
       "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/npm-run-all/-/npm-run-all-4.1.5.tgz",
-      "integrity": "sha512-Oo82gJDAVcaMdi3nuoKFavkIHBRVqQ1qvMb+9LHk/cF4P6B2m8aP04hGf7oL6wZ9BuGwX1onlLhpuoofSyoQDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9708,8 +9680,6 @@
     },
     "node_modules/npm-run-all/node_modules/ansi-styles": {
       "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9721,8 +9691,6 @@
     },
     "node_modules/npm-run-all/node_modules/chalk": {
       "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9736,8 +9704,6 @@
     },
     "node_modules/npm-run-all/node_modules/color-convert": {
       "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9746,15 +9712,11 @@
     },
     "node_modules/npm-run-all/node_modules/color-name": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/npm-run-all/node_modules/cross-spawn": {
       "version": "6.0.6",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.6.tgz",
-      "integrity": "sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9770,8 +9732,6 @@
     },
     "node_modules/npm-run-all/node_modules/escape-string-regexp": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9780,8 +9740,6 @@
     },
     "node_modules/npm-run-all/node_modules/has-flag": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9790,8 +9748,6 @@
     },
     "node_modules/npm-run-all/node_modules/path-key": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9800,8 +9756,6 @@
     },
     "node_modules/npm-run-all/node_modules/semver": {
       "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -9810,8 +9764,6 @@
     },
     "node_modules/npm-run-all/node_modules/shebang-command": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-      "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9823,8 +9775,6 @@
     },
     "node_modules/npm-run-all/node_modules/shebang-regex": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9833,8 +9783,6 @@
     },
     "node_modules/npm-run-all/node_modules/supports-color": {
       "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9846,8 +9794,6 @@
     },
     "node_modules/npm-run-all/node_modules/which": {
       "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -9871,8 +9817,6 @@
     },
     "node_modules/nth-check": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
-      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -9884,8 +9828,6 @@
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9894,8 +9836,6 @@
     },
     "node_modules/object-inspect": {
       "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
-      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9907,8 +9847,6 @@
     },
     "node_modules/object-keys": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9917,8 +9855,6 @@
     },
     "node_modules/object.assign": {
       "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
-      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9938,8 +9874,6 @@
     },
     "node_modules/object.fromentries": {
       "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.8.tgz",
-      "integrity": "sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9957,8 +9891,6 @@
     },
     "node_modules/object.groupby": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/object.groupby/-/object.groupby-1.0.3.tgz",
-      "integrity": "sha512-+Lhy3TQTuzXI5hevh8sBGqbmurHbbIjAi0Z4S63nthVLmLxfbj4T54a4CfZrXIrt9iP4mVAPYMo/v99taj3wjQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9972,8 +9904,6 @@
     },
     "node_modules/object.values": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.2.1.tgz",
-      "integrity": "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9991,15 +9921,11 @@
     },
     "node_modules/octal": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/octal/-/octal-1.0.0.tgz",
-      "integrity": "sha512-nnda7W8d+A3vEIY+UrDQzzboPf1vhs4JYVhff5CDkq9QNoZY7Xrxeo/htox37j9dZf7yNHevZzqtejWgy1vCqQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/ometa": {
       "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/ometa/-/ometa-0.2.2.tgz",
-      "integrity": "sha512-LZuoK/yjU3FvrxPjUXUlZ1bavCfBPqauA7fsNdwi+AVhRdyk2IzgP3JRnevvjzQ6fKHdUw8YISshf53FmpHrng==",
       "dev": true,
       "engines": {
         "node": ">= 0.2.0"
@@ -10007,8 +9933,6 @@
     },
     "node_modules/on-headers": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
-      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10017,8 +9941,6 @@
     },
     "node_modules/once": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -10026,8 +9948,6 @@
     },
     "node_modules/onetime": {
       "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
       "license": "MIT",
       "dependencies": {
         "mimic-fn": "^2.1.0"
@@ -10039,29 +9959,8 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/optionator": {
-      "version": "0.9.4",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
-      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "deep-is": "^0.1.3",
-        "fast-levenshtein": "^2.0.6",
-        "levn": "^0.4.1",
-        "prelude-ls": "^1.2.1",
-        "type-check": "^0.4.0",
-        "word-wrap": "^1.2.5"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
     "node_modules/own-keys": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
-      "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10078,8 +9977,6 @@
     },
     "node_modules/p-cancelable": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
-      "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10103,8 +10000,6 @@
     },
     "node_modules/p-locate": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
       "license": "MIT",
       "dependencies": {
         "p-limit": "^2.2.0"
@@ -10115,8 +10010,6 @@
     },
     "node_modules/p-locate/node_modules/p-limit": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
       "license": "MIT",
       "dependencies": {
         "p-try": "^2.0.0"
@@ -10130,8 +10023,6 @@
     },
     "node_modules/p-try": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -10139,30 +10030,15 @@
     },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
-      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "license": "BlueOak-1.0.0"
     },
     "node_modules/param-case": {
       "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
-      "integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "dot-case": "^3.0.4",
         "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/parent-module": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
-      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "path-platform": "~0.11.15"
       }
     },
     "node_modules/parse-json": {
@@ -10185,8 +10061,6 @@
     },
     "node_modules/pascal-case": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
-      "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10196,15 +10070,11 @@
     },
     "node_modules/path-browserify": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
-      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -10212,8 +10082,6 @@
     },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -10228,8 +10096,6 @@
     },
     "node_modules/path-key": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -10237,26 +10103,11 @@
     },
     "node_modules/path-parse": {
       "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/path-platform": {
-      "version": "0.11.15",
-      "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz",
-      "integrity": "sha512-Y30dB6rab1A/nfEKsZxmr01nUotHX0c/ZiIAsCTatEe1CmS5Pm5He7fZ195bPT7RdquoaL8lLxFCMQi/bS7IJg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
     "node_modules/path-scurry": {
       "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^10.2.0",
@@ -10271,21 +10122,10 @@
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
       "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "license": "ISC"
-    },
-    "node_modules/path-to-regexp": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-3.3.0.tgz",
-      "integrity": "sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/pause-stream": {
       "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
-      "integrity": "sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==",
       "dev": true,
       "license": [
         "MIT",
@@ -10297,21 +10137,15 @@
     },
     "node_modules/pend": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
-      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.3",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -10322,8 +10156,6 @@
     },
     "node_modules/pidtree": {
       "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.3.1.tgz",
-      "integrity": "sha512-qQbW94hLHEqCg7nhby4yRC7G2+jYHY4Rguc2bjw7Uug4GIJuu1tvf2uHaZv5Q8zdt+WKJ6qK1FOI6amaWUo5FA==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -10335,8 +10167,6 @@
     },
     "node_modules/pify": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-      "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10345,8 +10175,6 @@
     },
     "node_modules/pirates": {
       "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
-      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -10354,8 +10182,6 @@
     },
     "node_modules/pkg-dir": {
       "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
       "license": "MIT",
       "dependencies": {
         "find-up": "^4.0.0"
@@ -10366,8 +10192,6 @@
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
-      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10376,8 +10200,6 @@
     },
     "node_modules/postcss": {
       "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
       "dev": true,
       "funding": [
         {
@@ -10405,8 +10227,6 @@
     },
     "node_modules/postcss-modules-extract-imports": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.1.0.tgz",
-      "integrity": "sha512-k3kNe0aNFQDAZGbin48pL2VNidTF0w4/eASDsxlyspobzU3wZQLOGj7L9gfRe0Jo9/4uud09DsjFNH7winGv8Q==",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -10418,8 +10238,6 @@
     },
     "node_modules/postcss-modules-local-by-default": {
       "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.2.0.tgz",
-      "integrity": "sha512-5kcJm/zk+GJDSfw+V/42fJ5fhjL5YbFDl8nVdXkJPLLW+Vf9mTD5Xe0wqIaDnLuL2U6cDNpTr+UQ+v2HWIBhzw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10436,8 +10254,6 @@
     },
     "node_modules/postcss-modules-scope": {
       "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-3.2.1.tgz",
-      "integrity": "sha512-m9jZstCVaqGjTAuny8MdgE88scJnCiQSlSrOWcTQgM2t32UBe+MUmFSO5t7VMSfAf/FJKImAxBav8ooCHJXCJA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -10452,8 +10268,6 @@
     },
     "node_modules/postcss-modules-values": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-4.0.0.tgz",
-      "integrity": "sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -10468,8 +10282,6 @@
     },
     "node_modules/postcss-selector-parser": {
       "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
-      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10482,26 +10294,11 @@
     },
     "node_modules/postcss-value-parser": {
       "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
-      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/prelude-ls": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
-      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
     "node_modules/pretty-error": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-4.0.0.tgz",
-      "integrity": "sha512-AoJ5YMAcXKYxKhuJGdcvse+Voc6v1RgnsR3nWcYU7q4t6z0Q6T86sv5Zq8VIRbOWWFpvdGE83LtdSMNd+6Y0xw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10511,8 +10308,6 @@
     },
     "node_modules/pretty-format": {
       "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
-      "integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
       "license": "MIT",
       "dependencies": {
         "@jest/schemas": "30.0.5",
@@ -10525,8 +10320,6 @@
     },
     "node_modules/pretty-format/node_modules/ansi-styles": {
       "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -10537,8 +10330,6 @@
     },
     "node_modules/pretty-time": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/pretty-time/-/pretty-time-1.1.0.tgz",
-      "integrity": "sha512-28iF6xPQrP8Oa6uxE6a1biz+lWeTOAPKggvjB8HAs6nVMKZwf5bG++632Dx614hIWgUPkgivRfG+a8uAXGTIbA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10547,15 +10338,11 @@
     },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/progress": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10564,8 +10351,6 @@
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10576,8 +10361,6 @@
     },
     "node_modules/prop-types-extra": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/prop-types-extra/-/prop-types-extra-1.1.1.tgz",
-      "integrity": "sha512-59+AHNnHYCdiC+vMwY52WmvP5dM3QLeoumYuEyceQDi9aEhtwN9zIQ2ZNo25sMyXnbh32h+P1ezDsUpUH3JAew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10590,29 +10373,21 @@
     },
     "node_modules/prop-types-extra/node_modules/react-is": {
       "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/prop-types/node_modules/react-is": {
       "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/prr": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-      "integrity": "sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/ps-tree": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.2.0.tgz",
-      "integrity": "sha512-0VnamPPYHl4uaU/nSFeZZpR21QAWRz+sRv4iW9+v/GS/J5U5iZB5BNN6J0RMoOvdx2gWM2+ZFMIm58q24e4UYA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10627,8 +10402,6 @@
     },
     "node_modules/pump": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
-      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10638,8 +10411,6 @@
     },
     "node_modules/punycode": {
       "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
-      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10674,8 +10445,6 @@
     },
     "node_modules/quick-lru": {
       "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
-      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10687,28 +10456,14 @@
     },
     "node_modules/randombytes": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "^5.1.0"
       }
     },
-    "node_modules/range-parser": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
-      "integrity": "sha512-kA5WQoNVo4t9lNx2kQNFCxKeBl5IbbSNBl1M/tLkw9WCn+hxNBAW5Qh8gdhs63CJnhjJ2zQWFoqPJP2sK1AV5A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/raw-loader": {
       "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/raw-loader/-/raw-loader-4.0.2.tgz",
-      "integrity": "sha512-ZnScIV3ag9A4wPX/ZayxL/jZH+euYb6FcUinPcgiQW0+UBtEv0O6Q3lGd3cqJ+GHH+rksEv3Pj99oxJ3u3VIKA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10728,8 +10483,6 @@
     },
     "node_modules/raw-loader/node_modules/ajv": {
       "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10745,8 +10498,6 @@
     },
     "node_modules/raw-loader/node_modules/ajv-keywords": {
       "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -10755,15 +10506,11 @@
     },
     "node_modules/raw-loader/node_modules/json-schema-traverse": {
       "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/raw-loader/node_modules/schema-utils": {
       "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
-      "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10806,9 +10553,9 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
-      "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
+      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10817,8 +10564,6 @@
     },
     "node_modules/react-bootstrap": {
       "version": "2.10.10",
-      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-2.10.10.tgz",
-      "integrity": "sha512-gMckKUqn8aK/vCnfwoBpBVFUGT9SVQxwsYrp9yDHt0arXMamxALerliKBxr1TPbntirK/HGrUAHYbAeQTa9GHQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10849,8 +10594,6 @@
     },
     "node_modules/react-contexify": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/react-contexify/-/react-contexify-6.0.0.tgz",
-      "integrity": "sha512-jMhz6yZI81Jv3UDj7TXqCkhdkCFEEmvwGCPXsQuA2ZUC8EbCuVQ6Cy8FzKMXa0y454XTDClBN2YFvvmoFlrFkg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10862,22 +10605,20 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
-      "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
+      "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.3"
+        "react": "^19.2.5"
       }
     },
     "node_modules/react-draggable": {
       "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.5.0.tgz",
-      "integrity": "sha512-VC+HBLEZ0XJxnOxVAZsdRi8rD04Iz3SiiKOoYzamjylUcju/hP9np/aZdLHf/7WOD268WMoNJMvYfB5yAK45cw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10891,8 +10632,6 @@
     },
     "node_modules/react-draggable/node_modules/clsx": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
-      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10901,21 +10640,15 @@
     },
     "node_modules/react-is": {
       "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "license": "MIT"
     },
     "node_modules/react-lifecycles-compat": {
       "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/react-monaco-editor": {
       "version": "0.59.0",
-      "resolved": "https://registry.npmjs.org/react-monaco-editor/-/react-monaco-editor-0.59.0.tgz",
-      "integrity": "sha512-SggqfZCdUauNk7GI0388bk5n25zYsQ1ai1i+VhxAgwbCH+MTGl7L1fBNTJ6V+oXeUApf+bpzikprHJEZm9J/zA==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -10926,8 +10659,6 @@
     },
     "node_modules/react-transition-group": {
       "version": "4.4.5",
-      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
-      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -10943,8 +10674,6 @@
     },
     "node_modules/react-universal-interface": {
       "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/react-universal-interface/-/react-universal-interface-0.6.2.tgz",
-      "integrity": "sha512-dg8yXdcQmvgR13RIlZbTRQOoUrDciFVoSBZILwjE2LFISxZZ8loVJKAkuzswl5js8BHda79bIb2b84ehU8IjXw==",
       "dev": true,
       "peerDependencies": {
         "react": "*",
@@ -10953,8 +10682,6 @@
     },
     "node_modules/react-use": {
       "version": "17.6.0",
-      "resolved": "https://registry.npmjs.org/react-use/-/react-use-17.6.0.tgz",
-      "integrity": "sha512-OmedEScUMKFfzn1Ir8dBxiLLSOzhKe/dPZwVxcujweSj45aNM7BEGPb9BEVIgVEqEXx6f3/TsXzwIktNgUR02g==",
       "dev": true,
       "license": "Unlicense",
       "dependencies": {
@@ -10980,8 +10707,6 @@
     },
     "node_modules/read-pkg": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
-      "integrity": "sha512-BLq/cCO9two+lBgiTYNqD6GdtK8s4NpaWrl6/rCO9w0TUS8oJl7cmToOZfRYllKTISY6nt1U7jQ53brmKqY6BA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10995,8 +10720,6 @@
     },
     "node_modules/read-pkg/node_modules/path-type": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-      "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11008,8 +10731,6 @@
     },
     "node_modules/readable-stream": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11024,8 +10745,6 @@
     },
     "node_modules/readdirp": {
       "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
-      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11038,8 +10757,6 @@
     },
     "node_modules/rechoir": {
       "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.8.0.tgz",
-      "integrity": "sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11051,8 +10768,6 @@
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
-      "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11074,15 +10789,11 @@
     },
     "node_modules/regex-parser": {
       "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/regex-parser/-/regex-parser-2.3.1.tgz",
-      "integrity": "sha512-yXLRqatcCuKtVHsWrNg0JL3l1zGfdXeEvDa0bdu4tCDQw0RpMDZsqbkyRTUnKMR0tXF627V2oEWjBEaEdqTwtQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
-      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11126,8 +10837,6 @@
     },
     "node_modules/relateurl": {
       "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
-      "integrity": "sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11136,8 +10845,6 @@
     },
     "node_modules/renderkid": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/renderkid/-/renderkid-3.0.0.tgz",
-      "integrity": "sha512-q/7VIQA8lmM1hF+jn+sFSPWGlMkSAeNYcPLmDQx2zzuiDfaLrOmumR8iaUKlenFgh0XRPIUeSPlH3A+AW3Z5pg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11150,8 +10857,6 @@
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -11159,8 +10864,6 @@
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11169,15 +10872,11 @@
     },
     "node_modules/resize-observer-polyfill": {
       "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
-      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.11",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
-      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11197,15 +10896,11 @@
     },
     "node_modules/resolve-alpn": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
-      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/resolve-cwd": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
-      "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
       "license": "MIT",
       "dependencies": {
         "resolve-from": "^5.0.0"
@@ -11216,28 +10911,13 @@
     },
     "node_modules/resolve-cwd/node_modules/resolve-from": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
       "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
-    "node_modules/resolve-from": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
-      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -11246,8 +10926,6 @@
     },
     "node_modules/resolve-url-loader": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-url-loader/-/resolve-url-loader-5.0.0.tgz",
-      "integrity": "sha512-uZtduh8/8srhBoMx//5bwqjQ+rfYOUq8zC9NrMUGtjBiGTtFJM42s58/36+hTqeqINcnYe08Nj3LkK9lW4N8Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11263,15 +10941,11 @@
     },
     "node_modules/resolve-url-loader/node_modules/convert-source-map": {
       "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
-      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/responselike": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
-      "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11283,8 +10957,6 @@
     },
     "node_modules/roarr": {
       "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
-      "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
       "dev": true,
       "license": "BSD-3-Clause",
       "optional": true,
@@ -11302,16 +10974,12 @@
     },
     "node_modules/roarr/node_modules/sprintf-js": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "optional": true
     },
     "node_modules/rtl-css-js": {
       "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/rtl-css-js/-/rtl-css-js-1.16.1.tgz",
-      "integrity": "sha512-lRQgou1mu19e+Ya0LsTvKrVJ5TYUbqCVPAiImX3UfLTenarvPUl1QFdvu5Z3PYmHT9RCcwIfbjRQBntExyj3Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11320,8 +10988,6 @@
     },
     "node_modules/safe-array-concat": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
-      "integrity": "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11340,22 +11006,16 @@
     },
     "node_modules/safe-array-concat/node_modules/isarray": {
       "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/safe-buffer": {
       "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
-      "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11371,15 +11031,11 @@
     },
     "node_modules/safe-push-apply/node_modules/isarray": {
       "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/safe-regex-test": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
-      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11395,14 +11051,14 @@
       }
     },
     "node_modules/sass": {
-      "version": "1.97.2",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.97.2.tgz",
-      "integrity": "sha512-y5LWb0IlbO4e97Zr7c3mlpabcbBtS+ieiZ9iwDooShpFKWXf62zz5pEPdwrLYm+Bxn1fnbwFGzHuCLSA9tBmrw==",
+      "version": "1.99.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.99.0.tgz",
+      "integrity": "sha512-kgW13M54DUB7IsIRM5LvJkNlpH+WhMpooUcaWGFARkF1Tc82v9mIWkCbCYf+MBvpIUBSeSOTilpZjEPr2VYE6Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "chokidar": "^4.0.0",
-        "immutable": "^5.0.2",
+        "immutable": "^5.1.5",
         "source-map-js": ">=0.6.2 <2.0.0"
       },
       "bin": {
@@ -11416,9 +11072,9 @@
       }
     },
     "node_modules/sass-loader": {
-      "version": "16.0.6",
-      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-16.0.6.tgz",
-      "integrity": "sha512-sglGzId5gmlfxNs4gK2U3h7HlVRfx278YK6Ono5lwzuvi1jxig80YiuHkaDBVsYIKFhx8wN7XSCI0M2IDS/3qA==",
+      "version": "16.0.7",
+      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-16.0.7.tgz",
+      "integrity": "sha512-w6q+fRHourZ+e+xA1kcsF27iGM6jdB8teexYCfdUw0sYgcDNeZESnDNT9sUmmPm3ooziwUJXGwZJSTF3kOdBfA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11432,7 +11088,7 @@
         "url": "https://opencollective.com/webpack"
       },
       "peerDependencies": {
-        "@rspack/core": "0.x || 1.x",
+        "@rspack/core": "0.x || ^1.0.0 || ^2.0.0-0",
         "node-sass": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0",
         "sass": "^1.3.0",
         "sass-embedded": "*",
@@ -11458,15 +11114,11 @@
     },
     "node_modules/scheduler": {
       "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
-      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/schema-utils": {
       "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
-      "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11485,8 +11137,6 @@
     },
     "node_modules/screenfull": {
       "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/screenfull/-/screenfull-5.2.0.tgz",
-      "integrity": "sha512-9BakfsO2aUQN2K9Fdbj87RJIEZ82Q9IGim7FqM5OsebfoFC6ZHXgDq/KvniuLTPdeM8wY2o6Dj3WQ7KeQCj3cA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11498,8 +11148,6 @@
     },
     "node_modules/scss": {
       "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/scss/-/scss-0.2.4.tgz",
-      "integrity": "sha512-4u8V87F+Q/upVhUmhPnB4C1R11xojkRkWjExL2v0CX2EXTg18VrKd+9JWoeyCp2VEMdSpJsyAvVU+rVjogh51A==",
       "dev": true,
       "dependencies": {
         "ometa": "0.2.2"
@@ -11510,15 +11158,13 @@
     },
     "node_modules/scss-loader": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/scss-loader/-/scss-loader-0.0.1.tgz",
-      "integrity": "sha512-SbT/smRJjkvvdHSEdAYAplosVkrtaSwwgUlnQCOuDS5sOKNjrS/eYCMvKeV6+YxK5cCOCsOJZd3vltrXatFp+g==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -11529,16 +11175,12 @@
     },
     "node_modules/semver-compare": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
-      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
       "dev": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/serialize-error": {
       "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
-      "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -11554,8 +11196,6 @@
     },
     "node_modules/serialize-error/node_modules/type-fest": {
       "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
-      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "optional": true,
@@ -11568,8 +11208,6 @@
     },
     "node_modules/serialize-javascript": {
       "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -11628,6 +11266,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/serve-handler/node_modules/content-disposition": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+      "integrity": "sha512-kRGRZw3bLlFISDBgwTSA1TMBFN6J6GWDeubmDE3AF+3+yXL8hTWv8r5rkLbqYXY4RjPk/EzHnClI3zQf1cFmHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/serve-handler/node_modules/mime-db": {
       "version": "1.33.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
@@ -11651,12 +11299,22 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/serve/node_modules/arg": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
-      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+    "node_modules/serve-handler/node_modules/path-to-regexp": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-3.3.0.tgz",
+      "integrity": "sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/serve-handler/node_modules/range-parser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+      "integrity": "sha512-kA5WQoNVo4t9lNx2kQNFCxKeBl5IbbSNBl1M/tLkw9WCn+hxNBAW5Qh8gdhs63CJnhjJ2zQWFoqPJP2sK1AV5A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/serve/node_modules/chalk": {
       "version": "5.0.1",
@@ -11673,8 +11331,6 @@
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
-      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11691,8 +11347,6 @@
     },
     "node_modules/set-function-name": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
-      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11707,8 +11361,6 @@
     },
     "node_modules/set-harmonic-interval": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/set-harmonic-interval/-/set-harmonic-interval-1.0.1.tgz",
-      "integrity": "sha512-AhICkFV84tBP1aWqPwLZqFvAwqEoVA9kxNMniGEUvzOlm4vLmOFLiTT3UZ6bziJTy4bOVpzWGTfSCbmaayGx8g==",
       "dev": true,
       "license": "Unlicense",
       "engines": {
@@ -11717,8 +11369,6 @@
     },
     "node_modules/set-proto": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
-      "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11732,8 +11382,6 @@
     },
     "node_modules/shallow-clone": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
-      "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11745,8 +11393,6 @@
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -11757,8 +11403,6 @@
     },
     "node_modules/shebang-regex": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -11766,8 +11410,6 @@
     },
     "node_modules/shell-quote": {
       "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11779,8 +11421,6 @@
     },
     "node_modules/side-channel": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11799,8 +11439,6 @@
     },
     "node_modules/side-channel-list": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11816,8 +11454,6 @@
     },
     "node_modules/side-channel-map": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
-      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11835,8 +11471,6 @@
     },
     "node_modules/side-channel-weakmap": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
-      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11855,30 +11489,17 @@
     },
     "node_modules/signal-exit": {
       "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "license": "ISC"
     },
     "node_modules/slash": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
-    "node_modules/source-list-map": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
-      "integrity": "sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/source-map": {
       "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -11886,8 +11507,6 @@
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
-      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -11906,8 +11525,6 @@
     },
     "node_modules/spdx-correct": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
-      "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -11917,15 +11534,11 @@
     },
     "node_modules/spdx-exceptions": {
       "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
-      "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
       "dev": true,
       "license": "CC-BY-3.0"
     },
     "node_modules/spdx-expression-parse": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
-      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11935,15 +11548,11 @@
     },
     "node_modules/spdx-license-ids": {
       "version": "3.0.22",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.22.tgz",
-      "integrity": "sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ==",
       "dev": true,
       "license": "CC0-1.0"
     },
     "node_modules/split": {
       "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
-      "integrity": "sha512-wD2AeVmxXRBoX44wAycgjVpMhvbwdI2aZjCkvfNcH1YqHQvJVa1duWc73OyVGJUc05fhFaTZeQ/PYsrmyH0JVA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11955,14 +11564,10 @@
     },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "license": "BSD-3-Clause"
     },
     "node_modules/stack-generator": {
       "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.10.tgz",
-      "integrity": "sha512-mwnua/hkqM6pF4k8SnmZ2zfETsRUpWXREfA/goT8SLCV4iOFa4bzOX2nDipWAZFPTjLvQB82f5yaodMVhK0yJQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11971,8 +11576,6 @@
     },
     "node_modules/stack-utils": {
       "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
-      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
       "license": "MIT",
       "dependencies": {
         "escape-string-regexp": "^2.0.0"
@@ -11983,8 +11586,6 @@
     },
     "node_modules/stack-utils/node_modules/escape-string-regexp": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
-      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -11992,15 +11593,11 @@
     },
     "node_modules/stackframe": {
       "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
-      "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/stacktrace-gps": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/stacktrace-gps/-/stacktrace-gps-3.1.2.tgz",
-      "integrity": "sha512-GcUgbO4Jsqqg6RxfyTHFiPxdPqF+3LFmQhm7MgCuYQOYuWyqxo5pwRPz5d/u6/WYJdEnWfK4r+jGbyD8TSggXQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12010,8 +11607,6 @@
     },
     "node_modules/stacktrace-gps/node_modules/source-map": {
       "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-      "integrity": "sha512-MjZkVp0NHr5+TPihLcadqnlVoGIoWo4IBHptutGh9wI3ttUYvCG26HkSuDi+K6lsZ25syXJXcctwgyVCt//xqA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -12020,8 +11615,6 @@
     },
     "node_modules/stacktrace-js": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/stacktrace-js/-/stacktrace-js-2.0.2.tgz",
-      "integrity": "sha512-Je5vBeY4S1r/RnLydLl0TBTi3F2qdfWmYsGvtfZgEI+SCprPppaIhQf5nGcal4gI4cGpCV/duLcAzT1np6sQqg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12032,15 +11625,11 @@
     },
     "node_modules/std-env": {
       "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
-      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
-      "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12053,8 +11642,6 @@
     },
     "node_modules/stream-browserify": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
-      "integrity": "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12064,8 +11651,6 @@
     },
     "node_modules/stream-browserify/node_modules/readable-stream": {
       "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12079,8 +11664,6 @@
     },
     "node_modules/stream-combiner": {
       "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
-      "integrity": "sha512-rT00SPnTVyRsaSz5zgSPma/aHSOic5U1prhYdRy5HS2kTZviFpmDgzilbtsJsxiroqACmayynDN/9VzIbX5DOw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12089,8 +11672,6 @@
     },
     "node_modules/string_decoder": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12099,8 +11680,6 @@
     },
     "node_modules/string-argv": {
       "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
-      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -12122,15 +11701,11 @@
     },
     "node_modules/string-range": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/string-range/-/string-range-1.2.2.tgz",
-      "integrity": "sha512-tYft6IFi8SjplJpxCUxyqisD3b+R2CSkomrtJYCkvuf1KuCAWgz7YXt4O0jip7efpfCemwHEzTEAO8EuOYgh3w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -12144,8 +11719,6 @@
     "node_modules/string-width-cjs": {
       "name": "string-width",
       "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -12158,8 +11731,6 @@
     },
     "node_modules/string.prototype.padend": {
       "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.1.6.tgz",
-      "integrity": "sha512-XZpspuSB7vJWhvJc9DLSlrXl1mcA2BdoY5jjnS135ydXqLoqhs96JjDtCkjJEQHvfqZIp9hBuBMgI589peyx9Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12177,8 +11748,6 @@
     },
     "node_modules/string.prototype.trim": {
       "version": "1.2.10",
-      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
-      "integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12199,8 +11768,6 @@
     },
     "node_modules/string.prototype.trimend": {
       "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
-      "integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12218,8 +11785,6 @@
     },
     "node_modules/string.prototype.trimstart": {
       "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
-      "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12236,8 +11801,6 @@
     },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -12249,8 +11812,6 @@
     "node_modules/strip-ansi-cjs": {
       "name": "strip-ansi",
       "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -12291,8 +11852,6 @@
     },
     "node_modules/style-loader": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-4.0.0.tgz",
-      "integrity": "sha512-1V4WqhhZZgjVAVJyt7TdDPZoPBPNHbekX4fWnCJL1yQukhCeZhJySUL+gL9y6sNdN95uEOS83Y55SqHcP7MzLA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -12308,15 +11867,11 @@
     },
     "node_modules/stylis": {
       "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
-      "integrity": "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/sumchecker": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
-      "integrity": "sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -12328,8 +11883,6 @@
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -12340,8 +11893,6 @@
     },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -12352,9 +11903,9 @@
       }
     },
     "node_modules/synckit": {
-      "version": "0.11.11",
-      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.11.tgz",
-      "integrity": "sha512-MeQTA1r0litLUf0Rp/iisCaL8761lKAZHaimlbGK4j0HysC4PLfqygQj9srcs0m2RdtDYnF8UuYyKpbjHYp7Jw==",
+      "version": "0.11.12",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.12.tgz",
+      "integrity": "sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==",
       "license": "MIT",
       "dependencies": {
         "@pkgr/core": "^0.2.9"
@@ -12368,8 +11919,6 @@
     },
     "node_modules/tapable": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
-      "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -12382,8 +11931,6 @@
     },
     "node_modules/terser": {
       "version": "5.44.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.44.1.tgz",
-      "integrity": "sha512-t/R3R/n0MSwnnazuPpPNVO60LX0SKL45pyl9YlvxIdkH0Of7D5qM2EVe+yASRIlY5pZ73nclYJfNANGWPwFDZw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -12401,8 +11948,6 @@
     },
     "node_modules/terser-webpack-plugin": {
       "version": "5.3.16",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.16.tgz",
-      "integrity": "sha512-h9oBFCWrq78NyWWVcSwZarJkZ01c2AyGrzs1crmHZO3QUg9D61Wu4NPjBy69n7JqylFF5y+CsUZYmYEIZ3mR+Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12436,8 +11981,6 @@
     },
     "node_modules/terser-webpack-plugin/node_modules/jest-worker": {
       "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
-      "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12451,8 +11994,6 @@
     },
     "node_modules/terser-webpack-plugin/node_modules/supports-color": {
       "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12467,15 +12008,11 @@
     },
     "node_modules/terser/node_modules/commander": {
       "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/terser/node_modules/source-map-support": {
       "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12485,8 +12022,6 @@
     },
     "node_modules/test-exclude": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
-      "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
       "license": "ISC",
       "dependencies": {
         "@istanbuljs/schema": "^0.1.2",
@@ -12499,14 +12034,10 @@
     },
     "node_modules/three": {
       "version": "0.149.0",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.149.0.tgz",
-      "integrity": "sha512-tohpUxPDht0qExRLDTM8sjRLc5d9STURNrdnK3w9A+V4pxaTBfKWWT/IqtiLfg23Vfc3Z+ImNfvRw1/0CtxrkQ==",
       "license": "MIT"
     },
     "node_modules/throttle-debounce": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-3.0.1.tgz",
-      "integrity": "sha512-dTEWWNu6JmeVXY0ZYoPuH5cRIwc0MeGbJwah9KUNYSJwommQpCzTySTpEe8Gs1J23aeWEuAobe4Ag7EHVt/LOg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -12515,15 +12046,11 @@
     },
     "node_modules/through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12539,14 +12066,11 @@
     },
     "node_modules/tmpl": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
-      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
       "license": "BSD-3-Clause"
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -12557,31 +12081,27 @@
     },
     "node_modules/toggle-selection": {
       "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
-      "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/ts-easing": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/ts-easing/-/ts-easing-0.2.0.tgz",
-      "integrity": "sha512-Z86EW+fFFh/IFB1fqQ3/+7Zpf9t2ebOAxNI/V6Wo7r5gqiqtxmgTlQ1qbqQcjLKYeSHPTsEmvlJUDg/EuL0uHQ==",
       "dev": true,
       "license": "Unlicense"
     },
     "node_modules/ts-jest": {
-      "version": "29.4.6",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.6.tgz",
-      "integrity": "sha512-fSpWtOO/1AjSNQguk43hb/JCo16oJDnMJf3CdEGNkqsEX3t0KX96xvyX1D7PfLCpVoKu4MfVrqUkFyblYoY4lA==",
+      "version": "29.4.9",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.9.tgz",
+      "integrity": "sha512-LTb9496gYPMCqjeDLdPrKuXtncudeV1yRZnF4Wo5l3SFi0RYEnYRNgMrFIdg+FHvfzjCyQk1cLncWVqiSX+EvQ==",
       "license": "MIT",
       "dependencies": {
         "bs-logger": "^0.2.6",
         "fast-json-stable-stringify": "^2.1.0",
-        "handlebars": "^4.7.8",
+        "handlebars": "^4.7.9",
         "json5": "^2.2.3",
         "lodash.memoize": "^4.1.2",
         "make-error": "^1.3.6",
-        "semver": "^7.7.3",
+        "semver": "^7.7.4",
         "type-fest": "^4.41.0",
         "yargs-parser": "^21.1.1"
       },
@@ -12598,7 +12118,7 @@
         "babel-jest": "^29.0.0 || ^30.0.0",
         "jest": "^29.0.0 || ^30.0.0",
         "jest-util": "^29.0.0 || ^30.0.0",
-        "typescript": ">=4.3 <6"
+        "typescript": ">=4.3 <7"
       },
       "peerDependenciesMeta": {
         "@babel/core": {
@@ -12623,8 +12143,6 @@
     },
     "node_modules/ts-jest/node_modules/type-fest": {
       "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
-      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
       "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=16"
@@ -12634,9 +12152,9 @@
       }
     },
     "node_modules/ts-loader": {
-      "version": "9.5.4",
-      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.5.4.tgz",
-      "integrity": "sha512-nCz0rEwunlTZiy6rXFByQU1kVVpCIgUpc/psFiKVrUwrizdnIbRFu8w7bxhUF0X613DYwT4XzrZHpVyMe758hQ==",
+      "version": "9.5.7",
+      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.5.7.tgz",
+      "integrity": "sha512-/ZNrKgA3K3PtpMYOC71EeMWIloGw3IYEa5/t1cyz2r5/PyUwTXGzYJvcD3kfUvmhlfpz1rhV8B2O6IVTQ0avsg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12656,8 +12174,6 @@
     },
     "node_modules/ts-loader/node_modules/source-map": {
       "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
-      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -12666,8 +12182,6 @@
     },
     "node_modules/tsc-watch": {
       "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/tsc-watch/-/tsc-watch-7.2.0.tgz",
-      "integrity": "sha512-4gRFawQD1cVSaILvG7wl2x6NtteKbS2dGBMbL7Q6n1ldLIOKXCJUoEwUXdGuee4dp+zcnA6tukBBLz1lZrNI9w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12686,67 +12200,13 @@
         "typescript": "*"
       }
     },
-    "node_modules/tsconfig-paths": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
-      "integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/json5": "^0.0.29",
-        "json5": "^1.0.2",
-        "minimist": "^1.2.6",
-        "strip-bom": "^3.0.0"
-      }
-    },
-    "node_modules/tsconfig-paths/node_modules/json5": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
-      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.0"
-      },
-      "bin": {
-        "json5": "lib/cli.js"
-      }
-    },
-    "node_modules/tsconfig-paths/node_modules/strip-bom": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/tslib": {
       "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "devOptional": true,
       "license": "0BSD"
     },
-    "node_modules/type-check": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
-      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "prelude-ls": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
     "node_modules/type-detect": {
       "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -12766,8 +12226,6 @@
     },
     "node_modules/typed-array-buffer": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
-      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12781,8 +12239,6 @@
     },
     "node_modules/typed-array-byte-length": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
-      "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12801,8 +12257,6 @@
     },
     "node_modules/typed-array-byte-offset": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
-      "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12823,8 +12277,6 @@
     },
     "node_modules/typed-array-length": {
       "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz",
-      "integrity": "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12844,30 +12296,26 @@
     },
     "node_modules/typedarray": {
       "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/typedarray-to-buffer": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-1.0.4.tgz",
-      "integrity": "sha512-vjMKrfSoUDN8/Vnqitw2FmstOfuJ73G6CrSEKnf11A6RmasVxHqfeBcnTb6RsL4pTMuV5Zsv9IiHRphMZyckUw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/typedoc": {
-      "version": "0.28.15",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.15.tgz",
-      "integrity": "sha512-mw2/2vTL7MlT+BVo43lOsufkkd2CJO4zeOSuWQQsiXoV2VuEn7f6IZp2jsUDPmBMABpgR0R5jlcJ2OGEFYmkyg==",
+      "version": "0.28.19",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.19.tgz",
+      "integrity": "sha512-wKh+lhdmMFivMlc6vRRcMGXeGEHGU2g8a2CkPTJjJlwRf1iXbimWIPcFolCqe4E0d/FRtGszpIrsp3WLpDB8Pw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@gerrit0/mini-shiki": "^3.17.0",
+        "@gerrit0/mini-shiki": "^3.23.0",
         "lunr": "^2.3.9",
-        "markdown-it": "^14.1.0",
-        "minimatch": "^9.0.5",
-        "yaml": "^2.8.1"
+        "markdown-it": "^14.1.1",
+        "minimatch": "^10.2.5",
+        "yaml": "^2.8.3"
       },
       "bin": {
         "typedoc": "bin/typedoc"
@@ -12877,13 +12325,11 @@
         "pnpm": ">= 10"
       },
       "peerDependencies": {
-        "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x"
+        "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x || 6.0.x"
       }
     },
     "node_modules/typedoc-github-wiki-theme": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/typedoc-github-wiki-theme/-/typedoc-github-wiki-theme-2.1.0.tgz",
-      "integrity": "sha512-5j4vuoGwLn8PM1HeXocbwUF0Ra2qTFLeqsQwBQsLBPIx7Tl/lxkas1qIPFg/InOYwy9Y3Pn4xSjh+c/KM+jh6Q==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -12891,9 +12337,9 @@
       }
     },
     "node_modules/typedoc-plugin-markdown": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-4.9.0.tgz",
-      "integrity": "sha512-9Uu4WR9L7ZBgAl60N/h+jqmPxxvnC9nQAlnnO/OujtG2ubjnKTVUFY1XDhcMY+pCqlX3N2HsQM2QTYZIU9tJuw==",
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-4.11.0.tgz",
+      "integrity": "sha512-2iunh2ALyfyh204OF7h2u0kuQ84xB3jFZtFyUr01nThJkLvR8oGGSSDlyt2gyO4kXhvUxDcVbO0y43+qX+wFbw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -12903,27 +12349,40 @@
         "typedoc": "0.28.x"
       }
     },
+    "node_modules/typedoc/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/typedoc/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/typedoc/node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^2.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -12933,6 +12392,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -12964,8 +12424,6 @@
     },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
-      "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12983,8 +12441,6 @@
     },
     "node_modules/uncontrollable": {
       "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/uncontrollable/-/uncontrollable-7.2.1.tgz",
-      "integrity": "sha512-svtcfoTADIB0nT9nltgjujTi7BzVmwjZClOmskKu/E8FW9BXzg9os8OLr4f8Dlnk0rYWJIWr4wv9eKUXiQvQwQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12999,15 +12455,11 @@
     },
     "node_modules/undici-types": {
       "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/universalify": {
       "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -13016,8 +12468,6 @@
     },
     "node_modules/unrs-resolver": {
       "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
-      "integrity": "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -13050,8 +12500,6 @@
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
       "funding": [
         {
           "type": "opencollective",
@@ -13091,8 +12539,6 @@
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -13101,8 +12547,6 @@
     },
     "node_modules/url-loader": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/url-loader/-/url-loader-4.1.1.tgz",
-      "integrity": "sha512-3BTV812+AVHHOJQO8O5MkWgZ5aosP7GnROJwvzLS9hWDj00lZ6Z0wNak423Lp9PBZN05N+Jk/N5Si8jRAlGyWA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13129,8 +12573,6 @@
     },
     "node_modules/url-loader/node_modules/ajv": {
       "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13146,8 +12588,6 @@
     },
     "node_modules/url-loader/node_modules/ajv-keywords": {
       "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -13156,15 +12596,11 @@
     },
     "node_modules/url-loader/node_modules/json-schema-traverse": {
       "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/url-loader/node_modules/schema-utils": {
       "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
-      "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13182,22 +12618,16 @@
     },
     "node_modules/user-agent-data-types": {
       "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/user-agent-data-types/-/user-agent-data-types-0.4.2.tgz",
-      "integrity": "sha512-jXep3kO/dGNmDOkbDa8ccp4QArgxR4I76m3QVcJ1aOF0B9toc+YtSXtX5gLdDTZXyWlpQYQrABr6L1L2GZOghw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/utila": {
       "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/utila/-/utila-0.4.0.tgz",
-      "integrity": "sha512-Z0DbgELS9/L/75wZbro8xAnT50pBVFQZ+hUEueGDU5FN51YSCYM+jdxsfCiHjwNP/4LCDD0i/graKpeBnOXKRA==",
       "dev": true,
       "license": "MIT"
     },
@@ -13217,8 +12647,6 @@
     },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
-      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -13228,8 +12656,6 @@
     },
     "node_modules/vary": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -13238,8 +12664,6 @@
     },
     "node_modules/walker": {
       "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
-      "integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "makeerror": "1.0.12"
@@ -13247,8 +12671,6 @@
     },
     "node_modules/warning": {
       "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
-      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13257,8 +12679,6 @@
     },
     "node_modules/watchpack": {
       "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.0.tgz",
-      "integrity": "sha512-e6vZvY6xboSwLz2GD36c16+O/2Z6fKvIf4pOXptw2rY9MVwE/TXc6RGqxD3I3x0a28lwBY7DE+76uTPSsBrrCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13271,8 +12691,6 @@
     },
     "node_modules/webpack": {
       "version": "5.104.1",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.104.1.tgz",
-      "integrity": "sha512-Qphch25abbMNtekmEGJmeRUhLDbe+QfiWTiqpKYkpCOWY64v9eyl+KRRLmqOFA2AvKPpc9DC6+u2n76tQLBoaA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13373,8 +12791,6 @@
     },
     "node_modules/webpack-merge": {
       "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-6.0.1.tgz",
-      "integrity": "sha512-hXXvrjtx2PLYx4qruKl+kyRSLc52V+cCvMxRjmKwoA+CBbbF5GfIBtR6kCvl0fYGqTUPKB+1ktVmTHqMOzgCBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13387,31 +12803,17 @@
       }
     },
     "node_modules/webpack-sources": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",
-      "integrity": "sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.4.0.tgz",
+      "integrity": "sha512-gHwIe1cgBvvfLeu1Yz/dcFpmHfKDVxxyqI+kzqmuxZED81z2ChxpyqPaWcNqigPywhaEke7AjSGga+kxY55gjQ==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "source-list-map": "^2.0.0",
-        "source-map": "~0.6.1"
-      }
-    },
-    "node_modules/webpack/node_modules/webpack-sources": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.3.tgz",
-      "integrity": "sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "source-list-map": "^2.0.0",
-        "source-map": "~0.6.1"
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/webpackbar": {
       "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/webpackbar/-/webpackbar-7.0.0.tgz",
-      "integrity": "sha512-aS9soqSO2iCHgqHoCrj4LbfGQUboDCYJPSFOAchEK+9psIjNrfSWW4Y0YEz67MKURNvMmfo0ycOg9d/+OOf9/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13438,8 +12840,6 @@
     },
     "node_modules/which": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -13453,8 +12853,6 @@
     },
     "node_modules/which-boxed-primitive": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
-      "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13473,8 +12871,6 @@
     },
     "node_modules/which-builtin-type": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
-      "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13501,15 +12897,11 @@
     },
     "node_modules/which-builtin-type/node_modules/isarray": {
       "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/which-collection": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
-      "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13527,8 +12919,6 @@
     },
     "node_modules/which-typed-array": {
       "version": "1.1.19",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
-      "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13619,21 +13009,8 @@
     },
     "node_modules/wildcard": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.1.tgz",
-      "integrity": "sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/word-wrap": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
-      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/wordwrap": {
       "version": "1.0.0",
@@ -13643,8 +13020,6 @@
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -13661,8 +13036,6 @@
     "node_modules/wrap-ansi-cjs": {
       "name": "wrap-ansi",
       "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -13678,14 +13051,10 @@
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
     },
     "node_modules/write-file-atomic": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
-      "integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
       "license": "ISC",
       "dependencies": {
         "imurmurhash": "^0.1.4",
@@ -13697,8 +13066,6 @@
     },
     "node_modules/write-file-atomic/node_modules/signal-exit": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -13709,8 +13076,6 @@
     },
     "node_modules/xtend": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.2.0.tgz",
-      "integrity": "sha512-SLt5uylT+4aoXxXuwtQp5ZnMMzhDb1Xkg4pEqc00WUJCQifPfV9Ub1VrNhp9kXkrjZD2I2Hl8WnjP37jzZLPZw==",
       "dev": true,
       "engines": {
         "node": ">=0.4"
@@ -13718,8 +13083,6 @@
     },
     "node_modules/y18n": {
       "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
       "license": "ISC",
       "engines": {
         "node": ">=10"
@@ -13727,14 +13090,12 @@
     },
     "node_modules/yallist": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -13749,8 +13110,6 @@
     },
     "node_modules/yargs": {
       "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
       "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",
@@ -13767,8 +13126,6 @@
     },
     "node_modules/yargs-parser": {
       "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -13776,8 +13133,6 @@
     },
     "node_modules/yauzl": {
       "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,7 @@
         "monaco-editor-webpack-plugin": "^7.1.1",
         "npm-run-all": "^4.1.5",
         "path-browserify": "^1.0.1",
+        "puppeteer-core": "^24.43.1",
         "raw-loader": "^4.0.2",
         "react": "^19.2.3",
         "react-bootstrap": "^2.10.10",
@@ -2976,6 +2977,28 @@
         "url": "https://opencollective.com/popperjs"
       }
     },
+    "node_modules/@puppeteer/browsers": {
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.13.2.tgz",
+      "integrity": "sha512-5EUZSUIc37H6aIXyWO0Z4y8NlF8NnjgmqeQgOGiswAU7pY0HOo16ho4+alIWmSfdZnjqBRawMsP3I5YqLSn6kw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "extract-zip": "^2.0.1",
+        "progress": "^2.0.3",
+        "proxy-agent": "^6.5.0",
+        "semver": "^7.7.4",
+        "tar-fs": "^3.1.1",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "browsers": "lib/cjs/main-cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@react-aria/ssr": {
       "version": "3.9.10",
       "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.9.10.tgz",
@@ -3165,6 +3188,13 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/@tootallnate/quickjs-emscripten": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
@@ -4291,6 +4321,16 @@
         "node": ">=8.9"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
@@ -4617,6 +4657,19 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/ast-types": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/async-function": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
@@ -4641,6 +4694,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
       }
     },
     "node_modules/babel-jest": {
@@ -4743,6 +4811,103 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
     },
+    "node_modules/bare-events": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.3.tgz",
+      "integrity": "sha512-HdUm8EMQBLaJvGUdidNNbqpA1kYkwNcb+MYxkxCLAPJGQzlv9J0C24h8V65Z4c5GLd/JEALDvpFCQgpLJqc0zw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.1.tgz",
+      "integrity": "sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.1.tgz",
+      "integrity": "sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
+      "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.1.tgz",
+      "integrity": "sha512-Vp0cnjYyrEC4whYTymQ+YZi6pBpfiICZO3cfRG8sy67ZNWe951urv1x4eW1BKNngw3U+3fPYb5JQvHbCtxH7Ow==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.3.tgz",
+      "integrity": "sha512-Kccpc7ACfXaxfeInfqKcZtW4pT5YBn1mesc4sCsun6sRwtbJ4h+sNOaksUpYEJUKfN65YWC6Bw2OJEFiKxq8nQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.9.11",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.11.tgz",
@@ -4750,6 +4915,16 @@
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/basic-ftp": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+      "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/batch": {
@@ -5398,6 +5573,20 @@
         "node": ">=6.0"
       }
     },
+    "node_modules/chromium-bidi": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-14.0.0.tgz",
+      "integrity": "sha512-9gYlLtS6tStdRWzrtXaTMnqcM4dudNegMXJxkR0I/CXObHalYeYcAMPrL19eroNZHtJ8DQmu1E+ZNOYu/IXMXw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mitt": "^3.0.1",
+        "zod": "^3.24.1"
+      },
+      "peerDependencies": {
+        "devtools-protocol": "*"
+      }
+    },
     "node_modules/ci-info": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.1.tgz",
@@ -5934,6 +6123,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
@@ -6175,6 +6374,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/degenerator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "^0.13.4",
+        "escodegen": "^2.1.0",
+        "esprima": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -6235,6 +6449,13 @@
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/devtools-protocol": {
+      "version": "0.0.1608973",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1608973.tgz",
+      "integrity": "sha512-Tpm17fxYzt+J7VrGdc1k8YdRqS3YV7se/M6KeemEqvUbq/n7At1rWVuXMxQgpWkdwSdIEKYbU//Bve+Shm4YNQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/dns-packet": {
       "version": "5.6.1",
@@ -7287,6 +7508,16 @@
         "node": ">=0.8.x"
       }
     },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -7488,6 +7719,13 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -8118,6 +8356,21 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/get-uri": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
+      "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "basic-ftp": "^5.0.2",
+        "data-uri-to-buffer": "^6.0.2",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -8560,6 +8813,20 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/http-proxy-middleware": {
       "version": "2.0.9",
       "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz",
@@ -8597,6 +8864,20 @@
       },
       "engines": {
         "node": ">=10.19.0"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/human-signals": {
@@ -8802,6 +9083,16 @@
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.0.0"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/ipaddr.js": {
@@ -11110,6 +11401,13 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/monaco-editor": {
       "version": "0.52.2",
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.2.tgz",
@@ -11226,6 +11524,16 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "license": "MIT"
+    },
+    "node_modules/netmask": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.1.1.tgz",
+      "integrity": "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
     },
     "node_modules/nice-try": {
       "version": "1.0.5",
@@ -11831,6 +12139,40 @@
         "node": ">=6"
       }
     },
+    "node_modules/pac-proxy-agent": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
+      "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/quickjs-emscripten": "^0.23.0",
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "get-uri": "^6.0.1",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.6",
+        "pac-resolver": "^7.0.1",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-resolver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+      "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "degenerator": "^5.0.0",
+        "netmask": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -12348,6 +12690,43 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/proxy-agent": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
+      "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "http-proxy-agent": "^7.0.1",
+        "https-proxy-agent": "^7.0.6",
+        "lru-cache": "^7.14.1",
+        "pac-proxy-agent": "^7.1.0",
+        "proxy-from-env": "^1.1.0",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-agent/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/prr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
@@ -12400,6 +12779,25 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/puppeteer-core": {
+      "version": "24.43.1",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.43.1.tgz",
+      "integrity": "sha512-T5ScUMAsmhdNbgDR41AGESYeS6V9MSgetkSnVhhW+gXvzC42VesKCn5ld87gAZDJ6vLHL9GkRvY9WtQWSnwFbw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@puppeteer/browsers": "2.13.2",
+        "chromium-bidi": "14.0.0",
+        "debug": "^4.4.3",
+        "devtools-protocol": "0.0.1608973",
+        "typed-query-selector": "^2.12.2",
+        "webdriver-bidi-protocol": "0.4.1",
+        "ws": "^8.20.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/pure-rand": {
@@ -13379,9 +13777,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -13883,6 +14281,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
     "node_modules/sockjs": {
       "version": "0.3.24",
       "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.24.tgz",
@@ -13893,6 +14302,36 @@
         "faye-websocket": "^0.11.3",
         "uuid": "^8.3.2",
         "websocket-driver": "^0.7.4"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.1.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/source-list-map": {
@@ -14169,6 +14608,18 @@
       "license": "MIT",
       "dependencies": {
         "duplexer": "~0.1.1"
+      }
+    },
+    "node_modules/streamx": {
+      "version": "2.26.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.26.0.tgz",
+      "integrity": "sha512-VvNG1K72Po/xwJzxZFnZ++Tbrv4lwSptsbkFuzXCJAYZvCK5nnxsvXU6ajqkv7chyiI1Y0YXq2Jh8Iy8Y7NF/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
       }
     },
     "node_modules/string_decoder": {
@@ -14464,6 +14915,44 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tar-fs": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.2.tgz",
+      "integrity": "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
+      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
     "node_modules/terser": {
       "version": "5.44.1",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.44.1.tgz",
@@ -14579,6 +15068,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
       }
     },
     "node_modules/thingies": {
@@ -15010,6 +15509,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/typed-query-selector": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.2.tgz",
+      "integrity": "sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/typedarray": {
       "version": "0.0.6",
@@ -15478,6 +15984,13 @@
       "dependencies": {
         "minimalistic-assert": "^1.0.0"
       }
+    },
+    "node_modules/webdriver-bidi-protocol": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.1.tgz",
+      "integrity": "sha512-ARrjNjtWRRs2w4Tk7nqrf2gBI0QXWuOmMCx2hU+1jUt6d00MjMxURrhxhGbrsoiZKJrhTSTzbIrc554iKI10qw==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/webpack": {
       "version": "5.104.1",
@@ -16273,6 +16786,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -81,6 +81,7 @@
         "user-agent-data-types": "^0.4.2",
         "webpack": "^5.104.1",
         "webpack-cli": "^6.0.1",
+        "webpack-dev-server": "^5.2.4",
         "webpackbar": "^7.0.0"
       }
     },
@@ -2002,6 +2003,443 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@jsonjoy.com/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-q6XAnWQDIMA3+FTiOYajoYqySkO+JSat0ytXGSuRdq9uXE7o92gzuQwQM14xaCRlBLGq3v5miDGC4vkVTn54xA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/buffers": {
+      "version": "17.67.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/buffers/-/buffers-17.67.0.tgz",
+      "integrity": "sha512-tfExRpYxBvi32vPs9ZHaTjSP4fHAfzSmcahOfNxtvGHcyJel+aibkPlGeBB+7AoC6hL7lXIE++8okecBxx7lcw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/codegen": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/codegen/-/codegen-1.0.0.tgz",
+      "integrity": "sha512-E8Oy+08cmCf0EK/NMxpaJZmOxPqM+6iSe2S4nlSBrPZOORoDJILxtbSUEDKQyTamm/BVAhIGllOBNU79/dwf0g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-core": {
+      "version": "4.57.3",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-core/-/fs-core-4.57.3.tgz",
+      "integrity": "sha512-IvO50vkGydDZwS1e9rz/JXEtCCt9XvqxoGI6FlrVIvVm4/HpygMKW4ETtREWtMTsN5CLJ9FR6GuCduoQPZLBiw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/fs-node-builtins": "4.57.3",
+        "@jsonjoy.com/fs-node-utils": "4.57.3",
+        "thingies": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-fsa": {
+      "version": "4.57.3",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-fsa/-/fs-fsa-4.57.3.tgz",
+      "integrity": "sha512-JlIDGUWPl7Y6zl+/ISnZuh8z2aMr/xoR66D18zlaVAuL192CvlNJEzOlzp27x4P52HRtDnCSOk6f59vTsmp5vw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/fs-core": "4.57.3",
+        "@jsonjoy.com/fs-node-builtins": "4.57.3",
+        "@jsonjoy.com/fs-node-utils": "4.57.3",
+        "thingies": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-node": {
+      "version": "4.57.3",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node/-/fs-node-4.57.3.tgz",
+      "integrity": "sha512-089gZoKvbeOsT2jeBaVKSz91oFXQWFG7a62sMY6gVMHnoWbyGzTb6OVUP/V7G3wLQLJ555BEsHt8SD1nj1dgaQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/fs-core": "4.57.3",
+        "@jsonjoy.com/fs-node-builtins": "4.57.3",
+        "@jsonjoy.com/fs-node-utils": "4.57.3",
+        "@jsonjoy.com/fs-print": "4.57.3",
+        "@jsonjoy.com/fs-snapshot": "4.57.3",
+        "glob-to-regex.js": "^1.0.0",
+        "thingies": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-node-builtins": {
+      "version": "4.57.3",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-builtins/-/fs-node-builtins-4.57.3.tgz",
+      "integrity": "sha512-JAI3PqNuY8BR7ovy4h0bADLrqJLIcUauONNZfyTxUnj3Wf3tpTYe39eJ6z7FzYyA+tdMt33VpiQQUikGr3QOBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-node-to-fsa": {
+      "version": "4.57.3",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-to-fsa/-/fs-node-to-fsa-4.57.3.tgz",
+      "integrity": "sha512-uZGxyC0zDmcmW5bfHd4YivAZ54BLlbF9G0K5rBaksI/tZdJSGM7/AC+1TY7yvFu0Wc6gUHR7mFwf6SbQ3J1BTQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/fs-fsa": "4.57.3",
+        "@jsonjoy.com/fs-node-builtins": "4.57.3",
+        "@jsonjoy.com/fs-node-utils": "4.57.3"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-node-utils": {
+      "version": "4.57.3",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-utils/-/fs-node-utils-4.57.3.tgz",
+      "integrity": "sha512-quCil8AvfcOxob4pn0drGdcQWpkPVgkt9q1+EjeyXXT40/L3l5lvYrr6hR8LmHu0eg+DNNaUwqjLT6Hr7V4sdQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/fs-node-builtins": "4.57.3"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-print": {
+      "version": "4.57.3",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-print/-/fs-print-4.57.3.tgz",
+      "integrity": "sha512-ITwaLZpGIqD9jHndwMvDFZDIvbVzGRsJZDQ5HKln0vyMculu1c1nb7zbEBgY8BVSBZ9S2xO138OWIBGeRsrF3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/fs-node-utils": "4.57.3",
+        "tree-dump": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-snapshot": {
+      "version": "4.57.3",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-snapshot/-/fs-snapshot-4.57.3.tgz",
+      "integrity": "sha512-wdNaG2DxCtvj9lKldAnEV3ycYPEpk+p2cP2lHD1qdxkoQGlWUtQverqvG9KZSkm6BHFha4PP6XRZbpARNfHRxA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/buffers": "^17.65.0",
+        "@jsonjoy.com/fs-node-utils": "4.57.3",
+        "@jsonjoy.com/json-pack": "^17.65.0",
+        "@jsonjoy.com/util": "^17.65.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/base64": {
+      "version": "17.67.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/base64/-/base64-17.67.0.tgz",
+      "integrity": "sha512-5SEsJGsm15aP8TQGkDfJvz9axgPwAEm98S5DxOuYe8e1EbfajcDmgeXXzccEjh+mLnjqEKrkBdjHWS5vFNwDdw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/codegen": {
+      "version": "17.67.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/codegen/-/codegen-17.67.0.tgz",
+      "integrity": "sha512-idnkUplROpdBOV0HMcwhsCUS5TRUi9poagdGs70A6S4ux9+/aPuKbh8+UYRTLYQHtXvAdNfQWXDqZEx5k4Dj2Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/json-pack": {
+      "version": "17.67.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pack/-/json-pack-17.67.0.tgz",
+      "integrity": "sha512-t0ejURcGaZsn1ClbJ/3kFqSOjlryd92eQY465IYrezsXmPcfHPE/av4twRSxf6WE+TkZgLY+71vCZbiIiFKA/w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/base64": "17.67.0",
+        "@jsonjoy.com/buffers": "17.67.0",
+        "@jsonjoy.com/codegen": "17.67.0",
+        "@jsonjoy.com/json-pointer": "17.67.0",
+        "@jsonjoy.com/util": "17.67.0",
+        "hyperdyperid": "^1.2.0",
+        "thingies": "^2.5.0",
+        "tree-dump": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/json-pointer": {
+      "version": "17.67.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pointer/-/json-pointer-17.67.0.tgz",
+      "integrity": "sha512-+iqOFInH+QZGmSuaybBUNdh7yvNrXvqR+h3wjXm0N/3JK1EyyFAeGJvqnmQL61d1ARLlk/wJdFKSL+LHJ1eaUA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/util": "17.67.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/util": {
+      "version": "17.67.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/util/-/util-17.67.0.tgz",
+      "integrity": "sha512-6+8xBaz1rLSohlGh68D1pdw3AwDi9xydm8QNlAFkvnavCJYSze+pxoW2VKP8p308jtlMRLs5NTHfPlZLd4w7ew==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/buffers": "17.67.0",
+        "@jsonjoy.com/codegen": "17.67.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/json-pack": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pack/-/json-pack-1.21.0.tgz",
+      "integrity": "sha512-+AKG+R2cfZMShzrF2uQw34v3zbeDYUqnQ+jg7ORic3BGtfw9p/+N6RJbq/kkV8JmYZaINknaEQ2m0/f693ZPpg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/base64": "^1.1.2",
+        "@jsonjoy.com/buffers": "^1.2.0",
+        "@jsonjoy.com/codegen": "^1.0.0",
+        "@jsonjoy.com/json-pointer": "^1.0.2",
+        "@jsonjoy.com/util": "^1.9.0",
+        "hyperdyperid": "^1.2.0",
+        "thingies": "^2.5.0",
+        "tree-dump": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/json-pack/node_modules/@jsonjoy.com/buffers": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/buffers/-/buffers-1.2.1.tgz",
+      "integrity": "sha512-12cdlDwX4RUM3QxmUbVJWqZ/mrK6dFQH4Zxq6+r1YXKXYBNgZXndx2qbCJwh3+WWkCSn67IjnlG3XYTvmvYtgA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/json-pointer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pointer/-/json-pointer-1.0.2.tgz",
+      "integrity": "sha512-Fsn6wM2zlDzY1U+v4Nc8bo3bVqgfNTGcn6dMgs6FjrEnt4ZCe60o6ByKRjOGlI2gow0aE/Q41QOigdTqkyK5fg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/codegen": "^1.0.0",
+        "@jsonjoy.com/util": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/util": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/util/-/util-1.9.0.tgz",
+      "integrity": "sha512-pLuQo+VPRnN8hfPqUTLTHk126wuYdXVxE6aDmjSeV4NCAgyxWbiOIeNJVtID3h1Vzpoi9m4jXezf73I6LgabgQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/buffers": "^1.0.0",
+        "@jsonjoy.com/codegen": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/util/node_modules/@jsonjoy.com/buffers": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/buffers/-/buffers-1.2.1.tgz",
+      "integrity": "sha512-12cdlDwX4RUM3QxmUbVJWqZ/mrK6dFQH4Zxq6+r1YXKXYBNgZXndx2qbCJwh3+WWkCSn67IjnlG3XYTvmvYtgA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@leichtgewicht/ip-codec": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
+      "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
@@ -2012,6 +2450,19 @@
         "@emnapi/core": "^1.4.3",
         "@emnapi/runtime": "^1.4.3",
         "@tybys/wasm-util": "^0.10.0"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@parcel/watcher": {
@@ -2324,6 +2775,175 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/@peculiar/asn1-cms": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.7.0.tgz",
+      "integrity": "sha512-hew63shtzzvBcSHbhm+cyAmKe6AIfinT9hzEqSPjDC6opTTMKmTkQ0gHuN2KsWlvqiKw1S/fS94fhag/FJkioQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "@peculiar/asn1-x509-attr": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-csr": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.7.0.tgz",
+      "integrity": "sha512-VVsAyGqErT9D1SY4aEqozThXMVI+ssVRiv2DDeYuvpBKLIgZ3hYs3Ay3u/VSoKq6ESFi9cf6rf3IOOzfwh7oMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-ecc": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.7.0.tgz",
+      "integrity": "sha512-n7KEs/Q/wrB415cxy4fHOBhegp4NdJ15fkJPwcB/3/8iNBQC2L/N7SChJPKDJPZGYH0jD4Tg4/0vnHmwghnbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pfx": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.7.0.tgz",
+      "integrity": "sha512-V/nrlQVmhg7lYAsM7E13UDL5erAwFv6kCIVFqNaMIHSVi7dngcT839JkRTkQBqznMG98l2XjxYk74ZztAohZzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.7.0",
+        "@peculiar/asn1-pkcs8": "^2.7.0",
+        "@peculiar/asn1-rsa": "^2.7.0",
+        "@peculiar/asn1-schema": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pkcs8": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.7.0.tgz",
+      "integrity": "sha512-9GTl1nE8Mx1kTZ+7QyYatDyKsm34QcWRBFkY1iPvWC3X4Dona5s/tlLiQsx5WzVdZqiMBZNYT0buyw4/vbhnjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pkcs9": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.7.0.tgz",
+      "integrity": "sha512-Bh7m+OuIaSEllPQcSd9OSp93F4ROWH7sbITWV8MI+8dwsjE5111/87VxiWVvYFKyww3vp39geLv9ENqhwWHcew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.7.0",
+        "@peculiar/asn1-pfx": "^2.7.0",
+        "@peculiar/asn1-pkcs8": "^2.7.0",
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "@peculiar/asn1-x509-attr": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-rsa": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.7.0.tgz",
+      "integrity": "sha512-/qvENQrXyTZURjMqSeofHul0JJt2sNSzSwk36pl2olkHbaioMQgrASDZAlHXl0xUlnVbHj0uGgOrBMTb5x2aJQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-schema": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.7.0.tgz",
+      "integrity": "sha512-W8ZfWzLmQnrcky+eh3tni4IozMdqBDiHWU0N+vve/UGjMaUs8c0L7A2oEdkBXS8rTpWDpK/aoI3DG/L/hxmxPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/utils": "^2.0.2",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.7.0.tgz",
+      "integrity": "sha512-mUn9RRrkGDnG4ALfunDmzyRW5dg+sWCj/pfnCCqEHYbkGxEpvUt6iVJv8Yw1cyp6SWZ26ZE5oSmI5SqEaen15g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/utils": "^2.0.2",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509-attr": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.7.0.tgz",
+      "integrity": "sha512-NS8e7SOgXipkzUPLF/sce7ukpMpWjhxYsH0n6Y+bHYo4TTxOb95Zv7hqwSuL212mj5YxovjdOKQOgH1As3E94w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/utils/-/utils-2.0.3.tgz",
+      "integrity": "sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/x509": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/x509/-/x509-1.14.3.tgz",
+      "integrity": "sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.6.0",
+        "@peculiar/asn1-csr": "^2.6.0",
+        "@peculiar/asn1-ecc": "^2.6.0",
+        "@peculiar/asn1-pkcs9": "^2.6.0",
+        "@peculiar/asn1-rsa": "^2.6.0",
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.0",
+        "pvtsutils": "^1.3.6",
+        "reflect-metadata": "^0.2.2",
+        "tslib": "^2.8.1",
+        "tsyringe": "^4.10.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -2604,6 +3224,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/bonjour": {
+      "version": "3.5.13",
+      "resolved": "https://registry.npmjs.org/@types/bonjour/-/bonjour-3.5.13.tgz",
+      "integrity": "sha512-z9fJ5Im06zvUL548KvYNecEVlA7cVDkGUi6kZusb04mpyEFKCIZJvloCcmpmLaIahDpOQGHaHmG6imtPMmPXGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/bootstrap": {
       "version": "5.2.10",
       "resolved": "https://registry.npmjs.org/@types/bootstrap/-/bootstrap-5.2.10.tgz",
@@ -2625,6 +3266,27 @@
         "@types/keyv": "^3.1.4",
         "@types/node": "*",
         "@types/responselike": "^1.0.0"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect-history-api-fallback": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@types/connect-history-api-fallback/-/connect-history-api-fallback-1.5.4.tgz",
+      "integrity": "sha512-n6Cr2xS1h4uAulPRdlw6Jl6s1oG8KrVilPN2yUITEs+K48EzMJJ3W1xy8K5eWuFvjp3R74AOIGSmp2UfBJ8HFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express-serve-static-core": "*",
+        "@types/node": "*"
       }
     },
     "node_modules/@types/escodegen": {
@@ -2673,6 +3335,32 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/express": {
+      "version": "4.17.25",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.25.tgz",
+      "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.33",
+        "@types/qs": "*",
+        "@types/serve-static": "^1"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "4.19.8",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.8.tgz",
+      "integrity": "sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
     "node_modules/@types/hast": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
@@ -2696,6 +3384,23 @@
       "integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/http-proxy": {
+      "version": "1.17.17",
+      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.17.tgz",
+      "integrity": "sha512-ED6LB+Z1AVylNTu7hdzuBqOgMnvG/ld6wGCG8wFnAzKX5uyW2K3WD52v0gnLCTK/VLpXtKckgWuyScYK6cSPaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
@@ -2762,6 +3467,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/mime": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "25.9.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
@@ -2788,6 +3500,20 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -2831,12 +3557,72 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/retry": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.2.tgz",
+      "integrity": "sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-index": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@types/serve-index/-/serve-index-1.9.4.tgz",
+      "integrity": "sha512-qLpGZ/c2fhSs5gnYsQxtDEq3Oy8SXPClIXkW5ghvAvsNuVSA8k+gCONcUCS/UjLEYvYps+e8uBtfgXgvhwfNug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "1.15.10",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.10.tgz",
+      "integrity": "sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*",
+        "@types/send": "<1"
+      }
+    },
+    "node_modules/@types/serve-static/node_modules/@types/send": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.6.tgz",
+      "integrity": "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/signals": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@types/signals/-/signals-1.0.4.tgz",
       "integrity": "sha512-6Nfcw0msIx3Srr0bz7u6v+y3mj7uy5Lh6fEbkPazaMr4qz+CtyKjfb7SX+8pq7a2TV710k0pm0Qxj5ClTB4YCA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/sockjs": {
+      "version": "0.3.36",
+      "resolved": "https://registry.npmjs.org/@types/sockjs/-/sockjs-0.3.36.tgz",
+      "integrity": "sha512-MK9V6NzAS1+Ud7JV9lJLFqW85VbC9dq3LmwZCuBe4wBDgKC0Kj/jd8Xl+nSviU+Qc3+m7umHHyHg//2KSa0a0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
@@ -2881,6 +3667,16 @@
       "integrity": "sha512-g49ijasEJvCd7ifmAY2D0wdEtt1xRjBbA33PJTiv8mKBr7DoMsPeISoJ8oQOTopSRi+FBWPpPW5ouDj2QPKtGA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/yargs": {
       "version": "17.0.35",
@@ -3420,6 +4216,30 @@
         "node": ">=0.4"
       }
     },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -3544,6 +4364,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/ansi-html-community": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/ansi-html-community/-/ansi-html-community-0.0.8.tgz",
+      "integrity": "sha512-1APHAyr3+PCamwNw3bXCPp4HFLONZt/yIH0sZp0/469KWNTEy+qN5jQ3GVX6DMZ1UXAi34yVwtTeaG/HpBuuzw==",
+      "dev": true,
+      "engines": [
+        "node >= 0.8.0"
+      ],
+      "license": "Apache-2.0",
+      "bin": {
+        "ansi-html": "bin/ansi-html"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -3649,6 +4482,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/array-includes": {
       "version": "3.1.9",
@@ -3761,6 +4601,21 @@
       "integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
       "extraneous": true,
       "license": "MIT"
+    },
+    "node_modules/asn1js": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.10.tgz",
+      "integrity": "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "pvtsutils": "^1.3.6",
+        "pvutils": "^1.1.5",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/async-function": {
       "version": "1.0.0",
@@ -3897,6 +4752,13 @@
         "baseline-browser-mapping": "dist/cli.js"
       }
     },
+    "node_modules/batch": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
+      "integrity": "sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/big.js": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
@@ -3905,6 +4767,19 @@
       "license": "MIT",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/bl": {
@@ -3943,6 +4818,59 @@
       "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.15.1",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/body-parser/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/body-parser/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/bonjour-service": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.4.0.tgz",
+      "integrity": "sha512-fGQtj1qdR9vIKjFiWPQd52qIqwjaYqhcI40JEiDuvlZ86E7ZBPBwY9fPgHy9r2rYGIjiRfctNPYz6OQU73ww2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "multicast-dns": "^7.2.5"
+      }
     },
     "node_modules/boolbase": {
       "version": "1.0.0",
@@ -4239,6 +5167,22 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "license": "MIT"
     },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -4247,6 +5191,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/bytestreamjs": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/bytestreamjs/-/bytestreamjs-2.0.1.tgz",
+      "integrity": "sha512-U1Z/ob71V/bXfVABvNr/Kumf5VyeQRBEm6Txb0PQ6S7V5GpBM3w4Cbqz/xPDicR5tN0uvDifng8C+5qECeGwyQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/cacheable-lookup": {
@@ -4734,6 +5688,16 @@
         "typedarray": "^0.0.6"
       }
     },
+    "node_modules/connect-history-api-fallback": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-2.0.0.tgz",
+      "integrity": "sha512-U73+6lQFmfiNPrYbXqr6kZ1i1wiRqXnp2nhMsINseWXO8lDau0LGEffJ8kQi4EjLZympVgRdvqjAgiZ1tgzDDA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/consola": {
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
@@ -4754,10 +5718,37 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/copy-to-clipboard": {
@@ -5084,6 +6075,36 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/default-browser": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/defer-to-connect": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
@@ -5123,6 +6144,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/define-properties": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
@@ -5141,6 +6175,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -5149,6 +6193,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
       }
     },
     "node_modules/detect-libc": {
@@ -5179,8 +6234,20 @@
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dns-packet": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.6.1.tgz",
+      "integrity": "sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==",
+      "dev": true,
       "license": "MIT",
-      "optional": true
+      "dependencies": {
+        "@leichtgewicht/ip-codec": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/doctrine": {
       "version": "2.1.0",
@@ -5323,6 +6390,13 @@
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "license": "MIT"
     },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/electron": {
       "version": "41.1.1",
       "resolved": "https://registry.npmjs.org/electron/-/electron-41.1.1.tgz",
@@ -5384,6 +6458,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/end-of-stream": {
@@ -5708,6 +6792,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -6153,6 +7244,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/event-stream": {
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
@@ -6168,6 +7269,13 @@
         "stream-combiner": "~0.0.4",
         "through": "~2.3.1"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/events": {
       "version": "3.3.0",
@@ -6239,6 +7347,121 @@
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
+    },
+    "node_modules/express": {
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.5",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.15.1",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express/node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/express/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/express/node_modules/path-to-regexp": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/express/node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/extract-zip": {
       "version": "2.0.1",
@@ -6321,6 +7544,19 @@
       "integrity": "sha512-bijHueCGd0LqqNK9b5oCMHc0MluJAx0cwqASgbWMvkO01lCYgIhacVRLcaDz3QnyYIRNJRDwMb41VuT6pHJ91Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/faye-websocket": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.4.tgz",
+      "integrity": "sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "websocket-driver": ">=0.5.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
     },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
@@ -6466,6 +7702,42 @@
         "node": ">=8"
       }
     },
+    "node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/finalhandler/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/finalhandler/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -6511,6 +7783,27 @@
       "dev": true,
       "license": "ISC",
       "peer": true
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
     },
     "node_modules/for-each": {
       "version": "0.3.5",
@@ -6561,6 +7854,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/from": {
@@ -6839,6 +8152,23 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/glob-to-regex.js": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/glob-to-regex.js/-/glob-to-regex.js-1.2.0.tgz",
+      "integrity": "sha512-QMwlOQKU/IzqMUOAZWubUOT8Qft+Y0KQWnX9nK3ch0CJg0tTp4TvGZsTfudYKv2NzoQSyPcnA6TYeIQ3jGichQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
     "node_modules/glob-to-regexp": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
@@ -6940,6 +8270,13 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
+    },
+    "node_modules/handle-thing": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
+      "integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/handlebars": {
       "version": "4.7.9",
@@ -7072,6 +8409,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/hpack.js": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
+      "integrity": "sha512-zJxVehUdMGIKsRaNt7apO2Gqp0BdqW5yaiGHXXmbpvxgBYVZnAql+BJb4RO5ad2MgpbZKn5G6nMnegrH1FcNYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "obuf": "^1.0.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.1.0"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -7160,6 +8510,81 @@
       "dev": true,
       "license": "BSD-2-Clause"
     },
+    "node_modules/http-deceiver": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
+      "integrity": "sha512-LmpOGxTfbpgtGVxJrj5k7asXHCgNZp5nLfp+hWc8QQRqtb7fUy6kRY3BO1h9ddF6yIPYUARgxGOwB42DnxIaNw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/http-parser-js": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.10.tgz",
+      "integrity": "sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/http-proxy": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
+      "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^4.0.0",
+        "follow-redirects": "^1.0.0",
+        "requires-port": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/http-proxy-middleware": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz",
+      "integrity": "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-proxy": "^1.17.8",
+        "http-proxy": "^1.18.1",
+        "is-glob": "^4.0.1",
+        "is-plain-obj": "^3.0.0",
+        "micromatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "@types/express": "^4.17.13"
+      },
+      "peerDependenciesMeta": {
+        "@types/express": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/http2-wrapper": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
@@ -7183,12 +8608,35 @@
         "node": ">=10.17.0"
       }
     },
+    "node_modules/hyperdyperid": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/hyperdyperid/-/hyperdyperid-1.2.0.tgz",
+      "integrity": "sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.18"
+      }
+    },
     "node_modules/hyphenate-style-name": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.1.0.tgz",
       "integrity": "sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw==",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/icss-utils": {
       "version": "5.1.0",
@@ -7356,6 +8804,16 @@
         "loose-envify": "^1.0.0"
       }
     },
+    "node_modules/ipaddr.js": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.4.0.tgz",
+      "integrity": "sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/is": {
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/is/-/is-0.2.7.tgz",
@@ -7423,6 +8881,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-boolean-object": {
@@ -7599,6 +9070,41 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-inside-container/node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-map": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
@@ -7623,6 +9129,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-network-error": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.3.2.tgz",
+      "integrity": "sha512-PhBY86zaxNZUuWP6h13Vu5oFe0XY6/UlKzQnYFELzGVHygP3MxmvTfYSG7GN3aIab/iWudSMgjSnG9Dq+nHrgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-number": {
@@ -7656,6 +9175,19 @@
       "resolved": "https://registry.npmjs.org/is-object/-/is-object-0.1.2.tgz",
       "integrity": "sha512-GkfZZlIZtpkFrqyAXPQSRBMsaHAw+CgoKe2HXAkjd/sfoI9+hS8PT4wg2rJxdQyUKr7N2vHJbg7/jQtE5l5vBQ==",
       "dev": true
+    },
+    "node_modules/is-plain-obj": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
+      "integrity": "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/is-plain-object": {
       "version": "2.0.4",
@@ -8809,6 +10341,17 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/launch-editor": {
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.13.2.tgz",
+      "integrity": "sha512-4VVDnbOpLXy/s8rdRCSXb+zfMeFR0WlJWpET1iA9CQdlZDfwyLjUuGQzXU4VeOoey6AicSAluWan7Etga6Kcmg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picocolors": "^1.1.1",
+        "shell-quote": "^1.8.3"
+      }
+    },
     "node_modules/level-blobs": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/level-blobs/-/level-blobs-0.1.7.tgz",
@@ -9354,6 +10897,46 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/memfs": {
+      "version": "4.57.3",
+      "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.57.3.tgz",
+      "integrity": "sha512-dlvqataP1zUOlfj6pv9wgCSC5pRIooNntXgdLfR7FWlcKi1p8fMfJADtHp/+8Dhu5JFvMHNh7L0QVcuaaBKqqA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/fs-core": "4.57.3",
+        "@jsonjoy.com/fs-fsa": "4.57.3",
+        "@jsonjoy.com/fs-node": "4.57.3",
+        "@jsonjoy.com/fs-node-builtins": "4.57.3",
+        "@jsonjoy.com/fs-node-to-fsa": "4.57.3",
+        "@jsonjoy.com/fs-node-utils": "4.57.3",
+        "@jsonjoy.com/fs-print": "4.57.3",
+        "@jsonjoy.com/fs-snapshot": "4.57.3",
+        "@jsonjoy.com/json-pack": "^1.11.0",
+        "@jsonjoy.com/util": "^1.9.0",
+        "glob-to-regex.js": "^1.0.1",
+        "thingies": "^2.5.0",
+        "tree-dump": "^1.0.3",
+        "tslib": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
     "node_modules/memorystream": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
@@ -9363,11 +10946,31 @@
         "node": ">= 0.10.0"
       }
     },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "license": "MIT"
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -9392,6 +10995,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/mime-db": {
@@ -9457,6 +11073,13 @@
         "webpack": "^5.0.0"
       }
     },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -9512,6 +11135,20 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/multicast-dns": {
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.2.5.tgz",
+      "integrity": "sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dns-packet": "^5.2.2",
+        "thunky": "^1.0.2"
+      },
+      "bin": {
+        "multicast-dns": "cli.js"
+      }
     },
     "node_modules/nano-css": {
       "version": "5.6.2",
@@ -9989,6 +11626,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obuf": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
+      "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/octal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/octal/-/octal-1.0.0.tgz",
@@ -10003,6 +11647,19 @@
       "dev": true,
       "engines": {
         "node": ">= 0.2.0"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/on-headers": {
@@ -10034,6 +11691,25 @@
       },
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/open": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "wsl-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -10128,6 +11804,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-retry": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-6.2.1.tgz",
+      "integrity": "sha512-hEt02O4hUct5wtwg4H4KcWgDdm+l1bOaEy/hWzd8xtXB9BqxTWBBhb+2ImAtH4Cv4rPjV76xN3Zumqk3k3AhhQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.2",
+        "is-network-error": "^1.0.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
@@ -10181,6 +11875,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/pascal-case": {
@@ -10362,6 +12066,24 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pkijs": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/pkijs/-/pkijs-3.4.0.tgz",
+      "integrity": "sha512-emEcLuomt2j03vxD54giVB4SxTjnsqkU692xZOZXHDVoYyypEm+b3jpiTcc+Cf+myooc+/Ly0z01jqeNHVgJGw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@noble/hashes": "1.4.0",
+        "asn1js": "^3.0.6",
+        "bytestreamjs": "^2.0.1",
+        "pvtsutils": "^1.3.6",
+        "pvutils": "^1.1.3",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -10602,6 +12324,30 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-addr/node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/prr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
@@ -10672,6 +12418,42 @@
       ],
       "license": "MIT"
     },
+    "node_modules/pvtsutils": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
+      "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/pvutils": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.5.tgz",
+      "integrity": "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/quick-lru": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
@@ -10703,6 +12485,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/raw-loader": {
@@ -11049,6 +12847,13 @@
         "node": ">= 10.13.0"
       }
     },
+    "node_modules/reflect-metadata": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -11167,6 +12972,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/resize-observer-polyfill": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
@@ -11281,6 +13093,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/roarr": {
       "version": "2.15.4",
       "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
@@ -11316,6 +13138,19 @@
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.1.2"
+      }
+    },
+    "node_modules/run-applescript": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/safe-array-concat": {
@@ -11393,6 +13228,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/sass": {
       "version": "1.97.2",
@@ -11515,6 +13357,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/select-hose": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
+      "integrity": "sha512-mEugaLK+YfkijB4fx0e6kImuJdCIt2LxCRcbEYPqRGCs4F2ogyfZU5IAZRdjCP8JPq2AtdNoC/Dux63d9Kiryg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/selfsigned": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-5.5.0.tgz",
+      "integrity": "sha512-ftnu3TW4+3eBfLRFnDEkzGxSF/10BJBkaLJuBHZX0kiPS7bRdlpZGu6YGt4KngMkdTwJE6MbjavFpqHvqVt+Ew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/x509": "^1.14.2",
+        "pkijs": "^3.3.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/semver": {
       "version": "7.7.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
@@ -11534,6 +13397,58 @@
       "dev": true,
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/send/node_modules/debug/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/send/node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/serialize-error": {
       "version": "7.0.1",
@@ -11651,6 +13566,99 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/serve-index": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.2.tgz",
+      "integrity": "sha512-KDj11HScOaLmrPxl70KYNW1PksP4Nb/CLL2yvC+Qd2kHMPEEpfc4Re2e4FOay+bC/+XQl/7zAcWON3JVo5v3KQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "batch": "0.6.1",
+        "debug": "2.6.9",
+        "escape-html": "~1.0.3",
+        "http-errors": "~1.8.0",
+        "mime-types": "~2.1.35",
+        "parseurl": "~1.3.3"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-index/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/serve-index/node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/serve-index/node_modules/http-errors": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/serve-index/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/serve-index/node_modules/statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/serve/node_modules/arg": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
@@ -11729,6 +13737,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/shallow-clone": {
       "version": "3.0.1",
@@ -11868,6 +13883,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/sockjs": {
+      "version": "0.3.24",
+      "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.24.tgz",
+      "integrity": "sha512-GJgLTZ7vYb/JtPSSZ10hsOYIvEYsjbNU+zPdIHcUaWVNUEPivzxku31865sSSud0Da0W4lEeOPlmw93zLQchuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "faye-websocket": "^0.11.3",
+        "uuid": "^8.3.2",
+        "websocket-driver": "^0.7.4"
+      }
+    },
     "node_modules/source-list-map": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
@@ -11939,6 +13966,53 @@
       "integrity": "sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ==",
       "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/spdy": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/spdy/-/spdy-4.0.2.tgz",
+      "integrity": "sha512-r46gZQZQV+Kl9oItvl1JZZqJKGr+oEkB08A6BzkiR7593/7IbtuncXHd2YoYeTsG4157ZssMu9KYvUHLcjcDoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.0",
+        "handle-thing": "^2.0.0",
+        "http-deceiver": "^1.2.7",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/spdy-transport": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-3.0.0.tgz",
+      "integrity": "sha512-hsLVFE5SjA6TCisWeJXFKniGGOpBgMLmerfO2aCyCU5s7nJ/rpAepqmFifv/GCbSbueEeAJJnmSQ2rKC/g8Fcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.0",
+        "detect-node": "^2.0.4",
+        "hpack.js": "^2.1.6",
+        "obuf": "^1.1.2",
+        "readable-stream": "^3.0.6",
+        "wbuf": "^1.7.3"
+      }
+    },
+    "node_modules/spdy-transport/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/split": {
       "version": "0.3.3",
@@ -12028,6 +14102,16 @@
         "error-stack-parser": "^2.0.6",
         "stack-generator": "^2.0.5",
         "stacktrace-gps": "^3.0.4"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/std-env": {
@@ -12497,6 +14581,23 @@
         "node": ">=8"
       }
     },
+    "node_modules/thingies": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/thingies/-/thingies-2.6.0.tgz",
+      "integrity": "sha512-rMHRjmlFLM1R96UYPvpmnc3LYtdFrT33JIB7L9hetGue1qAPfn1N2LJeEjxUSidu1Iku+haLZXDuEXUHNGO/lg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "^2"
+      }
+    },
     "node_modules/three": {
       "version": "0.149.0",
       "resolved": "https://registry.npmjs.org/three/-/three-0.149.0.tgz",
@@ -12517,6 +14618,13 @@
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/thunky": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
+      "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
       "dev": true,
       "license": "MIT"
     },
@@ -12561,6 +14669,33 @@
       "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tree-dump": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/tree-dump/-/tree-dump-1.1.0.tgz",
+      "integrity": "sha512-rMuvhU4MCDbcbnleZTFezWsaZXRFemSqAM+7jPnzUl1fo9w3YEKOxAeui0fz3OI4EU4hf23iyA7uQRVko+UaBA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
     },
     "node_modules/ts-easing": {
       "version": "0.2.0",
@@ -12729,6 +14864,26 @@
       "devOptional": true,
       "license": "0BSD"
     },
+    "node_modules/tsyringe": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/tsyringe/-/tsyringe-4.10.0.tgz",
+      "integrity": "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/tsyringe/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true,
+      "license": "0BSD"
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -12762,6 +14917,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/typed-array-buffer": {
@@ -13014,6 +15183,16 @@
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/unrs-resolver": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
@@ -13201,6 +15380,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
@@ -13267,6 +15467,16 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/wbuf": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.3.tgz",
+      "integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "node_modules/webpack": {
@@ -13371,6 +15581,195 @@
         "node": ">=18"
       }
     },
+    "node_modules/webpack-dev-middleware": {
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-7.4.5.tgz",
+      "integrity": "sha512-uxQ6YqGdE4hgDKNf7hUiPXOdtkXvBJXrfEGYSx7P7LC8hnUYGK70X6xQXUvXeNyBDDcsiQXpG2m3G9vxowaEuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "colorette": "^2.0.10",
+        "memfs": "^4.43.1",
+        "mime-types": "^3.0.1",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "schema-utils": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 18.12.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "webpack": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/webpack-dev-middleware/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/webpack-dev-middleware/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/webpack-dev-middleware/node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/webpack-dev-server": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.4.tgz",
+      "integrity": "sha512-GqDPGZN9bRqKBTkp4aWkobDDHMsrXKoGSdOH56smIri8qR0JG8gfL8/v/f/OZR3/OKXjG8uwJbFVhKm/FNU/UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/bonjour": "^3.5.13",
+        "@types/connect-history-api-fallback": "^1.5.4",
+        "@types/express": "^4.17.25",
+        "@types/express-serve-static-core": "^4.17.21",
+        "@types/serve-index": "^1.9.4",
+        "@types/serve-static": "^1.15.5",
+        "@types/sockjs": "^0.3.36",
+        "@types/ws": "^8.5.10",
+        "ansi-html-community": "^0.0.8",
+        "bonjour-service": "^1.2.1",
+        "chokidar": "^3.6.0",
+        "colorette": "^2.0.10",
+        "compression": "^1.8.1",
+        "connect-history-api-fallback": "^2.0.0",
+        "express": "^4.22.1",
+        "graceful-fs": "^4.2.6",
+        "http-proxy-middleware": "^2.0.9",
+        "ipaddr.js": "^2.1.0",
+        "launch-editor": "^2.6.1",
+        "open": "^10.0.3",
+        "p-retry": "^6.2.0",
+        "schema-utils": "^4.2.0",
+        "selfsigned": "^5.5.0",
+        "serve-index": "^1.9.1",
+        "sockjs": "^0.3.24",
+        "spdy": "^4.0.2",
+        "webpack-dev-middleware": "^7.4.2",
+        "ws": "^8.18.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "engines": {
+        "node": ">= 18.12.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "webpack": {
+          "optional": true
+        },
+        "webpack-cli": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/webpack-dev-server/node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/webpack-dev-server/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/webpack-dev-server/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/webpack-dev-server/node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
     "node_modules/webpack-merge": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-6.0.1.tgz",
@@ -13434,6 +15833,31 @@
         "webpack": {
           "optional": true
         }
+      }
+    },
+    "node_modules/websocket-driver": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
+      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "http-parser-js": ">=0.5.1",
+        "safe-buffer": ">=5.1.0",
+        "websocket-extensions": ">=0.1.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/websocket-extensions": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+      "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/which": {
@@ -13705,6 +16129,60 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wsl-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+      "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/wsl-utils/node_modules/is-wsl": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/xtend": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "webpack:prod": "cross-env NODE_ENV=production webpack",
     "serve": "serve ./dist -p 8080 --no-clipboard --config ../serve.json",
     "dev": "run-p webpack:dev-watch serve",
+    "dev:hmr": "run-p webpack:dev-kotor-watch webpack:serve-hmr",
+    "webpack:dev-kotor-watch": "cross-env NODE_ENV=development webpack --watch --config webpack/kotor-watch.config.js",
+    "webpack:serve-hmr": "cross-env NODE_ENV=development webpack serve --config webpack/Game.hmr.js",
     "electron:watch": "tsc-watch --project tsconfig.electron.json",
     "electron:compile": "tsc --project tsconfig.electron.json",
     "electron:build": "npm run webpack:prod && npm run electron:compile && npm run electron:icon && cross-env CSC_IDENTITY_AUTO_DISCOVERY=false npx --yes electron-builder build --publish=never",
@@ -82,6 +85,7 @@
     "user-agent-data-types": "^0.4.2",
     "webpack": "^5.104.1",
     "webpack-cli": "^6.0.1",
+    "webpack-dev-server": "^5.2.4",
     "webpackbar": "^7.0.0"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "electron:icon": "npx --yes electron-icon-builder --input=src/assets/icon-256.png --output=src/assets/icons",
     "generate-manifest": "node scripts/generate-manifest.js",
     "typedoc": "typedoc --out ./wiki ./src/KotOR.ts",
-    "test": "jest --verbose --coverage --no-cache ./src/tests"
+    "test": "jest --verbose --coverage --no-cache"
   },
   "author": "KobaltBlu",
   "license": "GPL-3.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "electron:icon": "npx --yes electron-icon-builder --input=src/assets/icon-256.png --output=src/assets/icons",
     "generate-manifest": "node scripts/generate-manifest.js",
     "typedoc": "typedoc --out ./wiki ./src/KotOR.ts",
-    "test": "jest --verbose --coverage --no-cache ./src/tests"
+    "test": "jest --verbose --coverage --no-cache"
   },
   "author": "KobaltBlu",
   "license": "GPL-3.0",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "file-loader": "^6.2.0",
     "html-webpack-plugin": "^5.6.5",
     "idb-keyval": "^6.2.2",
+    "jest-util": "^30.3.0",
     "mini-css-extract-plugin": "^2.9.4",
     "monaco-editor-webpack-plugin": "^7.1.1",
     "npm-run-all": "^4.1.5",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "generate-manifest": "node scripts/generate-manifest.js",
     "typedoc": "typedoc --out ./wiki ./src/KotOR.ts",
     "test": "jest --verbose --coverage --no-cache",
-    "test:hmr-e2e": "node scripts/hmr-session.e2e.cjs"
+    "test:hmr-e2e": "node scripts/hmr-session.e2e.cjs",
+    "test:hmr-e2e:assets": "node scripts/hmr-session.e2e.cjs"
   },
   "author": "KobaltBlu",
   "license": "GPL-3.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "electron:icon": "npx --yes electron-icon-builder --input=src/assets/icon-256.png --output=src/assets/icons",
     "generate-manifest": "node scripts/generate-manifest.js",
     "typedoc": "typedoc --out ./wiki ./src/KotOR.ts",
-    "test": "jest --verbose --coverage --no-cache"
+    "test": "jest --verbose --coverage --no-cache",
+    "test:hmr-e2e": "node scripts/hmr-session.e2e.cjs"
   },
   "author": "KobaltBlu",
   "license": "GPL-3.0",
@@ -59,6 +60,7 @@
     "monaco-editor-webpack-plugin": "^7.1.1",
     "npm-run-all": "^4.1.5",
     "path-browserify": "^1.0.1",
+    "puppeteer-core": "^24.43.1",
     "raw-loader": "^4.0.2",
     "react": "^19.2.3",
     "react-bootstrap": "^2.10.10",

--- a/scripts/hmr-session.e2e.cjs
+++ b/scripts/hmr-session.e2e.cjs
@@ -124,10 +124,11 @@ async function killProcess(child) {
     return;
   }
   child.kill('SIGTERM');
-  await wait(2000);
+  await wait(500);
   if (!child.killed) {
     child.kill('SIGKILL');
   }
+  await wait(200);
 }
 
 async function resolveBrowserExecutable() {
@@ -264,11 +265,11 @@ async function main() {
       probeValue: after.probeValue,
     });
   } finally {
-    await fs.writeFile(PROBE_FILE, originalProbe, 'utf8').catch(() => {});
     if (browser) {
       await browser.close().catch(() => {});
     }
     await killProcess(server);
+    await fs.writeFile(PROBE_FILE, originalProbe, 'utf8').catch(() => {});
   }
 }
 

--- a/scripts/hmr-session.e2e.cjs
+++ b/scripts/hmr-session.e2e.cjs
@@ -514,7 +514,16 @@ async function main() {
       }
     });
 
-    await page.goto(`${readyUrl}&devresume=0`, { waitUntil: 'domcontentloaded', timeout: SERVER_TIMEOUT_MS });
+    await page.goto(readyUrl, { waitUntil: 'domcontentloaded', timeout: SERVER_TIMEOUT_MS });
+    // Drop any stale snapshot so boot resume does not hijack quick-play; resume
+    // stays enabled for F5 / engine-edit reloads in later phases.
+    await page.evaluate((key) => {
+      try {
+        window.localStorage.removeItem(key);
+      } catch {
+        // ignore
+      }
+    }, RESUME_STORAGE_KEY);
     await page.waitForFunction(() => window.__KOTOR_HMR_TEST__, { timeout: 60000 });
 
     const before = await page.evaluate(() => ({

--- a/scripts/hmr-session.e2e.cjs
+++ b/scripts/hmr-session.e2e.cjs
@@ -19,6 +19,9 @@ const USE_REAL_ASSETS = Boolean(
 const REAL_ASSET_READY_TIMEOUT_MS = Number(
   process.env.KOTOR_HMR_REAL_ASSET_TIMEOUT_MS || 600000,
 );
+const KOTOR_HMR_E2E_MODULE = process.env.KOTOR_HMR_E2E_MODULE || '';
+const USE_IN_MODULE =
+  USE_REAL_ASSETS && Boolean(KOTOR_HMR_E2E_MODULE);
 const SERVER_READY_URLS = [
   GAME_URL,
   `http://127.0.0.1:${PORT}/game/index.html?key=kotor`,
@@ -199,6 +202,27 @@ async function waitForRealAssetSession(page) {
   );
 }
 
+async function waitForInModuleSession(page, moduleName) {
+  const start = Date.now();
+  while (Date.now() - start < REAL_ASSET_READY_TIMEOUT_MS) {
+    const snapshot = await page.evaluate(() => {
+      const bridge = window.__KOTOR_HMR_TEST__;
+      return bridge ? bridge.snapshotSession() : { ready: false, module: null, area: null, player: null };
+    });
+    if (
+      snapshot.ready
+      && snapshot.module === moduleName
+      && snapshot.player
+    ) {
+      return snapshot;
+    }
+    await wait(2000);
+  }
+  throw new Error(
+    `Module ${moduleName} did not become playable within ${REAL_ASSET_READY_TIMEOUT_MS}ms`,
+  );
+}
+
 async function main() {
   const originalProbe = await fs.readFile(PROBE_FILE, 'utf8');
   let server;
@@ -248,6 +272,15 @@ async function main() {
       console.log(`[hmr-e2e] Real assets: waiting for GameState.Ready via ${KOTOR_DEV_GAME_DIR}`);
       const snapshot = await waitForRealAssetSession(page);
       console.log('[hmr-e2e] Real asset session snapshot:', snapshot);
+
+      if (USE_IN_MODULE) {
+        console.log(`[hmr-e2e] Quick-play into module: ${KOTOR_HMR_E2E_MODULE}`);
+        await page.evaluate(async (moduleName) => {
+          await window.__KOTOR_HMR_TEST__.startQuickPlayToModule(moduleName);
+        }, KOTOR_HMR_E2E_MODULE);
+        const inModule = await waitForInModuleSession(page, KOTOR_HMR_E2E_MODULE);
+        console.log('[hmr-e2e] In-module session snapshot:', inModule);
+      }
     } else {
       await page.evaluate(() => window.__KOTOR_HMR_TEST__.activateSession());
     }
@@ -260,6 +293,10 @@ async function main() {
           : 'Failed to activate simulated session before HMR',
       );
     }
+
+    const preHmrSnapshot = USE_IN_MODULE
+      ? await page.evaluate(() => window.__KOTOR_HMR_TEST__.snapshotSession())
+      : null;
 
     const navigationsBeforeHmr = mainFrameNavigations;
     const probeValue = Date.now();
@@ -310,8 +347,31 @@ async function main() {
       throw new Error(`HMR probe value mismatch (expected ${probeValue}, got ${after.probeValue})`);
     }
 
+    if (preHmrSnapshot) {
+      const postHmrSnapshot = await page.evaluate(() => window.__KOTOR_HMR_TEST__.snapshotSession());
+      if (postHmrSnapshot.module !== preHmrSnapshot.module) {
+        throw new Error(
+          `In-module session lost module name (${preHmrSnapshot.module} -> ${postHmrSnapshot.module})`,
+        );
+      }
+      if (!postHmrSnapshot.player || !preHmrSnapshot.player) {
+        throw new Error('In-module session lost player reference after HMR');
+      }
+      const { x: bx, y: by, z: bz } = preHmrSnapshot.player;
+      const { x: ax, y: ay, z: az } = postHmrSnapshot.player;
+      if (bx !== ax || by !== ay || bz !== az) {
+        throw new Error(
+          `In-module player position changed after HMR (${bx},${by},${bz}) -> (${ax},${ay},${az})`,
+        );
+      }
+    }
+
     console.log('HMR session preservation E2E passed:', {
-      mode: USE_REAL_ASSETS ? 'real-assets' : 'synthetic',
+      mode: USE_IN_MODULE
+        ? 'real-assets-in-module'
+        : USE_REAL_ASSETS
+          ? 'real-assets'
+          : 'synthetic',
       pageLoadId: after.pageLoadId,
       acceptCount: after.acceptCount,
       probeValue: after.probeValue,

--- a/scripts/hmr-session.e2e.cjs
+++ b/scripts/hmr-session.e2e.cjs
@@ -188,17 +188,17 @@ async function ensureDistAssets() {
 async function waitForRealAssetSession(page) {
   const start = Date.now();
   while (Date.now() - start < REAL_ASSET_READY_TIMEOUT_MS) {
-    const snapshot = await page.evaluate(() => {
-      const bridge = window.__KOTOR_HMR_TEST__;
-      return bridge ? bridge.snapshotSession() : { ready: false, module: null, area: null, player: null };
-    });
-    if (snapshot.ready) {
-      return snapshot;
+    await page.evaluate(() => window.__KOTOR_HMR_TEST__?.skipIntroMovies?.());
+    const ready = await page.evaluate(
+      () => window.__KOTOR_HMR_TEST__?.isQuickPlayReady?.() ?? false,
+    );
+    if (ready) {
+      return page.evaluate(() => window.__KOTOR_HMR_TEST__.snapshotSession());
     }
     await wait(2000);
   }
   throw new Error(
-    `Real asset load did not reach GameState.Ready within ${REAL_ASSET_READY_TIMEOUT_MS}ms`,
+    `Real asset load did not reach quick-play readiness within ${REAL_ASSET_READY_TIMEOUT_MS}ms`,
   );
 }
 

--- a/scripts/hmr-session.e2e.cjs
+++ b/scripts/hmr-session.e2e.cjs
@@ -148,12 +148,24 @@ async function resolveBrowserExecutable() {
   throw new Error('No Chromium executable found. Set PUPPETEER_EXECUTABLE_PATH.');
 }
 
+async function ensureDistAssets() {
+  const threeDest = path.join(ROOT, 'dist/three.min.js');
+  if (!fsSync.existsSync(threeDest)) {
+    await fs.mkdir(path.dirname(threeDest), { recursive: true });
+    await fs.copyFile(
+      path.join(ROOT, 'node_modules/three/build/three.min.js'),
+      threeDest,
+    );
+  }
+}
+
 async function main() {
   const originalProbe = await fs.readFile(PROBE_FILE, 'utf8');
   let server;
   let browser;
 
   try {
+    await ensureDistAssets();
     server = startDevServer();
     server.stdout.on('data', (chunk) => process.stdout.write(chunk));
     server.stderr.on('data', (chunk) => process.stderr.write(chunk));

--- a/scripts/hmr-session.e2e.cjs
+++ b/scripts/hmr-session.e2e.cjs
@@ -193,6 +193,7 @@ async function waitForRealAssetSession(page) {
       () => window.__KOTOR_HMR_TEST__?.isQuickPlayReady?.() ?? false,
     );
     if (ready) {
+      await page.evaluate(() => window.__KOTOR_HMR_TEST__.activateSession());
       return page.evaluate(() => window.__KOTOR_HMR_TEST__.snapshotSession());
     }
     await wait(2000);

--- a/scripts/hmr-session.e2e.cjs
+++ b/scripts/hmr-session.e2e.cjs
@@ -12,6 +12,13 @@ const ROOT = path.resolve(__dirname, '..');
 const PORT = Number(process.env.KOTOR_HMR_E2E_PORT || 8099);
 const PROBE_FILE = path.join(ROOT, 'src/dev/HmrTestProbe.ts');
 const GAME_URL = `http://127.0.0.1:${PORT}/game/?key=kotor`;
+const KOTOR_DEV_GAME_DIR = process.env.KOTOR_DEV_GAME_DIR || '';
+const USE_REAL_ASSETS = Boolean(
+  KOTOR_DEV_GAME_DIR && fsSync.existsSync(KOTOR_DEV_GAME_DIR),
+);
+const REAL_ASSET_READY_TIMEOUT_MS = Number(
+  process.env.KOTOR_HMR_REAL_ASSET_TIMEOUT_MS || 600000,
+);
 const SERVER_READY_URLS = [
   GAME_URL,
   `http://127.0.0.1:${PORT}/game/index.html?key=kotor`,
@@ -113,6 +120,7 @@ function startDevServer() {
         ...process.env,
         KOTOR_DEV_PORT: String(PORT),
         NODE_ENV: 'development',
+        ...(USE_REAL_ASSETS ? { KOTOR_DEV_GAME_DIR } : {}),
       },
       stdio: ['ignore', 'pipe', 'pipe'],
       detached: process.platform !== 'win32',
@@ -174,6 +182,23 @@ async function ensureDistAssets() {
   }
 }
 
+async function waitForRealAssetSession(page) {
+  const start = Date.now();
+  while (Date.now() - start < REAL_ASSET_READY_TIMEOUT_MS) {
+    const snapshot = await page.evaluate(() => {
+      const bridge = window.__KOTOR_HMR_TEST__;
+      return bridge ? bridge.snapshotSession() : { ready: false, module: null, area: null, player: null };
+    });
+    if (snapshot.ready) {
+      return snapshot;
+    }
+    await wait(2000);
+  }
+  throw new Error(
+    `Real asset load did not reach GameState.Ready within ${REAL_ASSET_READY_TIMEOUT_MS}ms`,
+  );
+}
+
 async function main() {
   const originalProbe = await fs.readFile(PROBE_FILE, 'utf8');
   let server;
@@ -193,7 +218,8 @@ async function main() {
     browser = await puppeteer.launch({
       headless: true,
       executablePath: await resolveBrowserExecutable(),
-      args: ['--no-sandbox', '--disable-setuid-sandbox'],
+      protocolTimeout: REAL_ASSET_READY_TIMEOUT_MS + 120000,
+      args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage'],
     });
 
     const page = await browser.newPage();
@@ -218,10 +244,21 @@ async function main() {
       acceptCount: window.__KOTOR_HMR_TEST__.getAcceptCount(),
     }));
 
-    await page.evaluate(() => window.__KOTOR_HMR_TEST__.activateSession());
+    if (USE_REAL_ASSETS) {
+      console.log(`[hmr-e2e] Real assets: waiting for GameState.Ready via ${KOTOR_DEV_GAME_DIR}`);
+      const snapshot = await waitForRealAssetSession(page);
+      console.log('[hmr-e2e] Real asset session snapshot:', snapshot);
+    } else {
+      await page.evaluate(() => window.__KOTOR_HMR_TEST__.activateSession());
+    }
+
     const sessionActiveBefore = await page.evaluate(() => window.__KOTOR_HMR_TEST__.isSessionActive());
     if (!sessionActiveBefore) {
-      throw new Error('Failed to activate simulated session before HMR');
+      throw new Error(
+        USE_REAL_ASSETS
+          ? 'GameState.Ready was not active before HMR after real asset load'
+          : 'Failed to activate simulated session before HMR',
+      );
     }
 
     const navigationsBeforeHmr = mainFrameNavigations;
@@ -274,6 +311,7 @@ async function main() {
     }
 
     console.log('HMR session preservation E2E passed:', {
+      mode: USE_REAL_ASSETS ? 'real-assets' : 'synthetic',
       pageLoadId: after.pageLoadId,
       acceptCount: after.acceptCount,
       probeValue: after.probeValue,

--- a/scripts/hmr-session.e2e.cjs
+++ b/scripts/hmr-session.e2e.cjs
@@ -11,6 +11,14 @@ const fsSync = require('fs');
 const ROOT = path.resolve(__dirname, '..');
 const PORT = Number(process.env.KOTOR_HMR_E2E_PORT || 8099);
 const PROBE_FILE = path.join(ROOT, 'src/dev/HmrTestProbe.ts');
+// Real engine file mutated by the engine-edit reload-resume phase. Engine
+// modules cannot hot-swap in place, so edits here must snapshot + reload +
+// auto-resume (see src/dev/DevSessionResume.ts).
+const ENGINE_FILE = path.join(ROOT, 'src/module/ModuleArea.ts');
+const ENGINE_MARKER_GLOBAL = '__KOTOR_HMR_E2E_ENGINE_MARKER__';
+// Engine edits rebuild the 22 MiB game chunk — slower than probe-only swaps.
+const ENGINE_COMPILE_TIMEOUT_MS = 300000;
+const RESUME_STORAGE_KEY = 'kotor.devResumeSnapshot';
 const GAME_URL = `http://127.0.0.1:${PORT}/game/?key=kotor`;
 const KOTOR_DEV_GAME_DIR = process.env.KOTOR_DEV_GAME_DIR || '';
 const USE_REAL_ASSETS = Boolean(
@@ -29,6 +37,10 @@ const SERVER_READY_URLS = [
 ];
 const SERVER_TIMEOUT_MS = 180000;
 const HMR_TIMEOUT_MS = 90000;
+// Two cycles catch once-only accept wiring (regressions that survive exactly one swap).
+const HMR_CYCLES = 2;
+// Physics settles the spawn z shortly after module load; exact equality flakes.
+const POSITION_EPSILON = 0.25;
 
 function wait(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -205,11 +217,27 @@ async function waitForRealAssetSession(page) {
 
 async function waitForInModuleSession(page, moduleName) {
   const start = Date.now();
+  let lastSnapshot = null;
+  let lastSnapshotLog = 0;
   while (Date.now() - start < REAL_ASSET_READY_TIMEOUT_MS) {
+    await page.evaluate(() => window.__KOTOR_HMR_TEST__?.skipIntroMovies?.());
+    const quickPlayError = await page.evaluate(
+      () => window.__KOTOR_HMR_E2E_QUICKPLAY_ERROR__ ?? null,
+    );
+    if (quickPlayError) {
+      throw new Error(`startQuickPlayToModule(${moduleName}) failed in-page: ${quickPlayError}`);
+    }
     const snapshot = await page.evaluate(() => {
       const bridge = window.__KOTOR_HMR_TEST__;
-      return bridge ? bridge.snapshotSession() : { ready: false, module: null, area: null, player: null };
+      return bridge
+        ? bridge.snapshotSession()
+        : { ready: false, mode: -1, module: null, area: null, creatureCount: null, player: null };
     });
+    lastSnapshot = snapshot;
+    if (Date.now() - lastSnapshotLog > 10000) {
+      console.log('[hmr-e2e] Waiting for in-module snapshot:', snapshot);
+      lastSnapshotLog = Date.now();
+    }
     if (
       snapshot.ready
       && snapshot.module === moduleName
@@ -220,12 +248,237 @@ async function waitForInModuleSession(page, moduleName) {
     await wait(2000);
   }
   throw new Error(
-    `Module ${moduleName} did not become playable within ${REAL_ASSET_READY_TIMEOUT_MS}ms`,
+    `Module ${moduleName} did not become playable within ${REAL_ASSET_READY_TIMEOUT_MS}ms; last snapshot: ${JSON.stringify(lastSnapshot)}`,
   );
+}
+
+/** page.evaluate that tolerates mid-navigation context destruction. */
+async function safeEvaluate(page, fn, ...args) {
+  try {
+    return await page.evaluate(fn, ...args);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Polls until DevSessionResume reports 'resumed' and the bridge confirms a
+ * playable session in the expected module. Tolerates the page being
+ * mid-reload when polling starts.
+ */
+async function waitForResumedSession(page, moduleName) {
+  const start = Date.now();
+  let last = null;
+  let lastLog = 0;
+  while (Date.now() - start < REAL_ASSET_READY_TIMEOUT_MS) {
+    const state = await safeEvaluate(page, () => ({
+      resumeState: window.__KOTOR_DEV_RESUME_STATE__ ?? null,
+      snapshot: window.__KOTOR_HMR_TEST__
+        ? window.__KOTOR_HMR_TEST__.snapshotSession()
+        : null,
+    }));
+    if (state) {
+      last = state;
+      if (Date.now() - lastLog > 10000) {
+        console.log('[hmr-e2e] Waiting for dev resume:', state.resumeState, state.snapshot?.module);
+        lastLog = Date.now();
+      }
+      if (state.resumeState === 'failed') {
+        throw new Error('DevSessionResume reported failure — see browser console');
+      }
+      if (
+        state.resumeState === 'resumed'
+        && state.snapshot?.ready
+        && state.snapshot.module === moduleName
+        && state.snapshot.player
+      ) {
+        return state.snapshot;
+      }
+    }
+    await wait(2000);
+  }
+  throw new Error(
+    `Session did not auto-resume into ${moduleName} within ${REAL_ASSET_READY_TIMEOUT_MS}ms; last: ${JSON.stringify(last)}`,
+  );
+}
+
+function assertPositionClose(label, expected, actual) {
+  if (
+    Math.abs(expected.x - actual.x) > POSITION_EPSILON
+    || Math.abs(expected.y - actual.y) > POSITION_EPSILON
+    || Math.abs(expected.z - actual.z) > POSITION_EPSILON
+  ) {
+    throw new Error(
+      `${label}: position drifted beyond epsilon ${POSITION_EPSILON} `
+      + `(${expected.x},${expected.y},${expected.z}) -> (${actual.x},${actual.y},${actual.z})`,
+    );
+  }
+}
+
+async function readStoredResumePosition(page) {
+  return page.evaluate((key) => {
+    try {
+      const stored = JSON.parse(window.localStorage.getItem(key) || 'null');
+      return stored?.position ?? null;
+    } catch {
+      return null;
+    }
+  }, RESUME_STORAGE_KEY);
+}
+
+function positionMatchesNudge(storedPos, nudged) {
+  return storedPos
+    && Math.abs(storedPos.x - nudged.x) <= POSITION_EPSILON
+    && Math.abs(storedPos.y - nudged.y) <= POSITION_EPSILON
+    && Math.abs(storedPos.z - nudged.z) <= POSITION_EPSILON;
+}
+
+/**
+ * Phase C — manual F5: a full reload must auto-resume the session in-module
+ * at the saved player position instead of returning to the main menu.
+ */
+async function runF5ResumePhase(page, moduleName) {
+  console.log('[hmr-e2e] Phase: F5 reload-resume');
+  await page.evaluate(() => window.__KOTOR_HMR_TEST__.nudgePlayer(2.0, 1.5));
+  const nudged = await page.evaluate(
+    () => window.__KOTOR_HMR_TEST__.snapshotSession().player,
+  );
+  if (!nudged) {
+    throw new Error('F5 phase: no player to nudge before reload');
+  }
+
+  // Autosave runs every 2s — wait until the stored snapshot reflects the nudge.
+  const storedDeadline = Date.now() + 20000;
+  let stored = null;
+  while (Date.now() < storedDeadline) {
+    stored = await page.evaluate((key) => {
+      try {
+        return JSON.parse(window.localStorage.getItem(key) || 'null');
+      } catch {
+        return null;
+      }
+    }, RESUME_STORAGE_KEY);
+    if (positionMatchesNudge(stored?.position, nudged)) {
+      break;
+    }
+    await wait(1000);
+  }
+  if (!stored?.position) {
+    throw new Error('F5 phase: dev resume snapshot never appeared in localStorage');
+  }
+
+  const pageLoadIdBefore = await page.evaluate(
+    () => window.__KOTOR_HMR_TEST__.getPageLoadId(),
+  );
+
+  await page.reload({ waitUntil: 'domcontentloaded', timeout: SERVER_TIMEOUT_MS });
+  await page.waitForFunction(() => window.__KOTOR_HMR_TEST__, { timeout: 120000 });
+
+  const resumed = await waitForResumedSession(page, moduleName);
+  const pageLoadIdAfter = await page.evaluate(
+    () => window.__KOTOR_HMR_TEST__.getPageLoadId(),
+  );
+  if (pageLoadIdAfter === pageLoadIdBefore) {
+    throw new Error('F5 phase: pageLoadId unchanged — reload did not actually happen');
+  }
+  const resumeSnapshotPos = await readStoredResumePosition(page);
+  if (!resumeSnapshotPos) {
+    throw new Error('F5 phase: no resume snapshot in localStorage after resume');
+  }
+  assertPositionClose('F5 resume (stored snapshot)', resumeSnapshotPos, resumed.player);
+  console.log('[hmr-e2e] F5 reload-resume passed:', {
+    module: resumed.module,
+    area: resumed.area,
+    player: resumed.player,
+  });
+  return resumed;
+}
+
+/**
+ * Phase B — engine edit: editing a real engine module (not the probe) must
+ * trigger snapshot -> full reload -> auto-resume, with the NEW engine code
+ * demonstrably executing in the resumed session.
+ */
+async function runEngineEditResumePhase(page, moduleName, compileTracker) {
+  console.log('[hmr-e2e] Phase: engine-edit reload-resume');
+  const pageLoadIdBefore = await page.evaluate(
+    () => window.__KOTOR_HMR_TEST__.getPageLoadId(),
+  );
+
+  // Wait for a fresh autosave so the abort-time snapshot is recent.
+  const autosaveDeadline = Date.now() + 20000;
+  let preEditSnapshotPos = null;
+  while (Date.now() < autosaveDeadline) {
+    preEditSnapshotPos = await readStoredResumePosition(page);
+    if (preEditSnapshotPos) {
+      break;
+    }
+    await wait(1000);
+  }
+  if (!preEditSnapshotPos) {
+    throw new Error('Engine phase: no dev resume snapshot before engine edit');
+  }
+
+  const engineSource = await fs.readFile(ENGINE_FILE, 'utf8');
+  const anchor = 'update(delta: number = 0){';
+  if (!engineSource.includes(anchor)) {
+    throw new Error(`Engine phase: anchor not found in ${ENGINE_FILE}`);
+  }
+  const markerLine = `\n    (window as any).${ENGINE_MARKER_GLOBAL} = (((window as any).${ENGINE_MARKER_GLOBAL} ?? 0) + 1);`;
+  const patched = engineSource.replace(anchor, anchor + markerLine);
+
+  const compileReady = compileTracker.waitForNextCompile(ENGINE_COMPILE_TIMEOUT_MS);
+  await fs.writeFile(ENGINE_FILE, patched, 'utf8');
+  await compileReady;
+
+  // The abort handler reloads the page; wait for a different pageLoadId.
+  const reloadDeadline = Date.now() + 120000;
+  let reloaded = false;
+  while (Date.now() < reloadDeadline) {
+    const currentId = await safeEvaluate(
+      page,
+      () => window.__KOTOR_HMR_TEST__?.getPageLoadId?.() ?? null,
+    );
+    if (currentId && currentId !== pageLoadIdBefore) {
+      reloaded = true;
+      break;
+    }
+    await wait(1000);
+  }
+  if (!reloaded) {
+    throw new Error('Engine phase: page did not reload after engine edit (abort handler missing?)');
+  }
+
+  const resumed = await waitForResumedSession(page, moduleName);
+  const resumeSnapshotPos = await readStoredResumePosition(page);
+  if (!resumeSnapshotPos) {
+    throw new Error('Engine phase: no resume snapshot in localStorage after resume');
+  }
+  assertPositionClose('Engine-edit resume (stored snapshot)', resumeSnapshotPos, resumed.player);
+
+  // Prove the NEW engine code is executing: the marker must keep counting.
+  const markerProof = await page.evaluate((markerGlobal) => new Promise((resolve) => {
+    const first = window[markerGlobal] ?? null;
+    setTimeout(() => {
+      resolve({ first, later: window[markerGlobal] ?? null });
+    }, 1500);
+  }), ENGINE_MARKER_GLOBAL);
+  if (markerProof.first === null || markerProof.later === null || !(markerProof.later > markerProof.first)) {
+    throw new Error(
+      `Engine phase: new engine code not executing after resume (marker ${JSON.stringify(markerProof)})`,
+    );
+  }
+  console.log('[hmr-e2e] Engine-edit reload-resume passed:', {
+    module: resumed.module,
+    player: resumed.player,
+    marker: markerProof,
+  });
+  return resumed;
 }
 
 async function main() {
   const originalProbe = await fs.readFile(PROBE_FILE, 'utf8');
+  const originalEngineSource = await fs.readFile(ENGINE_FILE, 'utf8');
   let server;
   let browser;
 
@@ -261,7 +514,7 @@ async function main() {
       }
     });
 
-    await page.goto(readyUrl, { waitUntil: 'domcontentloaded', timeout: SERVER_TIMEOUT_MS });
+    await page.goto(`${readyUrl}&devresume=0`, { waitUntil: 'domcontentloaded', timeout: SERVER_TIMEOUT_MS });
     await page.waitForFunction(() => window.__KOTOR_HMR_TEST__, { timeout: 60000 });
 
     const before = await page.evaluate(() => ({
@@ -276,8 +529,14 @@ async function main() {
 
       if (USE_IN_MODULE) {
         console.log(`[hmr-e2e] Quick-play into module: ${KOTOR_HMR_E2E_MODULE}`);
-        await page.evaluate(async (moduleName) => {
-          await window.__KOTOR_HMR_TEST__.startQuickPlayToModule(moduleName);
+        // Fire-and-forget: awaiting the full module load inside one evaluate
+        // call exceeds the CDP protocolTimeout on slow asset stores. Progress
+        // is observed by polling snapshotSession from Node instead.
+        await page.evaluate((moduleName) => {
+          window.__KOTOR_HMR_E2E_QUICKPLAY_ERROR__ = null;
+          window.__KOTOR_HMR_TEST__.startQuickPlayToModule(moduleName).catch((e) => {
+            window.__KOTOR_HMR_E2E_QUICKPLAY_ERROR__ = String((e && e.message) || e);
+          });
         }, KOTOR_HMR_E2E_MODULE);
         const inModule = await waitForInModuleSession(page, KOTOR_HMR_E2E_MODULE);
         console.log('[hmr-e2e] In-module session snapshot:', inModule);
@@ -299,53 +558,83 @@ async function main() {
       ? await page.evaluate(() => window.__KOTOR_HMR_TEST__.snapshotSession())
       : null;
 
-    const navigationsBeforeHmr = mainFrameNavigations;
-    const probeValue = Date.now();
-    const updatedProbe = originalProbe.replace(
-      /export const HMR_PROBE = \d+/,
-      `export const HMR_PROBE = ${probeValue}`,
-    );
-    if (updatedProbe === originalProbe) {
-      throw new Error('Failed to rewrite HmrTestProbe.ts for HMR trigger');
-    }
-    const compileReady = compileTracker.waitForNextCompile(HMR_TIMEOUT_MS);
-    await fs.writeFile(PROBE_FILE, updatedProbe, 'utf8');
-    await compileReady;
-    await wait(500);
+    // Heap marker: survives hot swaps, lost on any silent full reload.
+    await page.evaluate(() => {
+      window.__KOTOR_HMR_E2E_HEAP_MARKER__ = window.__KOTOR_HMR_TEST__.getPageLoadId();
+    });
 
-    await page.waitForFunction(
-      (expectedProbe) => {
-        const bridge = window.__KOTOR_HMR_TEST__;
-        return !!bridge
-          && bridge.getAcceptCount() > 0
-          && bridge.getProbeValue() === expectedProbe
-          && bridge.isSessionActive();
-      },
-      { timeout: HMR_TIMEOUT_MS },
-      probeValue,
-    );
+    let lastAfter = null;
+    for (let cycle = 1; cycle <= HMR_CYCLES; cycle += 1) {
+      const navigationsBeforeHmr = mainFrameNavigations;
+      const beforeCycle = await page.evaluate(() => ({
+        acceptCount: window.__KOTOR_HMR_TEST__.getAcceptCount(),
+        loopGeneration: window.__KOTOR_HMR_TEST__.getLoopGeneration(),
+      }));
 
-    const after = await page.evaluate(() => ({
-      pageLoadId: window.__KOTOR_HMR_TEST__.getPageLoadId(),
-      acceptCount: window.__KOTOR_HMR_TEST__.getAcceptCount(),
-      sessionActive: window.__KOTOR_HMR_TEST__.isSessionActive(),
-      probeValue: window.__KOTOR_HMR_TEST__.getProbeValue(),
-    }));
+      const probeValue = Date.now() + cycle;
+      const currentProbe = await fs.readFile(PROBE_FILE, 'utf8');
+      const updatedProbe = currentProbe.replace(
+        /export const HMR_PROBE = \d+/,
+        `export const HMR_PROBE = ${probeValue}`,
+      );
+      if (updatedProbe === currentProbe) {
+        throw new Error(`Cycle ${cycle}: failed to rewrite HmrTestProbe.ts for HMR trigger`);
+      }
+      const compileReady = compileTracker.waitForNextCompile(HMR_TIMEOUT_MS);
+      await fs.writeFile(PROBE_FILE, updatedProbe, 'utf8');
+      await compileReady;
+      await wait(500);
 
-    if (after.pageLoadId !== before.pageLoadId) {
-      throw new Error(`Full page reload detected (pageLoadId changed: ${before.pageLoadId} -> ${after.pageLoadId})`);
-    }
-    if (mainFrameNavigations > navigationsBeforeHmr) {
-      throw new Error(`Main-frame navigation occurred during HMR (${navigationsBeforeHmr} -> ${mainFrameNavigations})`);
-    }
-    if (!after.sessionActive) {
-      throw new Error('Session was not preserved after hot reload');
-    }
-    if (after.acceptCount <= before.acceptCount) {
-      throw new Error(`HotReloadManager accept count did not increase (${before.acceptCount} -> ${after.acceptCount})`);
-    }
-    if (after.probeValue !== probeValue) {
-      throw new Error(`HMR probe value mismatch (expected ${probeValue}, got ${after.probeValue})`);
+      await page.waitForFunction(
+        (expectedProbe, expectedAcceptCount) => {
+          const bridge = window.__KOTOR_HMR_TEST__;
+          return !!bridge
+            && bridge.getAcceptCount() >= expectedAcceptCount
+            && bridge.getProbeValue() === expectedProbe
+            && bridge.isSessionActive();
+        },
+        { timeout: HMR_TIMEOUT_MS },
+        probeValue,
+        beforeCycle.acceptCount + 1,
+      );
+
+      const after = await page.evaluate(() => ({
+        pageLoadId: window.__KOTOR_HMR_TEST__.getPageLoadId(),
+        acceptCount: window.__KOTOR_HMR_TEST__.getAcceptCount(),
+        loopGeneration: window.__KOTOR_HMR_TEST__.getLoopGeneration(),
+        sessionActive: window.__KOTOR_HMR_TEST__.isSessionActive(),
+        probeValue: window.__KOTOR_HMR_TEST__.getProbeValue(),
+        heapMarker: window.__KOTOR_HMR_E2E_HEAP_MARKER__ ?? null,
+      }));
+
+      if (after.pageLoadId !== before.pageLoadId) {
+        throw new Error(`Cycle ${cycle}: full page reload detected (pageLoadId changed: ${before.pageLoadId} -> ${after.pageLoadId})`);
+      }
+      if (mainFrameNavigations > navigationsBeforeHmr) {
+        throw new Error(`Cycle ${cycle}: main-frame navigation occurred during HMR (${navigationsBeforeHmr} -> ${mainFrameNavigations})`);
+      }
+      if (after.heapMarker !== before.pageLoadId) {
+        throw new Error(`Cycle ${cycle}: JS heap marker lost (expected ${before.pageLoadId}, got ${after.heapMarker}) — silent reload?`);
+      }
+      if (!after.sessionActive) {
+        throw new Error(`Cycle ${cycle}: session was not preserved after hot reload`);
+      }
+      if (after.acceptCount !== beforeCycle.acceptCount + 1) {
+        throw new Error(`Cycle ${cycle}: accept count delta != 1 (${beforeCycle.acceptCount} -> ${after.acceptCount})`);
+      }
+      if (after.loopGeneration !== beforeCycle.loopGeneration + 1) {
+        throw new Error(`Cycle ${cycle}: loop generation delta != 1 (${beforeCycle.loopGeneration} -> ${after.loopGeneration})`);
+      }
+      if (after.probeValue !== probeValue) {
+        throw new Error(`Cycle ${cycle}: HMR probe value mismatch (expected ${probeValue}, got ${after.probeValue})`);
+      }
+
+      console.log(`[hmr-e2e] Cycle ${cycle}/${HMR_CYCLES} preserved session:`, {
+        acceptCount: after.acceptCount,
+        loopGeneration: after.loopGeneration,
+        probeValue: after.probeValue,
+      });
+      lastAfter = after;
     }
 
     if (preHmrSnapshot) {
@@ -355,16 +644,62 @@ async function main() {
           `In-module session lost module name (${preHmrSnapshot.module} -> ${postHmrSnapshot.module})`,
         );
       }
+      if (postHmrSnapshot.area !== preHmrSnapshot.area) {
+        throw new Error(
+          `In-module session lost area (${preHmrSnapshot.area} -> ${postHmrSnapshot.area})`,
+        );
+      }
+      if (postHmrSnapshot.creatureCount !== preHmrSnapshot.creatureCount) {
+        throw new Error(
+          `In-module creature count changed after HMR (${preHmrSnapshot.creatureCount} -> ${postHmrSnapshot.creatureCount})`,
+        );
+      }
       if (!postHmrSnapshot.player || !preHmrSnapshot.player) {
         throw new Error('In-module session lost player reference after HMR');
       }
       const { x: bx, y: by, z: bz } = preHmrSnapshot.player;
       const { x: ax, y: ay, z: az } = postHmrSnapshot.player;
-      if (bx !== ax || by !== ay || bz !== az) {
+      if (
+        Math.abs(bx - ax) > POSITION_EPSILON
+        || Math.abs(by - ay) > POSITION_EPSILON
+        || Math.abs(bz - az) > POSITION_EPSILON
+      ) {
         throw new Error(
-          `In-module player position changed after HMR (${bx},${by},${bz}) -> (${ax},${ay},${az})`,
+          `In-module player position drifted beyond epsilon ${POSITION_EPSILON} after HMR (${bx},${by},${bz}) -> (${ax},${ay},${az})`,
         );
       }
+
+      // Liveness: the render loop must still produce frames after the swaps.
+      const framesAfterHmr = await page.evaluate(() => new Promise((resolve) => {
+        let frames = 0;
+        const start = performance.now();
+        const tick = () => {
+          frames += 1;
+          if (performance.now() - start < 1000) {
+            requestAnimationFrame(tick);
+          } else {
+            resolve(frames);
+          }
+        };
+        requestAnimationFrame(tick);
+      }));
+      if (!(framesAfterHmr > 0)) {
+        throw new Error('Render loop produced no frames within 1s after HMR — frozen session');
+      }
+      console.log('[hmr-e2e] In-module post-HMR state intact:', {
+        module: postHmrSnapshot.module,
+        area: postHmrSnapshot.area,
+        mode: postHmrSnapshot.mode,
+        creatureCount: postHmrSnapshot.creatureCount,
+        framesAfterHmr,
+      });
+    }
+
+    // Reload-resume phases need real assets + the dev resume snapshot path,
+    // so they only run in in-module mode (skipped in synthetic CI).
+    if (USE_IN_MODULE) {
+      await runF5ResumePhase(page, KOTOR_HMR_E2E_MODULE);
+      await runEngineEditResumePhase(page, KOTOR_HMR_E2E_MODULE, compileTracker);
     }
 
     console.log('HMR session preservation E2E passed:', {
@@ -373,16 +708,24 @@ async function main() {
         : USE_REAL_ASSETS
           ? 'real-assets'
           : 'synthetic',
-      pageLoadId: after.pageLoadId,
-      acceptCount: after.acceptCount,
-      probeValue: after.probeValue,
+      cycles: HMR_CYCLES,
+      pageLoadId: lastAfter.pageLoadId,
+      acceptCount: lastAfter.acceptCount,
+      loopGeneration: lastAfter.loopGeneration,
+      probeValue: lastAfter.probeValue,
     });
   } finally {
     if (browser) {
       await browser.close().catch(() => {});
     }
     await killProcess(server);
-    await fs.writeFile(PROBE_FILE, originalProbe, 'utf8').catch(() => {});
+    try {
+      await fs.writeFile(PROBE_FILE, originalProbe, 'utf8');
+      await fs.writeFile(ENGINE_FILE, originalEngineSource, 'utf8');
+    } catch (restoreErr) {
+      console.error('[hmr-e2e] CRITICAL: failed to restore probe/engine source files:', restoreErr);
+      throw restoreErr;
+    }
   }
 }
 

--- a/scripts/hmr-session.e2e.cjs
+++ b/scripts/hmr-session.e2e.cjs
@@ -1,0 +1,266 @@
+#!/usr/bin/env node
+'use strict';
+
+const { spawn } = require('child_process');
+const fs = require('fs/promises');
+const http = require('http');
+const path = require('path');
+
+const fsSync = require('fs');
+
+const ROOT = path.resolve(__dirname, '..');
+const PORT = Number(process.env.KOTOR_HMR_E2E_PORT || 8099);
+const PROBE_FILE = path.join(ROOT, 'src/dev/HmrTestProbe.ts');
+const GAME_URL = `http://127.0.0.1:${PORT}/game/?key=kotor`;
+const SERVER_READY_URLS = [
+  GAME_URL,
+  `http://127.0.0.1:${PORT}/game/index.html?key=kotor`,
+  `http://localhost:${PORT}/game/?key=kotor`,
+];
+const SERVER_TIMEOUT_MS = 180000;
+const HMR_TIMEOUT_MS = 90000;
+
+function wait(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function httpOk(url) {
+  return new Promise((resolve, reject) => {
+    const req = http.get(url, (res) => {
+      res.resume();
+      if (res.statusCode >= 200 && res.statusCode < 400) {
+        resolve();
+        return;
+      }
+      reject(new Error(`HTTP ${res.statusCode} for ${url}`));
+    });
+    req.on('error', reject);
+    req.setTimeout(5000, () => {
+      req.destroy(new Error(`Timeout requesting ${url}`));
+    });
+  });
+}
+
+async function waitForServer(urls, timeoutMs) {
+  const candidates = Array.isArray(urls) ? urls : [urls];
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    for (const url of candidates) {
+      try {
+        await httpOk(url);
+        return url;
+      } catch {
+        // try next candidate
+      }
+    }
+    await wait(1000);
+  }
+  throw new Error(
+    `Dev server did not become ready at ${candidates.join(', ')} within ${timeoutMs}ms`,
+  );
+}
+
+function createCompileTracker(child) {
+  let count = 0;
+  const onData = (chunk) => {
+    if (/compiled successfully/i.test(chunk.toString())) {
+      count += 1;
+    }
+  };
+  child.stdout.on('data', onData);
+  child.stderr.on('data', onData);
+
+  function waitForCount(targetCount, timeoutMs) {
+    return new Promise((resolve, reject) => {
+      const start = Date.now();
+      if (count >= targetCount) {
+        resolve(count);
+        return;
+      }
+      const timer = setInterval(() => {
+        if (count >= targetCount) {
+          clearInterval(timer);
+          resolve(count);
+        } else if (Date.now() - start >= timeoutMs) {
+          clearInterval(timer);
+          reject(
+            new Error(
+              `Webpack did not report a successful compile within ${timeoutMs}ms (have ${count}, need ${targetCount})`,
+            ),
+          );
+        }
+      }, 100);
+    });
+  }
+
+  return {
+    getCount: () => count,
+    waitForInitialCompile: (timeoutMs) => waitForCount(1, timeoutMs),
+    waitForNextCompile: (timeoutMs) => {
+      const target = count + 1;
+      return waitForCount(target, timeoutMs);
+    },
+  };
+}
+
+function startDevServer() {
+  return spawn(
+    'npx',
+    ['webpack', 'serve', '--config', 'webpack/Game.hmr.js'],
+    {
+      cwd: ROOT,
+      env: {
+        ...process.env,
+        KOTOR_DEV_PORT: String(PORT),
+        NODE_ENV: 'development',
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    },
+  );
+}
+
+async function killProcess(child) {
+  if (!child || child.killed) {
+    return;
+  }
+  child.kill('SIGTERM');
+  await wait(2000);
+  if (!child.killed) {
+    child.kill('SIGKILL');
+  }
+}
+
+async function resolveBrowserExecutable() {
+  if (process.env.PUPPETEER_EXECUTABLE_PATH) {
+    return process.env.PUPPETEER_EXECUTABLE_PATH;
+  }
+  const candidates = [
+    '/usr/bin/chromium-browser',
+    '/usr/bin/chromium',
+    '/usr/bin/google-chrome',
+    '/usr/bin/google-chrome-stable',
+  ];
+  for (const candidate of candidates) {
+    if (fsSync.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  throw new Error('No Chromium executable found. Set PUPPETEER_EXECUTABLE_PATH.');
+}
+
+async function main() {
+  const originalProbe = await fs.readFile(PROBE_FILE, 'utf8');
+  let server;
+  let browser;
+
+  try {
+    server = startDevServer();
+    server.stdout.on('data', (chunk) => process.stdout.write(chunk));
+    server.stderr.on('data', (chunk) => process.stderr.write(chunk));
+    const compileTracker = createCompileTracker(server);
+
+    await compileTracker.waitForInitialCompile(SERVER_TIMEOUT_MS);
+    const readyUrl = await waitForServer(SERVER_READY_URLS, 30000);
+
+    const puppeteer = require('puppeteer-core');
+    browser = await puppeteer.launch({
+      headless: true,
+      executablePath: await resolveBrowserExecutable(),
+      args: ['--no-sandbox', '--disable-setuid-sandbox'],
+    });
+
+    const page = await browser.newPage();
+    page.on('console', (msg) => {
+      console.log(`[browser:${msg.type()}]`, msg.text());
+    });
+    page.on('pageerror', (err) => {
+      console.log('[browser:pageerror]', err.message);
+    });
+    let mainFrameNavigations = 0;
+    page.on('framenavigated', (frame) => {
+      if (frame === page.mainFrame()) {
+        mainFrameNavigations += 1;
+      }
+    });
+
+    await page.goto(readyUrl, { waitUntil: 'domcontentloaded', timeout: SERVER_TIMEOUT_MS });
+    await page.waitForFunction(() => window.__KOTOR_HMR_TEST__, { timeout: 60000 });
+
+    const before = await page.evaluate(() => ({
+      pageLoadId: window.__KOTOR_HMR_TEST__.getPageLoadId(),
+      acceptCount: window.__KOTOR_HMR_TEST__.getAcceptCount(),
+    }));
+
+    await page.evaluate(() => window.__KOTOR_HMR_TEST__.activateSession());
+    const sessionActiveBefore = await page.evaluate(() => window.__KOTOR_HMR_TEST__.isSessionActive());
+    if (!sessionActiveBefore) {
+      throw new Error('Failed to activate simulated session before HMR');
+    }
+
+    const navigationsBeforeHmr = mainFrameNavigations;
+    const probeValue = Date.now();
+    const updatedProbe = originalProbe.replace(
+      /export const HMR_PROBE = \d+/,
+      `export const HMR_PROBE = ${probeValue}`,
+    );
+    if (updatedProbe === originalProbe) {
+      throw new Error('Failed to rewrite HmrTestProbe.ts for HMR trigger');
+    }
+    const compileReady = compileTracker.waitForNextCompile(HMR_TIMEOUT_MS);
+    await fs.writeFile(PROBE_FILE, updatedProbe, 'utf8');
+    await compileReady;
+    await wait(500);
+
+    await page.waitForFunction(
+      (expectedProbe) => {
+        const bridge = window.__KOTOR_HMR_TEST__;
+        return !!bridge
+          && bridge.getAcceptCount() > 0
+          && bridge.getProbeValue() === expectedProbe
+          && bridge.isSessionActive();
+      },
+      { timeout: HMR_TIMEOUT_MS },
+      probeValue,
+    );
+
+    const after = await page.evaluate(() => ({
+      pageLoadId: window.__KOTOR_HMR_TEST__.getPageLoadId(),
+      acceptCount: window.__KOTOR_HMR_TEST__.getAcceptCount(),
+      sessionActive: window.__KOTOR_HMR_TEST__.isSessionActive(),
+      probeValue: window.__KOTOR_HMR_TEST__.getProbeValue(),
+    }));
+
+    if (after.pageLoadId !== before.pageLoadId) {
+      throw new Error(`Full page reload detected (pageLoadId changed: ${before.pageLoadId} -> ${after.pageLoadId})`);
+    }
+    if (mainFrameNavigations > navigationsBeforeHmr) {
+      throw new Error(`Main-frame navigation occurred during HMR (${navigationsBeforeHmr} -> ${mainFrameNavigations})`);
+    }
+    if (!after.sessionActive) {
+      throw new Error('Session was not preserved after hot reload');
+    }
+    if (after.acceptCount <= before.acceptCount) {
+      throw new Error(`HotReloadManager accept count did not increase (${before.acceptCount} -> ${after.acceptCount})`);
+    }
+    if (after.probeValue !== probeValue) {
+      throw new Error(`HMR probe value mismatch (expected ${probeValue}, got ${after.probeValue})`);
+    }
+
+    console.log('HMR session preservation E2E passed:', {
+      pageLoadId: after.pageLoadId,
+      acceptCount: after.acceptCount,
+      probeValue: after.probeValue,
+    });
+  } finally {
+    await fs.writeFile(PROBE_FILE, originalProbe, 'utf8').catch(() => {});
+    if (browser) {
+      await browser.close().catch(() => {});
+    }
+    await killProcess(server);
+  }
+}
+
+main().catch((error) => {
+  console.error('HMR session preservation E2E failed:', error);
+  process.exit(1);
+});

--- a/scripts/hmr-session.e2e.cjs
+++ b/scripts/hmr-session.e2e.cjs
@@ -115,20 +115,34 @@ function startDevServer() {
         NODE_ENV: 'development',
       },
       stdio: ['ignore', 'pipe', 'pipe'],
+      detached: process.platform !== 'win32',
     },
   );
 }
 
 async function killProcess(child) {
-  if (!child || child.killed) {
+  if (!child || !child.pid) {
     return;
   }
-  child.kill('SIGTERM');
-  await wait(500);
-  if (!child.killed) {
-    child.kill('SIGKILL');
+  if (child.stdout) {
+    child.stdout.destroy();
   }
-  await wait(200);
+  if (child.stderr) {
+    child.stderr.destroy();
+  }
+  if (process.platform !== 'win32') {
+    try {
+      process.kill(-child.pid, 'SIGKILL');
+      return;
+    } catch {
+      // Fall through to direct child kill.
+    }
+  }
+  try {
+    child.kill('SIGKILL');
+  } catch {
+    // Process already exited.
+  }
 }
 
 async function resolveBrowserExecutable() {
@@ -273,7 +287,11 @@ async function main() {
   }
 }
 
-main().catch((error) => {
-  console.error('HMR session preservation E2E failed:', error);
-  process.exit(1);
-});
+main()
+  .then(() => {
+    process.exit(0);
+  })
+  .catch((error) => {
+    console.error('HMR session preservation E2E failed:', error);
+    process.exit(1);
+  });

--- a/scripts/prove-dev-fs-smoke.sh
+++ b/scripts/prove-dev-fs-smoke.sh
@@ -1,14 +1,21 @@
 #!/usr/bin/env bash
 # Smoke-test dev FS middleware on a running webpack:serve-hmr instance.
-# Usage: KOTOR_DEV_PORT=8170 ./scripts/prove-dev-fs-smoke.sh
+# Usage: KOTOR_DEV_PORT=8130 ./scripts/prove-dev-fs-smoke.sh
+# Requires: dev server already running with KOTOR_DEV_GAME_DIR set (same port).
 set -euo pipefail
 
-PORT="${KOTOR_DEV_PORT:-8095}"
+PORT="${KOTOR_DEV_PORT:-8130}"
 BASE="http://127.0.0.1:${PORT}"
+
+if ! curl -sf --connect-timeout 3 "${BASE}/__kotor_dev_fs?action=stat&path=chitin.key" >/dev/null 2>&1; then
+  echo "FAIL: no dev FS on port ${PORT} — start server first:"
+  echo "  KOTOR_DEV_GAME_DIR=/path/to/swkotor KOTOR_DEV_PORT=${PORT} npm run dev:hmr"
+  exit 1
+fi
 
 stat_chitin=$(curl -sf "${BASE}/__kotor_dev_fs?action=stat&path=chitin.key")
 echo "stat chitin.key: ${stat_chitin}"
-echo "${stat_chitin}" | grep -q '"exists":true' || { echo "FAIL: chitin.key missing"; exit 1; }
+echo "${stat_chitin}" | grep -q '"exists":true' || { echo "FAIL: chitin.key missing (is KOTOR_DEV_GAME_DIR set?)"; exit 1; }
 
 stat_bik=$(curl -sf "${BASE}/__kotor_dev_fs?action=stat&path=Movies/leclogo.bik")
 echo "stat Movies/leclogo.bik: ${stat_bik}"

--- a/scripts/prove-dev-fs-smoke.sh
+++ b/scripts/prove-dev-fs-smoke.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Smoke-test dev FS middleware on a running webpack:serve-hmr instance.
+# Usage: KOTOR_DEV_PORT=8170 ./scripts/prove-dev-fs-smoke.sh
+set -euo pipefail
+
+PORT="${KOTOR_DEV_PORT:-8095}"
+BASE="http://127.0.0.1:${PORT}"
+
+stat_chitin=$(curl -sf "${BASE}/__kotor_dev_fs?action=stat&path=chitin.key")
+echo "stat chitin.key: ${stat_chitin}"
+echo "${stat_chitin}" | grep -q '"exists":true' || { echo "FAIL: chitin.key missing"; exit 1; }
+
+stat_bik=$(curl -sf "${BASE}/__kotor_dev_fs?action=stat&path=Movies/leclogo.bik")
+echo "stat Movies/leclogo.bik: ${stat_bik}"
+echo "${stat_bik}" | grep -q '"exists":true' || { echo "FAIL: leclogo.bik missing"; exit 1; }
+
+hex=$(curl -sf "${BASE}/__kotor_dev_fs?action=read&path=chitin.key&offset=0&length=4" | xxd -p | tr -d '\n')
+echo "chitin.key first 4 bytes: ${hex}"
+test -n "${hex}" || { echo "FAIL: empty read"; exit 1; }
+
+echo "OK: dev FS smoke passed on port ${PORT}"

--- a/scripts/verify-in-module.cjs
+++ b/scripts/verify-in-module.cjs
@@ -82,6 +82,7 @@ function findChrome() {
 async function waitForBootstrap(page, timeoutMs) {
   const start = Date.now();
   while (Date.now() - start < timeoutMs) {
+    await page.evaluate(() => window.__KOTOR_HMR_TEST__?.skipIntroMovies?.());
     const ready = await page.evaluate(() => window.__KOTOR_HMR_TEST__?.isQuickPlayReady?.() ?? false);
     if (ready) {
       return;

--- a/scripts/verify-in-module.cjs
+++ b/scripts/verify-in-module.cjs
@@ -1,0 +1,220 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Manual verification against a running webpack HMR dev server.
+ * Usage:
+ *   KOTOR_DEV_PORT=8130 node scripts/verify-in-module.cjs
+ *   KOTOR_VERIFY_MODULE=end_m01aa KOTOR_VERIFY_HMR=1 node scripts/verify-in-module.cjs
+ */
+
+const fs = require('fs/promises');
+const fsSync = require('fs');
+const http = require('http');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+const PORT = Number(process.env.KOTOR_DEV_PORT || 8130);
+const MODULE = process.env.KOTOR_VERIFY_MODULE || 'end_m01aa';
+const GAME_URL = `http://127.0.0.1:${PORT}/game/?key=kotor`;
+const OUT_DIR = path.join(ROOT, '.hmr-investigation');
+const PROBE_FILE = path.join(ROOT, 'src/dev/HmrTestProbe.ts');
+const MODULE_TIMEOUT_MS = Number(process.env.KOTOR_VERIFY_MODULE_TIMEOUT_MS || 900000);
+const HMR_TIMEOUT_MS = Number(process.env.KOTOR_VERIFY_HMR_TIMEOUT_MS || 180000);
+const RUN_HMR = process.env.KOTOR_VERIFY_HMR === '1';
+
+function wait(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function httpOk(url) {
+  return new Promise((resolve, reject) => {
+    const req = http.get(url, (res) => {
+      res.resume();
+      if (res.statusCode >= 200 && res.statusCode < 400) {
+        resolve();
+        return;
+      }
+      reject(new Error(`HTTP ${res.statusCode} for ${url}`));
+    });
+    req.on('error', reject);
+    req.setTimeout(5000, () => req.destroy(new Error(`Timeout requesting ${url}`)));
+  });
+}
+
+async function waitForServer(url, timeoutMs) {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    try {
+      await httpOk(url);
+      return;
+    } catch {
+      await wait(1000);
+    }
+  }
+  throw new Error(`Dev server not ready at ${url} within ${timeoutMs}ms`);
+}
+
+async function loadPuppeteer() {
+  try {
+    return require('puppeteer-core');
+  } catch {
+    return require('puppeteer');
+  }
+}
+
+function findChrome() {
+  const candidates = [
+    process.env.PUPPETEER_EXECUTABLE_PATH,
+    '/usr/bin/google-chrome',
+    '/usr/bin/google-chrome-stable',
+    '/usr/bin/chromium',
+    '/usr/bin/chromium-browser',
+  ].filter(Boolean);
+  for (const exe of candidates) {
+    if (fsSync.existsSync(exe)) {
+      return exe;
+    }
+  }
+  return undefined;
+}
+
+async function waitForBootstrap(page, timeoutMs) {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    const ready = await page.evaluate(() => window.__KOTOR_HMR_TEST__?.isQuickPlayReady?.() ?? false);
+    if (ready) {
+      return;
+    }
+    await wait(2000);
+  }
+  throw new Error(`Game bootstrap not ready within ${timeoutMs}ms`);
+}
+
+async function waitForInModule(page, moduleName, timeoutMs) {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    const snap = await page.evaluate(() => window.__KOTOR_HMR_TEST__.snapshotSession());
+    if (snap.ready && snap.module === moduleName) {
+      return snap;
+    }
+    await wait(2000);
+  }
+  throw new Error(`Module ${moduleName} not ready within ${timeoutMs}ms`);
+}
+
+async function main() {
+  await waitForServer(GAME_URL, 120000);
+  await fs.mkdir(OUT_DIR, { recursive: true });
+
+  const puppeteer = await loadPuppeteer();
+  const browser = await puppeteer.launch({
+    headless: 'new',
+    executablePath: findChrome(),
+    protocolTimeout: MODULE_TIMEOUT_MS + 300000,
+    args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage'],
+  });
+
+  const page = await browser.newPage();
+  await page.setViewport({ width: 1280, height: 720 });
+  const errors = [];
+  page.on('pageerror', (err) => errors.push(err.message));
+
+  let mainFrameNavigations = 0;
+  page.on('framenavigated', (frame) => {
+    if (frame === page.mainFrame()) {
+      mainFrameNavigations += 1;
+    }
+  });
+
+  await page.goto(GAME_URL, { waitUntil: 'domcontentloaded', timeout: 120000 });
+  await page.waitForFunction(() => window.__KOTOR_HMR_TEST__, { timeout: 120000 });
+
+  console.log('[verify] Waiting for game bootstrap (2DA tables)...');
+  await waitForBootstrap(page, Number(process.env.KOTOR_VERIFY_BOOTSTRAP_TIMEOUT_MS || 600000));
+
+  console.log(`[verify] Quick-play into ${MODULE} (timeout ${MODULE_TIMEOUT_MS}ms)...`);
+  await page.evaluate(async (moduleName) => {
+    await window.__KOTOR_HMR_TEST__.startQuickPlayToModule(moduleName);
+  }, MODULE);
+
+  await waitForInModule(page, MODULE, MODULE_TIMEOUT_MS);
+
+  const pre = await page.evaluate(() => ({
+    pageLoadId: window.__KOTOR_HMR_TEST__.getPageLoadId(),
+    acceptCount: window.__KOTOR_HMR_TEST__.getAcceptCount(),
+    snapshot: window.__KOTOR_HMR_TEST__.snapshotSession(),
+    inspect: window.__KOTOR_HMR_TEST__.inspectCreatures(),
+  }));
+
+  await page.screenshot({ path: path.join(OUT_DIR, 'verify-in-module-pre.png') });
+  await fs.writeFile(path.join(OUT_DIR, 'verify-pre.json'), JSON.stringify(pre, null, 2));
+
+  console.log('[verify] Pre-HMR inspect:', {
+    headless: pre.inspect.headlessHumanoids.length,
+    totalCreatures: pre.inspect.totalCreatures,
+    module: pre.snapshot.module,
+  });
+
+  let hmrOk = null;
+  if (RUN_HMR) {
+    const originalProbe = await fs.readFile(PROBE_FILE, 'utf8');
+    const probeValue = Date.now();
+    const updatedProbe = originalProbe.replace(
+      /export const HMR_PROBE = \d+/,
+      `export const HMR_PROBE = ${probeValue}`,
+    );
+    const navBefore = mainFrameNavigations;
+    await fs.writeFile(PROBE_FILE, updatedProbe, 'utf8');
+
+    await page.waitForFunction(
+      (expected) => {
+        const bridge = window.__KOTOR_HMR_TEST__;
+        return bridge.getAcceptCount() > 0
+          && bridge.getProbeValue() === expected
+          && bridge.isSessionActive();
+      },
+      { timeout: HMR_TIMEOUT_MS },
+      probeValue,
+    );
+
+    const post = await page.evaluate(() => ({
+      pageLoadId: window.__KOTOR_HMR_TEST__.getPageLoadId(),
+      acceptCount: window.__KOTOR_HMR_TEST__.getAcceptCount(),
+      snapshot: window.__KOTOR_HMR_TEST__.snapshotSession(),
+      inspect: window.__KOTOR_HMR_TEST__.inspectCreatures(),
+    }));
+
+    hmrOk = post.pageLoadId === pre.pageLoadId
+      && mainFrameNavigations === navBefore
+      && post.snapshot.module === pre.snapshot.module
+      && post.inspect.headlessHumanoids.length === pre.inspect.headlessHumanoids.length;
+
+    await page.screenshot({ path: path.join(OUT_DIR, 'verify-in-module-post-hmr.png') });
+    await fs.writeFile(path.join(OUT_DIR, 'verify-post.json'), JSON.stringify(post, null, 2));
+
+    await fs.writeFile(PROBE_FILE, originalProbe, 'utf8');
+    console.log('[verify] HMR ok:', hmrOk);
+  }
+
+  const result = {
+    module: MODULE,
+    headlessHumanoids: pre.inspect.headlessHumanoids.length,
+    totalCreatures: pre.inspect.totalCreatures,
+    hmrOk,
+    errors: errors.length,
+  };
+  await fs.writeFile(path.join(OUT_DIR, 'verify-result.json'), JSON.stringify(result, null, 2));
+  console.log('[verify] Result:', result);
+
+  await browser.close();
+
+  if (pre.inspect.headlessHumanoids.length > 0) {
+    process.exitCode = 1;
+  }
+}
+
+main().catch((err) => {
+  console.error('[verify] Failed:', err);
+  process.exit(1);
+});

--- a/scripts/verify-in-module.cjs
+++ b/scripts/verify-in-module.cjs
@@ -119,7 +119,7 @@ async function main() {
   const browser = await puppeteer.launch({
     headless: 'new',
     executablePath: findChrome(),
-    protocolTimeout: MODULE_TIMEOUT_MS + 300000,
+    protocolTimeout: MODULE_TIMEOUT_MS + HMR_TIMEOUT_MS + 600000,
     args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage'],
   });
 

--- a/scripts/verify-in-module.cjs
+++ b/scripts/verify-in-module.cjs
@@ -81,15 +81,22 @@ function findChrome() {
 
 async function waitForBootstrap(page, timeoutMs) {
   const start = Date.now();
+  let lastLog = 0;
   while (Date.now() - start < timeoutMs) {
     await page.evaluate(() => window.__KOTOR_HMR_TEST__?.skipIntroMovies?.());
+    const status = await page.evaluate(() => window.__KOTOR_HMR_TEST__?.getBootstrapStatus?.() ?? null);
     const ready = await page.evaluate(() => window.__KOTOR_HMR_TEST__?.isQuickPlayReady?.() ?? false);
+    if (Date.now() - lastLog > 30000) {
+      console.log('[verify] Bootstrap status:', status);
+      lastLog = Date.now();
+    }
     if (ready) {
       return;
     }
     await wait(2000);
   }
-  throw new Error(`Game bootstrap not ready within ${timeoutMs}ms`);
+  const finalStatus = await page.evaluate(() => window.__KOTOR_HMR_TEST__?.getBootstrapStatus?.() ?? null);
+  throw new Error(`Game bootstrap not ready within ${timeoutMs}ms — ${JSON.stringify(finalStatus)}`);
 }
 
 async function waitForInModule(page, moduleName, timeoutMs) {
@@ -132,7 +139,7 @@ async function main() {
   await page.waitForFunction(() => window.__KOTOR_HMR_TEST__, { timeout: 120000 });
 
   console.log('[verify] Waiting for game bootstrap (2DA tables)...');
-  await waitForBootstrap(page, Number(process.env.KOTOR_VERIFY_BOOTSTRAP_TIMEOUT_MS || 600000));
+  await waitForBootstrap(page, Number(process.env.KOTOR_VERIFY_BOOTSTRAP_TIMEOUT_MS || 1200000));
 
   console.log(`[verify] Quick-play into ${MODULE} (timeout ${MODULE_TIMEOUT_MS}ms)...`);
   await page.evaluate(async (moduleName) => {

--- a/src/GameState.ts
+++ b/src/GameState.ts
@@ -943,7 +943,12 @@ export class GameState implements EngineContext {
   }
 
   static ensureDialogAudio(): void {
-    const existing = GameState.CutsceneManager.audioEmitter;
+    const cutsceneManager = GameState.CutsceneManager;
+    if (!cutsceneManager) {
+      return;
+    }
+
+    const existing = cutsceneManager.audioEmitter;
     if (existing && !existing.isDestroyed) {
       return;
     }
@@ -952,7 +957,7 @@ export class GameState implements EngineContext {
     voEmitter.maxDistance = 50;
     voEmitter.type = AudioEmitterType.GLOBAL;
     voEmitter.setPriorityGroupId(AudioPriorityGroup.UNMASKABLE_SOUND);
-    GameState.CutsceneManager.audioEmitter = voEmitter;
+    cutsceneManager.audioEmitter = voEmitter;
     voEmitter.load();
   }
 

--- a/src/GameState.ts
+++ b/src/GameState.ts
@@ -1003,6 +1003,7 @@ export class GameState implements EngineContext {
 
       //Remove all cached scripts and kill all running instances
       GameState.NWScript.Reload();
+      GameState.module?.area?.invalidateAreaObjectScriptSlots();
 
       //Resets all keys to their default state
       GameState.controls.initKeys();

--- a/src/GameState.ts
+++ b/src/GameState.ts
@@ -149,6 +149,7 @@ export class GameState implements EngineContext {
   static iniConfig: INIConfig;
   
   static Ready = false;
+  static hmrLoopGeneration = 0;
   
   static CameraDebugZoom = 1;
   
@@ -1164,9 +1165,22 @@ export class GameState implements EngineContext {
 
   static forwardVector = new THREE.Vector3(0, 0, );
 
+  static hmrInvalidateLoop(): void {
+    GameState.hmrLoopGeneration += 1;
+  }
+
+  static hmrIsSessionActive(): boolean {
+    return GameState.Ready;
+  }
+
   static Update(){
-    
-    requestAnimationFrame( GameState.Update );
+    const loopGeneration = GameState.hmrLoopGeneration;
+    requestAnimationFrame(() => {
+      if (loopGeneration !== GameState.hmrLoopGeneration) {
+        return;
+      }
+      GameState.Update();
+    });
 
     GameState.forwardVector.set(0, 0, -1);
 

--- a/src/GameState.ts
+++ b/src/GameState.ts
@@ -150,6 +150,8 @@ export class GameState implements EngineContext {
   
   static Ready = false;
   static hmrLoopGeneration = 0;
+  /** Generation for which an rAF continuation is already queued; null between frames. */
+  static hmrLoopScheduledGeneration: number | null = null;
   
   static CameraDebugZoom = 1;
   
@@ -999,11 +1001,11 @@ export class GameState implements EngineContext {
         try{ GameState.module.dispose(); }catch(e){
           console.error(e);
         }
+        GameState.module = undefined;
       }
 
       //Remove all cached scripts and kill all running instances
       GameState.NWScript.Reload();
-      GameState.module?.area?.invalidateAreaObjectScriptSlots();
 
       //Resets all keys to their default state
       GameState.controls.initKeys();
@@ -1065,6 +1067,7 @@ export class GameState implements EngineContext {
         }
         GameState.module.area.musicBackgroundPlay();
         GameState.loadingModule = false;
+        GameState.ensureUpdateLoop();
       });
     }catch(e){
       console.error(e);
@@ -1168,15 +1171,31 @@ export class GameState implements EngineContext {
 
   static hmrInvalidateLoop(): void {
     GameState.hmrLoopGeneration += 1;
+    GameState.hmrLoopScheduledGeneration = null;
   }
 
   static hmrIsSessionActive(): boolean {
     return GameState.Ready;
   }
 
+  /**
+   * Restart the rAF loop after HMR invalidation if it is not already scheduled.
+   */
+  static ensureUpdateLoop(): void {
+    if (!GameState.Ready || !GameState.OnReadyCalled || !GameState.clock) {
+      return;
+    }
+    if (GameState.hmrLoopScheduledGeneration === GameState.hmrLoopGeneration) {
+      return;
+    }
+    GameState.Update();
+  }
+
   static Update(){
     const loopGeneration = GameState.hmrLoopGeneration;
+    GameState.hmrLoopScheduledGeneration = loopGeneration;
     requestAnimationFrame(() => {
+      GameState.hmrLoopScheduledGeneration = null;
       if (loopGeneration !== GameState.hmrLoopGeneration) {
         return;
       }

--- a/src/GameState.ts
+++ b/src/GameState.ts
@@ -942,13 +942,27 @@ export class GameState implements EngineContext {
     return p ? p : GameState.PartyManager.Player;
   }
 
-  static ResetModuleAudio(){                        
-    GameState.CutsceneManager.audioEmitter = 
-    this.audioEmitter = new AudioEmitter(AudioEngine.GetAudioEngine(), AudioEngineChannel.VO);
-    this.audioEmitter.maxDistance = 50;
-    this.audioEmitter.type = AudioEmitterType.GLOBAL;
-    this.audioEmitter.setPriorityGroupId(AudioPriorityGroup.UNMASKABLE_SOUND);
-    this.audioEmitter.load();
+  static ensureDialogAudio(): void {
+    const existing = GameState.CutsceneManager.audioEmitter;
+    if (existing && !existing.isDestroyed) {
+      return;
+    }
+
+    const voEmitter = new AudioEmitter(AudioEngine.GetAudioEngine(), AudioEngineChannel.VO);
+    voEmitter.maxDistance = 50;
+    voEmitter.type = AudioEmitterType.GLOBAL;
+    voEmitter.setPriorityGroupId(AudioPriorityGroup.UNMASKABLE_SOUND);
+    GameState.CutsceneManager.audioEmitter = voEmitter;
+    voEmitter.load();
+  }
+
+  static ResetModuleAudio(){
+    const existing = GameState.CutsceneManager.audioEmitter;
+    if (existing && !existing.isDestroyed) {
+      existing.destroy();
+    }
+
+    GameState.ensureDialogAudio();
   }
 
   /**

--- a/src/apps/common/components/loadingScreen/LoadingScreen.scss
+++ b/src/apps/common/components/loadingScreen/LoadingScreen.scss
@@ -40,7 +40,52 @@
     font-family: sans-serif;
     text-align: center;
   }
-  
+  .loading-message {
+    max-width: min(90vw, 900px);
+    margin: 0 auto;
+    padding: 0 16px;
+    box-sizing: border-box;
+  }
+
+  .loading-message-text {
+    color: #fff;
+    font-size: 18pt;
+    line-height: 1.3;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    margin-bottom: 12px;
+  }
+
+  .loading-progress {
+    font-size: 11pt;
+  }
+
+  .loading-progress-track {
+    height: 8px;
+    border: 1px solid rgba(33, 135, 231, 0.9);
+    border-radius: 4px;
+    background: rgba(0, 0, 0, 0.45);
+    overflow: hidden;
+    box-shadow: 0 0 12px rgba(33, 135, 231, 0.35);
+  }
+
+  .loading-progress-bar {
+    height: 100%;
+    background: linear-gradient(90deg, rgba(0, 183, 229, 0.95), rgba(33, 135, 231, 0.95));
+    transition: width 0.15s ease-out;
+  }
+
+  .loading-progress-meta {
+    display: flex;
+    justify-content: space-between;
+    gap: 12px;
+    margin-top: 8px;
+    color: rgba(255, 255, 255, 0.85);
+    font-size: 10pt;
+    font-variant-numeric: tabular-nums;
+  }
+
   .background {
     display: block;
     position: absolute;

--- a/src/apps/common/components/loadingScreen/LoadingScreen.tsx
+++ b/src/apps/common/components/loadingScreen/LoadingScreen.tsx
@@ -1,28 +1,31 @@
 import React, { useEffect, useRef, useState } from "react";
 import "@/apps/common/components/loadingScreen/LoadingScreen.scss";
+import { formatLoaderEta, ILoaderProgress } from '@/apps/common/loader/LoaderProgress';
 
 export interface ILoadingScreenProps {
   active?: boolean;
   message?: string;
   backgroundURL?: string;
   logoURL?: string;
+  progress?: ILoaderProgress | null;
 }
 
 export const LoadingScreen = (props: ILoadingScreenProps) => {
-
-  //component props
   const [active, setActive] = useState<boolean>(!!props.active);
   const [message, setMessage] = useState<string>(props.message || 'Loading...');
   const [backgroundURL, setBackgroundURL] = useState<string>(props.backgroundURL || '');
   const [logoURL, setLogoURL] = useState<string>(props.logoURL || '');
+  const [progress, setProgress] = useState<ILoaderProgress | null>(props.progress ?? null);
+  const [etaLabel, setEtaLabel] = useState<string>('');
 
-  //fade in and out
   const [fadeIn, setFadeIn] = useState<boolean>(false);
   const [fadeOut, setFadeOut] = useState<boolean>(false);
   const [visible, setVisible] = useState<boolean>(false);
 
   const fadeInTimeout = useRef<NodeJS.Timeout | null>(null);
   const fadeOutTimeout = useRef<NodeJS.Timeout | null>(null);
+  const progressStartRef = useRef<number | null>(null);
+  const smoothedRateRef = useRef<number | null>(null);
 
   const onHide = () => {
     clearTimeout(fadeOutTimeout.current as any);
@@ -39,17 +42,14 @@ export const LoadingScreen = (props: ILoadingScreenProps) => {
     clearTimeout(fadeInTimeout.current as any);
     setFadeIn(true);
     setFadeOut(false);
-    // fadeInTimeout.current = setTimeout(() => {
-      setVisible(true);
-    // }, 1000);
+    setVisible(true);
   };
 
   useEffect(() => {
-    console.log('active', active);
     setActive(!!props.active);
-    if(!!props.active){
+    if (!!props.active) {
       onShow();
-    }else{
+    } else {
       onHide();
     }
   }, [props.active]);
@@ -60,19 +60,81 @@ export const LoadingScreen = (props: ILoadingScreenProps) => {
     setLogoURL(props.logoURL || '');
   }, [props.message, props.backgroundURL, props.logoURL]);
 
-  //se-pre-con class
+  useEffect(() => {
+    const next = props.progress ?? null;
+    setProgress(next);
+
+    if (!next || next.total <= 0) {
+      progressStartRef.current = null;
+      smoothedRateRef.current = null;
+      setEtaLabel('');
+      return;
+    }
+
+    if (progressStartRef.current === null || next.completed === 0) {
+      progressStartRef.current = performance.now();
+      smoothedRateRef.current = null;
+    }
+
+    if (next.completed <= 0) {
+      setEtaLabel('Calculating...');
+      return;
+    }
+
+    const elapsedSeconds = (performance.now() - (progressStartRef.current as number)) / 1000;
+    if (elapsedSeconds <= 0) {
+      setEtaLabel('Calculating...');
+      return;
+    }
+
+    const instantRate = next.completed / elapsedSeconds;
+    smoothedRateRef.current =
+      smoothedRateRef.current === null
+        ? instantRate
+        : smoothedRateRef.current * 0.65 + instantRate * 0.35;
+
+    const remaining = Math.max(0, next.total - next.completed);
+    const etaSeconds = remaining / (smoothedRateRef.current || instantRate);
+    setEtaLabel(formatLoaderEta(etaSeconds));
+  }, [props.progress]);
+
+  const showProgress = !!progress && progress.total > 0;
+  const percent = showProgress
+    ? Math.min(100, Math.round((progress.completed / progress.total) * 100))
+    : 0;
+  const statusLine = showProgress
+    ? progress.currentAsset || progress.message || message
+    : message;
+
   return (
     <div className={`app-loader ${visible ? 'active' : ''} ${fadeIn ? 'fade-in' : ''} ${fadeOut ? 'fade-out' : ''}`}>
-      <div className="background" style={{backgroundImage: (!!backgroundURL) ? `url(${backgroundURL})` : 'initial'}}></div>
-      <div className="logo-wrapper">{logoURL ? <img src={logoURL} /> : null}</div>
+      <div className="background" style={{ backgroundImage: !!backgroundURL ? `url(${backgroundURL})` : 'initial' }}></div>
+      <div className="logo-wrapper">{logoURL ? <img src={logoURL} alt="" /> : null}</div>
       <div className="loading-container">
         <div className="spinner-wrapper">
           <div className="ball"></div>
           <div className="ball1"></div>
         </div>
-        <div className="loading-message">{message}</div>
+        <div className="loading-message">
+          <div className="loading-message-text" title={statusLine}>
+            {statusLine}
+          </div>
+          {showProgress && (
+            <div className="loading-progress">
+              <div className="loading-progress-track">
+                <div className="loading-progress-bar" style={{ width: `${percent}%` }} />
+              </div>
+              <div className="loading-progress-meta">
+                <span>{percent}%</span>
+                <span>
+                  {progress.completed} / {progress.total}
+                </span>
+                {etaLabel ? <span>{etaLabel}</span> : null}
+              </div>
+            </div>
+          )}
+        </div>
       </div>
     </div>
   );
-
 };

--- a/src/apps/common/loader/LoaderProgress.test.ts
+++ b/src/apps/common/loader/LoaderProgress.test.ts
@@ -1,0 +1,63 @@
+import { ILoaderProgress, LoaderProgressTracker, formatLoaderEta } from '@/apps/common/loader/LoaderProgress';
+
+describe('LoaderProgressTracker', () => {
+  it('begins with total and resets completed count', () => {
+    const emissions: ILoaderProgress[] = [];
+    const tracker = new LoaderProgressTracker((p) => emissions.push(p), 'Loading assets');
+
+    tracker.begin(10, 'Loading assets');
+
+    expect(emissions[0]).toEqual({
+      message: 'Loading assets',
+      completed: 0,
+      total: 10,
+    });
+  });
+
+  it('tracks item start and completion', () => {
+    const emissions: ILoaderProgress[] = [];
+    const tracker = new LoaderProgressTracker((p) => emissions.push(p));
+
+    tracker.begin(2);
+    tracker.itemStart('foo.2da');
+    tracker.itemComplete();
+
+    expect(emissions[emissions.length - 1]).toEqual({
+      message: 'Loading...',
+      currentAsset: 'foo.2da',
+      completed: 1,
+      total: 2,
+    });
+  });
+
+  it('adds to total without changing completed', () => {
+    const emissions: ILoaderProgress[] = [];
+    const tracker = new LoaderProgressTracker((p) => emissions.push(p));
+
+    tracker.begin(1);
+    tracker.itemComplete();
+    tracker.addTotal(3);
+
+    expect(emissions[emissions.length - 1]).toEqual({
+      message: 'Loading...',
+      completed: 1,
+      total: 4,
+    });
+  });
+});
+
+describe('formatLoaderEta', () => {
+  it('returns Almost done for short remaining times', () => {
+    expect(formatLoaderEta(3)).toBe('Almost done');
+  });
+
+  it('formats seconds and minutes', () => {
+    expect(formatLoaderEta(45)).toBe('45s remaining');
+    expect(formatLoaderEta(125)).toBe('2m 5s remaining');
+  });
+
+  it('returns empty string for invalid input', () => {
+    expect(formatLoaderEta(Number.NaN)).toBe('');
+    expect(formatLoaderEta(-1)).toBe('');
+  });
+});

--- a/src/apps/common/loader/LoaderProgress.test.ts
+++ b/src/apps/common/loader/LoaderProgress.test.ts
@@ -44,6 +44,20 @@ describe('LoaderProgressTracker', () => {
       total: 4,
     });
   });
+
+  it('updates message via setMessage without changing counts', () => {
+    const emissions: ILoaderProgress[] = [];
+    const tracker = new LoaderProgressTracker((p) => emissions.push(p), 'Phase one');
+
+    tracker.begin(5);
+    tracker.setMessage('Loading BIFs');
+
+    expect(emissions[emissions.length - 1]).toEqual({
+      message: 'Loading BIFs',
+      completed: 0,
+      total: 5,
+    });
+  });
 });
 
 describe('formatLoaderEta', () => {
@@ -54,6 +68,10 @@ describe('formatLoaderEta', () => {
   it('formats seconds and minutes', () => {
     expect(formatLoaderEta(45)).toBe('45s remaining');
     expect(formatLoaderEta(125)).toBe('2m 5s remaining');
+  });
+
+  it('formats hours', () => {
+    expect(formatLoaderEta(3665)).toBe('1h 1m remaining');
   });
 
   it('returns empty string for invalid input', () => {

--- a/src/apps/common/loader/LoaderProgress.ts
+++ b/src/apps/common/loader/LoaderProgress.ts
@@ -1,0 +1,84 @@
+export interface ILoaderProgress {
+  message: string;
+  currentAsset?: string;
+  completed: number;
+  total: number;
+}
+
+export type LoaderProgressCallback = (progress: ILoaderProgress) => void;
+
+/**
+ * Tracks parallel asset loads and emits normalized progress updates.
+ */
+export class LoaderProgressTracker {
+  #message: string;
+  #total = 0;
+  #completed = 0;
+  #currentAsset = '';
+  #onProgress: LoaderProgressCallback;
+
+  constructor(onProgress: LoaderProgressCallback, message = 'Loading...') {
+    this.#onProgress = onProgress;
+    this.#message = message;
+  }
+
+  setMessage(message: string): void {
+    this.#message = message;
+    this.#emit();
+  }
+
+  begin(total: number, message?: string): void {
+    if (message) {
+      this.#message = message;
+    }
+    this.#total = Math.max(0, total);
+    this.#completed = 0;
+    this.#currentAsset = '';
+    this.#emit();
+  }
+
+  addTotal(count: number): void {
+    this.#total += Math.max(0, count);
+    this.#emit();
+  }
+
+  itemStart(asset: string): void {
+    this.#currentAsset = asset;
+    this.#emit();
+  }
+
+  itemComplete(): void {
+    this.#completed = Math.min(this.#completed + 1, this.#total || this.#completed + 1);
+    this.#emit();
+  }
+
+  #emit(): void {
+    this.#onProgress({
+      message: this.#message,
+      currentAsset: this.#currentAsset || undefined,
+      completed: this.#completed,
+      total: this.#total,
+    });
+  }
+}
+
+export function formatLoaderEta(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds < 0) {
+    return '';
+  }
+  if (seconds < 5) {
+    return 'Almost done';
+  }
+  const totalSeconds = Math.ceil(seconds);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const secs = totalSeconds % 60;
+
+  if (hours > 0) {
+    return `${hours}h ${minutes}m remaining`;
+  }
+  if (minutes > 0) {
+    return `${minutes}m ${secs}s remaining`;
+  }
+  return `${secs}s remaining`;
+}

--- a/src/apps/forge/App.tsx
+++ b/src/apps/forge/App.tsx
@@ -29,6 +29,7 @@ export const App = (props: any) => {
   const [showGrantModal, setShowGrantModal] = appContext.showGrantModal;
   const [showLoadingScreen] = appContext.showLoadingScreen;
   const [loadingScreenMessage] = appContext.loadingScreenMessage;
+  const [loadingScreenProgress] = appContext.loadingScreenProgress;
   const [loadingScreenBackgroundURL] = appContext.loadingScreenBackgroundURL;
   const [loadingScreenLogoURL] = appContext.loadingScreenLogoURL;
   const [isDragOver, setIsDragOver] = useState(false);
@@ -384,7 +385,13 @@ export const App = (props: any) => {
       </div>
       <ModalManager manager={ForgeState.modalManager}></ModalManager>
       <ModalGrantAccess onUserGrant={onUserGrant} onUserCancel={onUserCancel}></ModalGrantAccess>
-      <LoadingScreen active={showLoadingScreen} message={loadingScreenMessage} backgroundURL={loadingScreenBackgroundURL} logoURL={loadingScreenLogoURL} />
+      <LoadingScreen
+        active={showLoadingScreen}
+        message={loadingScreenMessage}
+        progress={loadingScreenProgress}
+        backgroundURL={loadingScreenBackgroundURL}
+        logoURL={loadingScreenLogoURL}
+      />
     </>
   );
 

--- a/src/apps/forge/ForgeInitializer.ts
+++ b/src/apps/forge/ForgeInitializer.ts
@@ -89,6 +89,11 @@ export class ForgeInitializer {
 
   static SetLoadingMessage(message: string){
     ForgeInitializer.ProcessEventListener('on-loader-message', [message]);
+    ForgeInitializer.ProcessEventListener('on-loader-progress', [null]);
+  }
+
+  static SetLoadingProgress(progress: import('@/apps/common/loader/LoaderProgress').ILoaderProgress) {
+    ForgeInitializer.ProcessEventListener('on-loader-progress', [progress]);
   }
 
   static async Init(game: KotOR.GameEngineType){

--- a/src/apps/forge/ForgeInitializer.ts
+++ b/src/apps/forge/ForgeInitializer.ts
@@ -1,5 +1,6 @@
 import * as path from "path";
 import * as KotOR from "@/apps/forge/KotOR";
+import { ILoaderProgress } from '@/apps/common/loader/LoaderProgress';
 
 /**
  * ForgeInitializer class.
@@ -92,7 +93,7 @@ export class ForgeInitializer {
     ForgeInitializer.ProcessEventListener('on-loader-progress', [null]);
   }
 
-  static SetLoadingProgress(progress: import('@/apps/common/loader/LoaderProgress').ILoaderProgress) {
+  static SetLoadingProgress(progress: ILoaderProgress) {
     ForgeInitializer.ProcessEventListener('on-loader-progress', [progress]);
   }
 

--- a/src/apps/forge/context/AppContext.tsx
+++ b/src/apps/forge/context/AppContext.tsx
@@ -49,6 +49,7 @@ export const AppProvider = (props: any) => {
   };
   const onLoadingScreenHide = () => {
     setShowLoadingScreen(false);
+    setLoadingScreenProgress(null);
   };
   const onLoadingScreenInit = (backgroundURL: string, logoURL: string) => {
     setLoadingScreenBackgroundURL(backgroundURL);

--- a/src/apps/forge/context/AppContext.tsx
+++ b/src/apps/forge/context/AppContext.tsx
@@ -4,6 +4,7 @@ import { EditorTabManager } from "@/apps/forge/managers/EditorTabManager";
 import { LoadingScreenProvider } from "@/apps/forge/context/LoadingScreenContext";
 
 import * as KotOR from "@/apps/forge/KotOR";
+import { ILoaderProgress } from '@/apps/common/loader/LoaderProgress';
 
 export interface AppProviderValues {
   // someValue: [any, React.Dispatch<any>];
@@ -12,6 +13,7 @@ export interface AppProviderValues {
   showGrantModal: [boolean, React.Dispatch<any>];
   showLoadingScreen: [boolean, React.Dispatch<any>];
   loadingScreenMessage: [string, React.Dispatch<any>];
+  loadingScreenProgress: [ILoaderProgress | null, React.Dispatch<ILoaderProgress | null>];
   loadingScreenBackgroundURL: [string, React.Dispatch<any>];
   loadingScreenLogoURL: [string, React.Dispatch<any>];
 }
@@ -27,12 +29,21 @@ export const AppProvider = (props: any) => {
   const [showGrantModal, setShowGrantModal] = useState<boolean>(false);
   const [showLoadingScreen, setShowLoadingScreen] = useState<boolean>(false);
   const [loadingScreenMessage, setLoadingScreenMessage] = useState<string>('');
+  const [loadingScreenProgress, setLoadingScreenProgress] = useState<ILoaderProgress | null>(null);
   const [loadingScreenBackgroundURL, setLoadingScreenBackgroundURL] = useState<string>('');
   const [loadingScreenLogoURL, setLoadingScreenLogoURL] = useState<string>('');
 
   const onLoadingScreenMessage = (message: string) => {
     setLoadingScreenMessage(message);
-  }
+    setLoadingScreenProgress(null);
+  };
+
+  const onLoadingScreenProgress = (progress: ILoaderProgress | null) => {
+    setLoadingScreenProgress(progress);
+    if (progress?.message) {
+      setLoadingScreenMessage(progress.message);
+    }
+  };
   const onLoadingScreenShow = () => {
     setShowLoadingScreen(true);
   }
@@ -47,11 +58,13 @@ export const AppProvider = (props: any) => {
   useEffect(() => { 
     // ForgeState.tabManager = tabManager;
     ForgeState.addEventListener('on-loader-message', onLoadingScreenMessage);
+    ForgeState.addEventListener('on-loader-progress', onLoadingScreenProgress);
     ForgeState.addEventListener('on-loader-show', onLoadingScreenShow);
     ForgeState.addEventListener('on-loader-hide', onLoadingScreenHide);
     ForgeState.addEventListener('on-loader-init', onLoadingScreenInit);
     return () => {
       ForgeState.removeEventListener('on-loader-message', onLoadingScreenMessage);
+      ForgeState.removeEventListener('on-loader-progress', onLoadingScreenProgress);
       ForgeState.removeEventListener('on-loader-show', onLoadingScreenShow);
       ForgeState.removeEventListener('on-loader-hide', onLoadingScreenHide);
       ForgeState.removeEventListener('on-loader-init', onLoadingScreenInit);
@@ -64,6 +77,7 @@ export const AppProvider = (props: any) => {
     showGrantModal: [showGrantModal, setShowGrantModal],
     showLoadingScreen: [showLoadingScreen, setShowLoadingScreen],
     loadingScreenMessage: [loadingScreenMessage, setLoadingScreenMessage],
+    loadingScreenProgress: [loadingScreenProgress, setLoadingScreenProgress],
     loadingScreenBackgroundURL: [loadingScreenBackgroundURL, setLoadingScreenBackgroundURL],
     loadingScreenLogoURL: [loadingScreenLogoURL, setLoadingScreenLogoURL],
   };

--- a/src/apps/forge/context/AppContext.tsx
+++ b/src/apps/forge/context/AppContext.tsx
@@ -46,10 +46,10 @@ export const AppProvider = (props: any) => {
   };
   const onLoadingScreenShow = () => {
     setShowLoadingScreen(true);
-  }
+  };
   const onLoadingScreenHide = () => {
     setShowLoadingScreen(false);
-  }
+  };
   const onLoadingScreenInit = (backgroundURL: string, logoURL: string) => {
     setLoadingScreenBackgroundURL(backgroundURL);
     setLoadingScreenLogoURL(logoURL);

--- a/src/apps/forge/states/ForgeState.ts
+++ b/src/apps/forge/states/ForgeState.ts
@@ -16,6 +16,7 @@ import { AudioPlayerState } from "@/apps/forge/states/AudioPlayerState";
 
 import * as KotOR from "@/apps/forge/KotOR";
 import { ForgeInitializer } from "@/apps/forge/ForgeInitializer";
+import { ILoaderProgress } from '@/apps/common/loader/LoaderProgress';
 import { NWScriptLanguageService } from "@/apps/forge/states/NWScriptLanguageService";
 import { LYTLanguageService } from "@/apps/forge/states/LYTLanguageService";
 import { TXILanguageService } from "@/apps/forge/states/TXILanguageService";
@@ -114,6 +115,12 @@ export class ForgeState {
    */
   static loaderMessage(message: string): void {
     ForgeState.processEventListener('on-loader-message', [message]);
+    ForgeState.processEventListener('on-loader-progress', [null]);
+  }
+
+  static loaderProgress(progress: ILoaderProgress): void {
+    ForgeState.processEventListener('on-loader-message', [progress.message]);
+    ForgeState.processEventListener('on-loader-progress', [progress]);
   }
 
   static async InitializeApp(): Promise<void>{
@@ -137,6 +144,13 @@ export class ForgeState {
       KotOR.GameState.GameKey = KotOR.ApplicationProfile.GameKey;
       ForgeInitializer.AddEventListener('on-loader-message', (message: string) => {
         ForgeState.loaderMessage(message);
+      });
+      ForgeInitializer.AddEventListener('on-loader-progress', (progress: ILoaderProgress | null) => {
+        if (progress) {
+          ForgeState.loaderProgress(progress);
+        } else {
+          ForgeState.processEventListener('on-loader-progress', [null]);
+        }
       });
       ForgeInitializer.Init(KotOR.ApplicationProfile.GameKey).then( async () => {
         await this.initNWScriptParser();

--- a/src/apps/forge/states/tabs/TabResourceExplorerState.tsx
+++ b/src/apps/forge/states/tabs/TabResourceExplorerState.tsx
@@ -1,16 +1,16 @@
-import React from "react";
-import { TabState } from "@/apps/forge/states/tabs/TabState";
-import { TabResourceExplorer } from "@/apps/forge/components/tabs/tab-resource-explorer/TabResourceExplorer";
-import * as path from "path";
-import BaseTabStateOptions from "@/apps/forge/interfaces/BaseTabStateOptions";
-import { AsyncLoop } from "@/utility/AsyncLoop";
-import * as KotOR from "@/apps/forge/KotOR";
+import React from 'react';
+import { TabState } from '@/apps/forge/states/tabs/TabState';
+import { TabResourceExplorer } from '@/apps/forge/components/tabs/tab-resource-explorer/TabResourceExplorer';
+import * as path from 'path';
+import BaseTabStateOptions from '@/apps/forge/interfaces/BaseTabStateOptions';
+import { AsyncLoop } from '@/utility/AsyncLoop';
+import * as KotOR from '@/apps/forge/KotOR';
 import { EditorFile } from "@/apps/forge/EditorFile";
-import { ForgeState } from "@/apps/forge/states/ForgeState";
-import { FileBrowserNode } from "@/apps/forge/FileBrowserNode";
+import { ForgeState } from '@/apps/forge/states/ForgeState';
+import { FileBrowserNode } from '@/apps/forge/FileBrowserNode';
+import { LoaderProgressTracker } from '@/apps/common/loader/LoaderProgress';
 
 export class TabResourceExplorerState extends TabState {
-
   static Resources: FileBrowserNode[] = [];
   static readonly ARCHIVE_RESOURCE_TYPES = new Set(['sav', 'mod', 'erf']);
   resourceNodes: FileBrowserNode[] = [];
@@ -18,65 +18,80 @@ export class TabResourceExplorerState extends TabState {
 
   onReload?: Function;
 
-  constructor(options: BaseTabStateOptions = {}){
+  constructor(options: BaseTabStateOptions = {}) {
     super(options);
     this.isClosable = false;
 
     this.setContentView(
       <TabResourceExplorer tab={this} nodes={TabResourceExplorerState.Resources}></TabResourceExplorer>
     );
-
   }
 
-  reload(){
-    if(typeof this.onReload === 'function'){
+  reload() {
+    if (typeof this.onReload === 'function') {
       this.onReload();
     }
   }
 
-  getBifSounds(){
-    const folderNode = TabResourceExplorerState.Resources.find( (node: FileBrowserNode) => node.name.toLocaleLowerCase() == 'bifs' );
-    if(!folderNode){
+  getBifSounds() {
+    const folderNode = TabResourceExplorerState.Resources.find(
+      (node: FileBrowserNode) => node.name.toLocaleLowerCase() == 'bifs'
+    );
+    if (!folderNode) {
       return [];
     }
-    const soundNodes = folderNode.nodes.find( (node: FileBrowserNode) => node.type == 'group' && node.name.toLocaleLowerCase() === 'sounds' );
-    if(!soundNodes){
+    const soundNodes = folderNode.nodes.find(
+      (node: FileBrowserNode) => node.type == 'group' && node.name.toLocaleLowerCase() === 'sounds'
+    );
+    if (!soundNodes) {
       return [];
     }
-    return soundNodes.nodes.filter( (node: FileBrowserNode) => node.type == 'resource' && node.name.toLocaleLowerCase().endsWith('.wav') );
+    return soundNodes.nodes.filter(
+      (node: FileBrowserNode) => node.type == 'resource' && node.name.toLocaleLowerCase().endsWith('.wav')
+    );
   }
 
-  getStreamSounds(){
-    const folderNode = TabResourceExplorerState.Resources.find( (node: FileBrowserNode) => node.name.toLocaleLowerCase() == 'streamsounds' );
-    if(!folderNode){
+  getStreamSounds() {
+    const folderNode = TabResourceExplorerState.Resources.find(
+      (node: FileBrowserNode) => node.name.toLocaleLowerCase() == 'streamsounds'
+    );
+    if (!folderNode) {
       return [];
     }
-    return folderNode.nodes.filter( (node: FileBrowserNode) => node.type == 'resource' && node.name.toLocaleLowerCase().endsWith('.wav') );
+    return folderNode.nodes.filter(
+      (node: FileBrowserNode) => node.type == 'resource' && node.name.toLocaleLowerCase().endsWith('.wav')
+    );
   }
 
-  static async GenerateResourceList( state: TabResourceExplorerState ){
-    ForgeState.loaderMessage('Loading [BIFs]...');
-    const bifs      = await TabResourceExplorerState.LoadBifs();
-    ForgeState.loaderMessage('Loading [RIMs]...');
-    const rims      = await TabResourceExplorerState.LoadRims();
-    ForgeState.loaderMessage('Loading [Modules]...');
-    const modules   = await TabResourceExplorerState.LoadModules();
-    ForgeState.loaderMessage('Loading [LIPs]...');
-    const lips      = await TabResourceExplorerState.LoadLips();
-    ForgeState.loaderMessage('Loading [Textures]...');
-    const textures  = await TabResourceExplorerState.LoadTextures();
-    ForgeState.loaderMessage('Loading [StreamWaves]...');
-    const waves     = await TabResourceExplorerState.LoadFolderForFileBrowser('StreamWaves');   //KOTOR
-    ForgeState.loaderMessage('Loading [StreamSounds]...');
-    const sounds    = await TabResourceExplorerState.LoadFolderForFileBrowser('StreamSounds');  //KOTOR & TSL
-    ForgeState.loaderMessage('Loading [StreamMusic]...');
-    const music     = await TabResourceExplorerState.LoadFolderForFileBrowser('StreamMusic');   //KOTOR & TSL
-    ForgeState.loaderMessage('Loading [StreamVoice]...');
-    const voice     = await TabResourceExplorerState.LoadFolderForFileBrowser('StreamVoice');   //TSL
-    ForgeState.loaderMessage('Loading [Override]...');
-    const override  = await TabResourceExplorerState.LoadFolderForFileBrowser('Override');      //KOTOR & TSL
-    ForgeState.loaderMessage('Loading [Saves]...');
-    const saves     = await TabResourceExplorerState.LoadSaves();                                //KOTOR & TSL
+  static async GenerateResourceList(state: TabResourceExplorerState) {
+    const tracker = new LoaderProgressTracker(
+      (progress) => ForgeState.loaderProgress(progress),
+      'Building resource explorer...',
+    );
+    tracker.begin(
+      TabResourceExplorerState.countBifs() +
+        TabResourceExplorerState.countRims() +
+        TabResourceExplorerState.countModules() +
+        TabResourceExplorerState.countLips() +
+        TabResourceExplorerState.countTextures(),
+    );
+
+    tracker.setMessage('Loading [BIFs]...');
+    const bifs = await TabResourceExplorerState.LoadBifs(tracker);
+    tracker.setMessage('Loading [RIMs]...');
+    const rims = await TabResourceExplorerState.LoadRims(tracker);
+    tracker.setMessage('Loading [Modules]...');
+    const modules = await TabResourceExplorerState.LoadModules(tracker);
+    tracker.setMessage('Loading [LIPs]...');
+    const lips = await TabResourceExplorerState.LoadLips(tracker);
+    tracker.setMessage('Loading [Textures]...');
+    const textures = await TabResourceExplorerState.LoadTextures(tracker);
+    const waves = await TabResourceExplorerState.LoadFolderForFileBrowser('StreamWaves', tracker);
+    const sounds = await TabResourceExplorerState.LoadFolderForFileBrowser('StreamSounds', tracker);
+    const music = await TabResourceExplorerState.LoadFolderForFileBrowser('StreamMusic', tracker);
+    const voice = await TabResourceExplorerState.LoadFolderForFileBrowser('StreamVoice', tracker);
+    const override = await TabResourceExplorerState.LoadFolderForFileBrowser('Override', tracker);
+    const saves = await TabResourceExplorerState.LoadSaves(tracker);
 
     bifs.sort();
     rims.sort();
@@ -88,23 +103,80 @@ export class TabResourceExplorerState extends TabState {
     // music.sort();
     // voice.sort();
 
-    TabResourceExplorerState.Resources.push( 
-      ...[
-        bifs, rims, modules, lips, textures, waves, sounds, music, voice, override
-        , saves
-      ].filter((node: FileBrowserNode) => (node instanceof FileBrowserNode && node.nodes.length)) 
+    TabResourceExplorerState.Resources.push(
+      ...[bifs, rims, modules, lips, textures, waves, sounds, music, voice, override, saves].filter(
+        (node: FileBrowserNode) => node instanceof FileBrowserNode && node.nodes.length
+      )
     );
     state.reload();
     ForgeState.loaderHide();
     return TabResourceExplorerState.Resources;
   }
 
-  static LoadBifs() {
-    return new Promise<FileBrowserNode>( (resolve, reject) => {
-      let bifs: KotOR.BIFObject[] = [];
-      KotOR.BIFManager.bifs.forEach( (bif: KotOR.BIFObject) => {
+  static countBifs(): number {
+    let count = 0;
+    KotOR.BIFManager.bifs.forEach(() => {
+      count++;
+    });
+    return count;
+  }
+
+  static countRims(): number {
+    let count = 0;
+    KotOR.RIMManager.RIMs.forEach((rim: KotOR.RIMObject) => {
+      if (rim.group == 'RIMs') {
+        count++;
+      }
+    });
+    return count;
+  }
+
+  static countModules(): number {
+    let count = 0;
+    KotOR.RIMManager.RIMs.forEach((rim: KotOR.RIMObject) => {
+      if (rim.group == 'Module') {
+        count++;
+      }
+    });
+    KotOR.ERFManager.ERFs.forEach((erf: KotOR.ERFObject) => {
+      if (erf.group == 'Module') {
+        count++;
+      }
+    });
+    return count;
+  }
+
+  static countLips(): number {
+    let count = 0;
+    KotOR.RIMManager.RIMs.forEach((rim: KotOR.RIMObject) => {
+      if (rim.group == 'Lips') {
+        count++;
+      }
+    });
+    KotOR.ERFManager.ERFs.forEach((erf: KotOR.ERFObject) => {
+      if (erf.group == 'Lips') {
+        count++;
+      }
+    });
+    return count;
+  }
+
+  static countTextures(): number {
+    let count = 0;
+    KotOR.ERFManager.ERFs.forEach((erf: KotOR.ERFObject) => {
+      if (erf.group == 'Textures') {
+        count++;
+      }
+    });
+    return count;
+  }
+
+  static LoadBifs(tracker?: LoaderProgressTracker) {
+    return new Promise<FileBrowserNode>((resolve, reject) => {
+      const bifs: KotOR.BIFObject[] = [];
+      KotOR.BIFManager.bifs.forEach((bif: KotOR.BIFObject) => {
         bifs.push(bif);
-      })
+      });
 
       const bifList: FileBrowserNode = new FileBrowserNode({
         name: 'BIFs',
@@ -113,13 +185,14 @@ export class TabResourceExplorerState extends TabState {
         canOrphan: false,
       });
 
-      let bifLoader = new AsyncLoop({
+      const bifLoader = new AsyncLoop({
         array: bifs,
         onLoop: (bif: KotOR.BIFObject, asyncLoop: AsyncLoop) => {
-          let name = bif.file.split(path.sep).pop()?.split('.')[0];
-          let subTypes: {[key: string]: FileBrowserNode} = {};
+          const name = bif.file.split(path.sep).pop()?.split('.')[0];
+          tracker?.itemStart(name || bif.file);
+          const subTypes: { [key: string]: FileBrowserNode } = {};
 
-          let node: FileBrowserNode = new FileBrowserNode({
+          const node: FileBrowserNode = new FileBrowserNode({
             name: name,
             type: 'group',
             nodes: [],
@@ -129,8 +202,8 @@ export class TabResourceExplorerState extends TabState {
           bifList.addChildNode(node);
 
           for (let i = 0; i < bif.resources.length; i++) {
-            let resource = bif.resources[i];
-            let resref = KotOR.KEYManager.Key.getFileLabel(resource.Id);
+            const resource = bif.resources[i];
+            const resref = KotOR.KEYManager.Key.getFileLabel(resource.Id);
 
             if (subTypes[resource.resType] == undefined) {
               subTypes[resource.resType] = new FileBrowserNode({
@@ -143,7 +216,7 @@ export class TabResourceExplorerState extends TabState {
 
             subTypes[resource.resType].addChildNode(
               new FileBrowserNode({
-                name: (`${resref}.${KotOR.ResourceTypes.getKeyByValue(resource.resType)}`),
+                name: `${resref}.${KotOR.ResourceTypes.getKeyByValue(resource.resType)}`,
                 type: 'resource',
                 data: {
                   path: EditorFile.referenceURIForArchiveResource(
@@ -151,19 +224,20 @@ export class TabResourceExplorerState extends TabState {
                     bif.file,
                     resref,
                     KotOR.ResourceTypes.getKeyByValue(resource.resType) as string,
-                  )
+                  ),
                 },
               })
             );
           }
 
+          tracker?.itemComplete();
           asyncLoop.next();
         },
       });
       bifLoader.iterate(() => {
-        for(let i = 0; i < bifList.nodes.length; i++){
+        for (let i = 0; i < bifList.nodes.length; i++) {
           const bif = bifList.nodes[i];
-          if(bif.nodes.length == 1 && bif.nodes[0].type == 'group'){
+          if (bif.nodes.length == 1 && bif.nodes[0].type == 'group') {
             bif.nodes = bif.nodes[0].nodes;
           }
         }
@@ -172,14 +246,14 @@ export class TabResourceExplorerState extends TabState {
     });
   }
 
-  static LoadRims() {
-		return new Promise<FileBrowserNode>( (resolve, reject) => {
-      let rims: KotOR.RIMObject[] = [];
-      KotOR.RIMManager.RIMs.forEach( (rim: KotOR.RIMObject) => {
-        if(rim.group == "RIMs"){
+  static LoadRims(tracker?: LoaderProgressTracker) {
+    return new Promise<FileBrowserNode>((resolve, reject) => {
+      const rims: KotOR.RIMObject[] = [];
+      KotOR.RIMManager.RIMs.forEach((rim: KotOR.RIMObject) => {
+        if (rim.group == 'RIMs') {
           rims.push(rim);
         }
-      })
+      });
 
       const rimList: FileBrowserNode = new FileBrowserNode({
         name: 'RIMs',
@@ -188,13 +262,14 @@ export class TabResourceExplorerState extends TabState {
         canOrphan: false,
       });
 
-      let rimLoader = new AsyncLoop({
+      const rimLoader = new AsyncLoop({
         array: rims,
         onLoop: (rim: KotOR.RIMObject, asyncLoop: AsyncLoop) => {
-          let name = rim.resource_path.split(path.sep).pop()?.split('.')[0];
-          let subTypes: {[key: string]: FileBrowserNode} = {};
+          const name = rim.resource_path.split(path.sep).pop()?.split('.')[0];
+          tracker?.itemStart(name || rim.resource_path);
+          const subTypes: { [key: string]: FileBrowserNode } = {};
 
-          let node: FileBrowserNode = new FileBrowserNode({
+          const node: FileBrowserNode = new FileBrowserNode({
             name: name,
             type: 'group',
             nodes: [],
@@ -204,8 +279,8 @@ export class TabResourceExplorerState extends TabState {
           rimList.addChildNode(node);
 
           for (let i = 0; i < rim.resources.length; i++) {
-            let resource = rim.resources[i];
-            let resref = resource.resRef;
+            const resource = rim.resources[i];
+            const resref = resource.resRef;
 
             if (subTypes[resource.resType] == undefined) {
               subTypes[resource.resType] = new FileBrowserNode({
@@ -216,58 +291,65 @@ export class TabResourceExplorerState extends TabState {
               node.addChildNode(subTypes[resource.resType]);
             }
 
-            subTypes[resource.resType].addChildNode(new FileBrowserNode({
-              name: `${resref}.${KotOR.ResourceTypes.getKeyByValue(resource.resType)}`,
-              type: 'resource',
-              data: {
-                path: EditorFile.referenceURIForArchiveResource(
-                  'rim',
-                  rim.resource_path,
-                  resref,
-                  KotOR.ResourceTypes.getKeyByValue(resource.resType) as string,
-                ),
-              },
-            }));
+            subTypes[resource.resType].addChildNode(
+              new FileBrowserNode({
+                name: `${resref}.${KotOR.ResourceTypes.getKeyByValue(resource.resType)}`,
+                type: 'resource',
+                data: {
+                  path: EditorFile.referenceURIForArchiveResource(
+                    'rim',
+                    rim.resource_path,
+                    resref,
+                    KotOR.ResourceTypes.getKeyByValue(resource.resType) as string,
+                  ),
+                },
+              })
+            );
           }
 
+          tracker?.itemComplete();
           asyncLoop.next();
         },
       });
       rimLoader.iterate(() => {
-        for(let i = 0; i < rimList.nodes.length; i++){
+        for (let i = 0; i < rimList.nodes.length; i++) {
           const rim = rimList.nodes[i];
-          if(rim.nodes.length == 1 && rim.nodes[0].type == 'group'){
+          if (rim.nodes.length == 1 && rim.nodes[0].type == 'group') {
             rim.nodes = rim.nodes[0].nodes;
           }
         }
         resolve(rimList);
       });
     });
-	}
-	
-  static LoadModules() {
-		return new Promise<FileBrowserNode>( (resolve, reject) => {
+  }
+
+  static LoadModules(tracker?: LoaderProgressTracker) {
+    return new Promise<FileBrowserNode>((resolve, reject) => {
       let modules: any[] = [];
 
-      KotOR.RIMManager.RIMs.forEach( (rim: KotOR.RIMObject) => {
-        if(rim.group == "Module"){
+      KotOR.RIMManager.RIMs.forEach((rim: KotOR.RIMObject) => {
+        if (rim.group == 'Module') {
           modules.push(rim);
         }
       });
 
-      KotOR.ERFManager.ERFs.forEach( (erf: KotOR.ERFObject) => {
-        if(erf.group == "Module"){
+      KotOR.ERFManager.ERFs.forEach((erf: KotOR.ERFObject) => {
+        if (erf.group == 'Module') {
           modules.push(erf);
         }
       });
-      
+
       //Sort the array by filename
-      modules = modules.sort( (a: KotOR.ERFObject|KotOR.RIMObject, b: KotOR.ERFObject|KotOR.RIMObject) => {
-        let nameA = a.resource_path.split(path.sep).pop() || '';
-        let nameB = b.resource_path.split(path.sep).pop() || '';
-        
-        if (nameA < nameB) { return -1; }
-        if (nameA > nameB) { return 1; }
+      modules = modules.sort((a: KotOR.ERFObject | KotOR.RIMObject, b: KotOR.ERFObject | KotOR.RIMObject) => {
+        const nameA = a.resource_path.split(path.sep).pop() || '';
+        const nameB = b.resource_path.split(path.sep).pop() || '';
+
+        if (nameA < nameB) {
+          return -1;
+        }
+        if (nameA > nameB) {
+          return 1;
+        }
         return 0;
       });
 
@@ -278,13 +360,14 @@ export class TabResourceExplorerState extends TabState {
         canOrphan: false,
       });
 
-      let rimLoader = new AsyncLoop({
+      const rimLoader = new AsyncLoop({
         array: modules,
-        onLoop: (rim: KotOR.RIMObject|KotOR.ERFObject, asyncLoop: AsyncLoop) => {
-          let name = rim.resource_path.split(path.sep).pop();
-          let subTypes: {[key: string]: FileBrowserNode} = {};
+        onLoop: (rim: KotOR.RIMObject | KotOR.ERFObject, asyncLoop: AsyncLoop) => {
+          const name = rim.resource_path.split(path.sep).pop();
+          tracker?.itemStart(name || rim.resource_path);
+          const subTypes: { [key: string]: FileBrowserNode } = {};
 
-          let node: FileBrowserNode = new FileBrowserNode({
+          const node: FileBrowserNode = new FileBrowserNode({
             name: name,
             type: 'group',
             nodes: [],
@@ -293,11 +376,11 @@ export class TabResourceExplorerState extends TabState {
 
           rimList.addChildNode(node);
 
-          let files = ((rim as any)?.keyList ? (rim as any).keyList : rim.resources as any);
+          const files = (rim as any)?.keyList ? (rim as any).keyList : (rim.resources as any);
 
           for (let i = 0; i < files.length; i++) {
-            let resource = files[i];
-            let resref = resource.resRef;
+            const resource = files[i];
+            const resref = resource.resRef;
 
             if (subTypes[resource.resType] == undefined) {
               subTypes[resource.resType] = new FileBrowserNode({
@@ -308,27 +391,30 @@ export class TabResourceExplorerState extends TabState {
               node.addChildNode(subTypes[resource.resType]);
             }
 
-            subTypes[resource.resType].addChildNode(new FileBrowserNode({
-              name: `${resref}.${KotOR.ResourceTypes.getKeyByValue(resource.resType)}`,
-              type: 'resource',
-              data: {
-                path: EditorFile.referenceURIForArchiveResource(
-                  rim instanceof KotOR.RIMObject ? 'rim' : 'erf',
-                  rim.resource_path,
-                  resref,
-                  KotOR.ResourceTypes.getKeyByValue(resource.resType) as string,
-                ),
-              }
-            }));
+            subTypes[resource.resType].addChildNode(
+              new FileBrowserNode({
+                name: `${resref}.${KotOR.ResourceTypes.getKeyByValue(resource.resType)}`,
+                type: 'resource',
+                data: {
+                  path: EditorFile.referenceURIForArchiveResource(
+                    rim instanceof KotOR.RIMObject ? 'rim' : 'erf',
+                    rim.resource_path,
+                    resref,
+                    KotOR.ResourceTypes.getKeyByValue(resource.resType) as string,
+                  ),
+                },
+              })
+            );
           }
 
+          tracker?.itemComplete();
           asyncLoop.next();
         },
       });
       rimLoader.iterate(() => {
-        for(let i = 0; i < rimList.nodes.length; i++){
+        for (let i = 0; i < rimList.nodes.length; i++) {
           const rim = rimList.nodes[i];
-          if(rim.nodes.length == 1 && rim.nodes[0].type == 'group'){
+          if (rim.nodes.length == 1 && rim.nodes[0].type == 'group') {
             rim.nodes = rim.nodes[0].nodes;
           }
         }
@@ -336,104 +422,112 @@ export class TabResourceExplorerState extends TabState {
       });
     });
   }
-	
-  static LoadLips() {
-		return new Promise<FileBrowserNode>( (resolve, reject) => {
-			let modules: any[] = [];
 
-			KotOR.RIMManager.RIMs.forEach( (rim: KotOR.RIMObject) => {
-				if(rim.group == "Lips"){
-					modules.push(rim);
-				}
-			});
+  static LoadLips(tracker?: LoaderProgressTracker) {
+    return new Promise<FileBrowserNode>((resolve, reject) => {
+      let modules: any[] = [];
 
-			KotOR.ERFManager.ERFs.forEach( (erf: KotOR.ERFObject) => {
-				if(erf.group == "Lips"){
-					modules.push(erf);
-				}
-			});
-			
-			//Sort the array by filename
-			modules = modules.sort( (a: KotOR.ERFObject|KotOR.RIMObject, b: KotOR.ERFObject|KotOR.RIMObject) => {
-				let nameA = a.resource_path.split(path.sep).pop() || '';
-				let nameB = b.resource_path.split(path.sep).pop() || '';
-				
-				if (nameA < nameB) { return -1; }
-				if (nameA > nameB) { return 1; }
-				return 0;
-			});
+      KotOR.RIMManager.RIMs.forEach((rim: KotOR.RIMObject) => {
+        if (rim.group == 'Lips') {
+          modules.push(rim);
+        }
+      });
 
-			const rimList: FileBrowserNode = new FileBrowserNode({
-				name: 'LIPs',
-				type: 'group',
-				nodes: [],
-				canOrphan: false,
-			});
+      KotOR.ERFManager.ERFs.forEach((erf: KotOR.ERFObject) => {
+        if (erf.group == 'Lips') {
+          modules.push(erf);
+        }
+      });
 
-			let rimLoader = new AsyncLoop({
-				array: modules,
-				onLoop: (rim: KotOR.RIMObject|KotOR.ERFObject, asyncLoop: AsyncLoop) => {
-					let name = rim.resource_path.split(path.sep).pop();
-					let subTypes: {[key: string]: FileBrowserNode} = {};
+      //Sort the array by filename
+      modules = modules.sort((a: KotOR.ERFObject | KotOR.RIMObject, b: KotOR.ERFObject | KotOR.RIMObject) => {
+        const nameA = a.resource_path.split(path.sep).pop() || '';
+        const nameB = b.resource_path.split(path.sep).pop() || '';
 
-					let node: FileBrowserNode = new FileBrowserNode({
-						name: name,
-						type: 'group',
-						nodes: [],
-						canOrphan: false,
-					});
+        if (nameA < nameB) {
+          return -1;
+        }
+        if (nameA > nameB) {
+          return 1;
+        }
+        return 0;
+      });
 
-					rimList.addChildNode(node);
+      const rimList: FileBrowserNode = new FileBrowserNode({
+        name: 'LIPs',
+        type: 'group',
+        nodes: [],
+        canOrphan: false,
+      });
 
-					let files = ((rim as any)?.keyList ? (rim as any).keyList : rim.resources as any);
+      const rimLoader = new AsyncLoop({
+        array: modules,
+        onLoop: (rim: KotOR.RIMObject | KotOR.ERFObject, asyncLoop: AsyncLoop) => {
+          const name = rim.resource_path.split(path.sep).pop();
+          tracker?.itemStart(name || rim.resource_path);
+          const subTypes: { [key: string]: FileBrowserNode } = {};
 
-					for (let i = 0; i < files.length; i++) {
-						let resource = files[i];
-						let resRef = resource.resRef;
+          const node: FileBrowserNode = new FileBrowserNode({
+            name: name,
+            type: 'group',
+            nodes: [],
+            canOrphan: false,
+          });
 
-						if (subTypes[resource.resType] == undefined) {
-							subTypes[resource.resType] = new FileBrowserNode({
-								name: KotOR.ResourceTypes.getKeyByValue(resource.resType),
-								type: 'group',
-							});
-							node.addChildNode(subTypes[resource.resType]);
-						}
+          rimList.addChildNode(node);
 
-						subTypes[resource.resType].addChildNode(new FileBrowserNode({
-							name: `${resRef}.${KotOR.ResourceTypes.getKeyByValue(resource.resType)}`,
-							type: 'resource',
-							data: {
-								path: EditorFile.referenceURIForArchiveResource(
-                  rim instanceof KotOR.RIMObject ? 'rim' : 'erf',
-                  rim.resource_path,
-                  resRef,
-                  KotOR.ResourceTypes.getKeyByValue(resource.resType) as string,
-                ),
-							}
-						}));
-					}
+          const files = (rim as any)?.keyList ? (rim as any).keyList : (rim.resources as any);
 
-					asyncLoop.next();
-				},
-			});
-			rimLoader.iterate(() => {
-        for(let i = 0; i < rimList.nodes.length; i++){
+          for (let i = 0; i < files.length; i++) {
+            const resource = files[i];
+            const resRef = resource.resRef;
+
+            if (subTypes[resource.resType] == undefined) {
+              subTypes[resource.resType] = new FileBrowserNode({
+                name: KotOR.ResourceTypes.getKeyByValue(resource.resType),
+                type: 'group',
+              });
+              node.addChildNode(subTypes[resource.resType]);
+            }
+
+            subTypes[resource.resType].addChildNode(
+              new FileBrowserNode({
+                name: `${resRef}.${KotOR.ResourceTypes.getKeyByValue(resource.resType)}`,
+                type: 'resource',
+                data: {
+                  path: EditorFile.referenceURIForArchiveResource(
+                    rim instanceof KotOR.RIMObject ? 'rim' : 'erf',
+                    rim.resource_path,
+                    resRef,
+                    KotOR.ResourceTypes.getKeyByValue(resource.resType) as string,
+                  ),
+                },
+              })
+            );
+          }
+
+          tracker?.itemComplete();
+          asyncLoop.next();
+        },
+      });
+      rimLoader.iterate(() => {
+        for (let i = 0; i < rimList.nodes.length; i++) {
           const rim = rimList.nodes[i];
-          if(rim.nodes.length == 1 && rim.nodes[0].type == 'group'){
+          if (rim.nodes.length == 1 && rim.nodes[0].type == 'group') {
             rim.nodes = rim.nodes[0].nodes;
           }
         }
-				resolve(rimList);
-			});
-		});
+        resolve(rimList);
+      });
+    });
   }
-	
-  static LoadTextures() {
-    return new Promise<FileBrowserNode>( (resolve, reject) => {
-      let texture_packs: any[] = [];
 
-      KotOR.ERFManager.ERFs.forEach( (erf: KotOR.ERFObject) => {
-        if(erf.group == "Textures"){
+  static LoadTextures(tracker?: LoaderProgressTracker) {
+    return new Promise<FileBrowserNode>((resolve, reject) => {
+      const texture_packs: any[] = [];
+
+      KotOR.ERFManager.ERFs.forEach((erf: KotOR.ERFObject) => {
+        if (erf.group == 'Textures') {
           texture_packs.push(erf);
         }
       });
@@ -445,13 +539,14 @@ export class TabResourceExplorerState extends TabState {
         canOrphan: false,
       });
 
-      let erfLoader = new AsyncLoop({
+      const erfLoader = new AsyncLoop({
         array: texture_packs,
         onLoop: (erf: KotOR.ERFObject, asyncLoop: AsyncLoop) => {
-          let name = erf.resource_path.split(path.sep).pop();
-          let subTypes: {[key: string]: FileBrowserNode} = {};
+          const name = erf.resource_path.split(path.sep).pop();
+          tracker?.itemStart(name || erf.resource_path);
+          const subTypes: { [key: string]: FileBrowserNode } = {};
 
-          let node: FileBrowserNode = new FileBrowserNode({
+          const node: FileBrowserNode = new FileBrowserNode({
             name: name,
             type: 'group',
             nodes: [],
@@ -460,12 +555,12 @@ export class TabResourceExplorerState extends TabState {
 
           erfList.addChildNode(node);
 
-          let files = erf.keyList;
+          const files = erf.keyList;
 
           for (let i = 0; i < files.length; i++) {
-            let resource = files[i];
-            let resref = resource.resRef;
-            let letter = resref[0].toLowerCase();
+            const resource = files[i];
+            const resref = resource.resRef;
+            const letter = resref[0].toLowerCase();
 
             if (subTypes[letter] == undefined) {
               subTypes[letter] = new FileBrowserNode({
@@ -476,20 +571,23 @@ export class TabResourceExplorerState extends TabState {
               node.addChildNode(subTypes[letter]);
             }
 
-            subTypes[letter].addChildNode(new FileBrowserNode({
-              name: `${resref}.${KotOR.ResourceTypes.getKeyByValue(resource.resType)}`,
-              type: 'resource',
-              data: {
-                path: EditorFile.referenceURIForArchiveResource(
-                  'erf',
-                  erf.resource_path,
-                  resref,
-                  KotOR.ResourceTypes.getKeyByValue(resource.resType) as string,
-                ),
-              },
-            }));
+            subTypes[letter].addChildNode(
+              new FileBrowserNode({
+                name: `${resref}.${KotOR.ResourceTypes.getKeyByValue(resource.resType)}`,
+                type: 'resource',
+                data: {
+                  path: EditorFile.referenceURIForArchiveResource(
+                    'erf',
+                    erf.resource_path,
+                    resref,
+                    KotOR.ResourceTypes.getKeyByValue(resource.resType) as string,
+                  ),
+                },
+              })
+            );
           }
 
+          tracker?.itemComplete();
           asyncLoop.next();
         },
       });
@@ -499,94 +597,97 @@ export class TabResourceExplorerState extends TabState {
     });
   }
 
-	static LoadFolderForFileBrowser(folder_name = '') {
-    return new Promise<FileBrowserNode>( (resolve, reject) => {
+  static LoadFolderForFileBrowser(folder_name = '', tracker?: LoaderProgressTracker) {
+    tracker?.setMessage(`Loading [${folder_name}]...`);
+    return new Promise<FileBrowserNode>((resolve, reject) => {
       //Load StreamWaves
-      let folder: FileBrowserNode =  new FileBrowserNode({ 
-        name: folder_name, 
-        type: 'group', 
-        nodes: [] 
+      const folder: FileBrowserNode = new FileBrowserNode({
+        name: folder_name,
+        type: 'group',
+        nodes: [],
       });
-      KotOR.GameFileSystem.exists(folder_name).then((exists: boolean) => {
-        if(!exists){
-          resolve(folder);
-          return;
-        }
-        return KotOR.GameFileSystem.readdir(folder_name, { recursive: true });
-      }).then((files: string[] | void) => {
-        if(!Array.isArray(files)){
-          return;
-        }
-        (folder.nodes as any)._indexes = {};
+      KotOR.GameFileSystem.exists(folder_name)
+        .then((exists: boolean) => {
+          if (!exists) {
+            resolve(folder);
+            return;
+          }
+          return KotOR.GameFileSystem.readdir(folder_name, { recursive: true });
+        })
+        .then((files: string[] | void) => {
+          if (!Array.isArray(files)) {
+            return;
+          }
+          tracker?.addTotal(files.length);
+          (folder.nodes as any)._indexes = {};
 
-        for (let i = 0; i < files.length; i++) {
-          let file = files[i];
-          let parts = file.split(path.sep);
-          parts.shift();
+          for (let i = 0; i < files.length; i++) {
+            const file = files[i];
+            const parts = file.split(path.sep);
+            parts.shift();
 
-          let newfile = parts.pop() || '';
-          let targetFolder = folder;
+            const newfile = parts.pop() || '';
+            tracker?.itemStart(newfile.trim() || file);
+            let targetFolder = folder;
 
-          for (let i = 0; i < parts.length; i++) {
-            if (
-              typeof (targetFolder.nodes as any)._indexes[parts[i]] ===
-              'undefined'
-            ) {
-              //Push the new folder and get the index
-              let index =
-                targetFolder.addChildNode( new FileBrowserNode({
-                  name: parts[i].trim(),
-                  type: 'group',
-                  nodes: [],
-                })) - 1;
-              (targetFolder.nodes as any)._indexes[parts[i]] = index;
-              targetFolder = targetFolder.nodes[index];
-              (targetFolder.nodes as any)._indexes = {};
-            } else {
-              let index = (targetFolder.nodes as any)._indexes[parts[i]];
-              targetFolder = targetFolder.nodes[index];
+            for (let i = 0; i < parts.length; i++) {
+              if (typeof (targetFolder.nodes as any)._indexes[parts[i]] === 'undefined') {
+                //Push the new folder and get the index
+                const index =
+                  targetFolder.addChildNode(
+                    new FileBrowserNode({
+                      name: parts[i].trim(),
+                      type: 'group',
+                      nodes: [],
+                    })
+                  ) - 1;
+                (targetFolder.nodes as any)._indexes[parts[i]] = index;
+                targetFolder = targetFolder.nodes[index];
+                (targetFolder.nodes as any)._indexes = {};
+              } else {
+                const index = (targetFolder.nodes as any)._indexes[parts[i]];
+                targetFolder = targetFolder.nodes[index];
+              }
             }
+
+            targetFolder.addChildNode(
+              new FileBrowserNode({
+                name: newfile.trim(),
+                type: 'resource',
+                data: { path: EditorFile.referenceURIForGameRelative(files[i]) },
+                nodes: [],
+              })
+            );
+
+            tracker?.itemComplete();
           }
 
-          targetFolder.addChildNode( 
-            new FileBrowserNode({
-              name: newfile.trim(),
-              type: 'resource',
-              data: { path: EditorFile.referenceURIForGameRelative(files[i]) },
-              nodes: [],
-            })
-          );
+          folder.nodes.sort((a: any, b: any) => {
+            const compareType = a.type == 'group' && b.type != 'group' ? -1 : 1;
+            const compareName = a.name.localeCompare(b.name);
 
-          /*targetFolder.nodeList.sort( (a, b) => {
-            return a.type == 'group' ? 0 : 1;
-          });*/
-        }
+            return compareType || compareName;
+          });
 
-        folder.nodes.sort((a: any, b: any) => {
-          let compareType =
-            a.type == 'group' && b.type != 'group' ? -1 : 1;
-          let compareName = a.name.localeCompare(b.name);
-
-          return compareType || compareName;
+          resolve(folder);
+        })
+        .catch((err: any) => {
+          // Optional folders (e.g. StreamVoice on K1) may not exist in some installs.
+          // Keep explorer loading resilient and skip missing folders quietly.
+          const errMsg = String(err?.message || err || '');
+          const isMissingDir =
+            errMsg.toLowerCase().includes('failed to resolve directory inside game folder') ||
+            errMsg.toLowerCase().includes('failed to resolve file path directory handle');
+          if (!isMissingDir) {
+            console.error(err);
+          }
+          resolve(folder);
         });
-
-        resolve(folder);
-      }).catch( (err: any) => {
-        // Optional folders (e.g. StreamVoice on K1) may not exist in some installs.
-        // Keep explorer loading resilient and skip missing folders quietly.
-        const errMsg = String(err?.message || err || '');
-        const isMissingDir =
-          errMsg.toLowerCase().includes('failed to resolve directory inside game folder') ||
-          errMsg.toLowerCase().includes('failed to resolve file path directory handle');
-        if(!isMissingDir){
-          console.error(err);
-        }
-        resolve(folder)
-      }); 
     });
-	}
+  }
 
-  static LoadSaves() {
+  static LoadSaves(tracker?: LoaderProgressTracker) {
+    tracker?.setMessage('Loading [Saves]...');
     return new Promise<FileBrowserNode>(async (resolve) => {
       const savesRoot: FileBrowserNode = new FileBrowserNode({
         name: 'Saves',
@@ -598,8 +699,10 @@ export class TabResourceExplorerState extends TabState {
       try {
         const files = await KotOR.GameFileSystem.readdir('Saves', { recursive: true });
         const saveArchives = files.filter((filepath: string) => filepath.toLowerCase().endsWith('savegame.sav'));
+        tracker?.addTotal(saveArchives.length);
 
         for (const savePath of saveArchives) {
+          tracker?.itemStart(savePath.split(path.sep).pop() || savePath);
           try {
             const erf = new KotOR.ERFObject(savePath);
             await erf.load();
@@ -625,6 +728,8 @@ export class TabResourceExplorerState extends TabState {
             }
           } catch (e) {
             console.error('LoadSaves: failed to load save archive', savePath, e);
+          } finally {
+            tracker?.itemComplete();
           }
         }
 
@@ -671,32 +776,36 @@ export class TabResourceExplorerState extends TabState {
 
       const isNestedArchiveType = TabResourceExplorerState.ARCHIVE_RESOURCE_TYPES.has(restype.toLowerCase());
       if (isNestedArchiveType) {
-        subTypes[resource.resType].addChildNode(new FileBrowserNode({
-          name: `${resource.resRef}.${restype}`,
-          type: 'group',
-          data: {
-            lazyArchive: {
-              resRef: resource.resRef,
-              resType: resource.resType,
-              parentArchivePath: archivePath,
-              parentArchiveBuffer: archiveBuffer,
+        subTypes[resource.resType].addChildNode(
+          new FileBrowserNode({
+            name: `${resource.resRef}.${restype}`,
+            type: 'group',
+            data: {
+              lazyArchive: {
+                resRef: resource.resRef,
+                resType: resource.resType,
+                parentArchivePath: archivePath,
+                parentArchiveBuffer: archiveBuffer,
+              },
+              lazyLoaded: false,
             },
-            lazyLoaded: false,
-          },
-          nodes: [],
-        }));
+            nodes: [],
+          })
+        );
         continue;
       }
 
-      subTypes[resource.resType].addChildNode(new FileBrowserNode({
-        name: `${resource.resRef}.${restype}`,
-        type: 'resource',
-        data: {
-          path: archivePath
-            ? EditorFile.referenceURIForArchiveResource('erf', archivePath, resource.resRef, restype)
-            : undefined,
-        },
-      }));
+      subTypes[resource.resType].addChildNode(
+        new FileBrowserNode({
+          name: `${resource.resRef}.${restype}`,
+          type: 'resource',
+          data: {
+            path: archivePath
+              ? EditorFile.referenceURIForArchiveResource('erf', archivePath, resource.resRef, restype)
+              : undefined,
+          },
+        })
+      );
     }
 
     return archiveNode;
@@ -745,5 +854,4 @@ export class TabResourceExplorerState extends TabState {
       node.data.lazyLoaded = true;
     }
   }
-
 }

--- a/src/apps/forge/states/tabs/TabResourceExplorerState.tsx
+++ b/src/apps/forge/states/tabs/TabResourceExplorerState.tsx
@@ -5,7 +5,7 @@ import * as path from 'path';
 import BaseTabStateOptions from '@/apps/forge/interfaces/BaseTabStateOptions';
 import { AsyncLoop } from '@/utility/AsyncLoop';
 import * as KotOR from '@/apps/forge/KotOR';
-import { EditorFile } from "@/apps/forge/EditorFile";
+import { EditorFile } from '@/apps/forge/EditorFile';
 import { ForgeState } from '@/apps/forge/states/ForgeState';
 import { FileBrowserNode } from '@/apps/forge/FileBrowserNode';
 import { LoaderProgressTracker } from '@/apps/common/loader/LoaderProgress';
@@ -109,7 +109,6 @@ export class TabResourceExplorerState extends TabState {
       )
     );
     state.reload();
-    ForgeState.loaderHide();
     return TabResourceExplorerState.Resources;
   }
 

--- a/src/apps/game/GameInitializer.ts
+++ b/src/apps/game/GameInitializer.ts
@@ -1,6 +1,7 @@
 import * as path from "path";
 import * as KotOR from "@/apps/game/KotOR";
 import pLimit from "p-limit";
+import { ILoaderProgress, LoaderProgressTracker } from '@/apps/common/loader/LoaderProgress';
 
 const fsLimit = pLimit(16);
 
@@ -92,6 +93,11 @@ export class GameInitializer {
 
   static SetLoadingMessage(message: string){
     GameInitializer.ProcessEventListener('on-loader-message', [message]);
+    GameInitializer.ProcessEventListener('on-loader-progress', [null]);
+  }
+
+  static SetLoadingProgress(progress: ILoaderProgress) {
+    GameInitializer.ProcessEventListener('on-loader-progress', [progress]);
   }
 
   static async Init(game: KotOR.GameEngineType){
@@ -246,14 +252,32 @@ export class GameInitializer {
   }
 
   static async LoadGameResources(){
-    GameInitializer.SetLoadingMessage("Loading Assets");
-    const promises = [
-      GameInitializer.LoadOverride(), 
-      GameInitializer.LoadRIMs(), 
-      GameInitializer.Load2DAs(), 
-      GameInitializer.LoadTexturePacks()
-    ];
-    await Promise.all(promises);
+    const tracker = new LoaderProgressTracker(
+      (progress) => GameInitializer.SetLoadingProgress(progress),
+      'Loading Assets',
+    );
+    tracker.begin(4, 'Loading Assets');
+
+    tracker.setMessage('Loading Override...');
+    tracker.itemStart('Override');
+    await GameInitializer.LoadOverride();
+    tracker.itemComplete();
+
+    tracker.setMessage('Loading RIMs...');
+    tracker.itemStart('RIMs');
+    await GameInitializer.LoadRIMs();
+    tracker.itemComplete();
+
+    tracker.setMessage('Loading 2DA tables...');
+    tracker.itemStart('2DA');
+    await GameInitializer.Load2DAs();
+    tracker.itemComplete();
+
+    tracker.setMessage('Loading texture packs...');
+    tracker.itemStart('TexturePacks');
+    await GameInitializer.LoadTexturePacks();
+    tracker.itemComplete();
+
     const nonBlockingPromises = [
       GameInitializer.LoadGameAudioResources('streammusic'), 
       GameInitializer.LoadGameAudioResources('streamsounds'), 

--- a/src/apps/game/app.tsx
+++ b/src/apps/game/app.tsx
@@ -13,6 +13,7 @@ export const GameApp = () => {
   const [showCheatConsole] = appContext.showCheatConsole;
   const [showLoadingScreen] = appContext.showLoadingScreen;
   const [loadingScreenMessage] = appContext.loadingScreenMessage;
+  const [loadingScreenProgress] = appContext.loadingScreenProgress;
   const [loadingScreenBackgroundURL] = appContext.loadingScreenBackgroundURL;
   const [loadingScreenLogoURL] = appContext.loadingScreenLogoURL;
   return (
@@ -26,7 +27,13 @@ export const GameApp = () => {
       {gameLoaded && showCheatConsole && (
         <CheatConsole />
       )}
-      <LoadingScreen active={showLoadingScreen} message={loadingScreenMessage} backgroundURL={loadingScreenBackgroundURL} logoURL={loadingScreenLogoURL} />
+      <LoadingScreen
+        active={showLoadingScreen}
+        message={loadingScreenMessage}
+        progress={loadingScreenProgress}
+        backgroundURL={loadingScreenBackgroundURL}
+        logoURL={loadingScreenLogoURL}
+      />
     </>
   )
 }

--- a/src/apps/game/context/AppContext.tsx
+++ b/src/apps/game/context/AppContext.tsx
@@ -72,6 +72,7 @@ export const AppProvider = (props: any) => {
 
   const onLoadingScreenHide = () => {
     setShowLoadingScreen(false);
+    setLoadingScreenProgress(null);
   }
 
   const onLoadingScreenInit = (backgroundURL: string, logoURL: string, message?: string) => {

--- a/src/apps/game/context/AppContext.tsx
+++ b/src/apps/game/context/AppContext.tsx
@@ -4,6 +4,18 @@ import * as KotOR from "@/apps/game/KotOR";
 import { ILoaderProgress } from '@/apps/common/loader/LoaderProgress';
 import { HotReloadManager } from "@/dev/HotReloadManager";
 
+function readPreservedSessionUiState(gameKeyFallback: KotOR.GameEngineType) {
+  const preserved = HotReloadManager.shouldSkipBootstrap();
+  return {
+    appReady: preserved,
+    gameLoaded: preserved && KotOR.GameState.Ready,
+    showLoadingScreen: !preserved,
+    showEULAModal: preserved ? false : !AppState.eulaAccepted,
+    showGrantModal: preserved ? false : (AppState.eulaAccepted && !AppState.directoryLocated),
+    gameKey: AppState.gameKey || gameKeyFallback,
+  };
+}
+
 export interface AppProviderValues {
   appState: [typeof AppState];
   gameKey: [KotOR.GameEngineType, React.Dispatch<KotOR.GameEngineType>];
@@ -26,15 +38,16 @@ export function useApp(){
 }
 
 export const AppProvider = (props: any) => {
-  const [gameKey, setGameKey] = useState<KotOR.GameEngineType>(props.gameKey || KotOR.GameEngineType.KOTOR);
-  const [appReady, setAppReady] = useState<boolean>(false);
-  const [gameLoaded, setGameLoaded] = useState<boolean>(false);
-  const [showEULAModal, setShowEULAModal] = useState<boolean>(props.showEULAModal || false);
-  const [showGrantModal, setShowGrantModal] = useState<boolean>(props.showGrantModal || false);
+  const initialUi = readPreservedSessionUiState(props.gameKey || KotOR.GameEngineType.KOTOR);
+  const [gameKey, setGameKey] = useState<KotOR.GameEngineType>(initialUi.gameKey);
+  const [appReady, setAppReady] = useState<boolean>(initialUi.appReady);
+  const [gameLoaded, setGameLoaded] = useState<boolean>(initialUi.gameLoaded);
+  const [showEULAModal, setShowEULAModal] = useState<boolean>(initialUi.showEULAModal);
+  const [showGrantModal, setShowGrantModal] = useState<boolean>(initialUi.showGrantModal);
   const [showCheatConsole, setShowCheatConsole] = useState<boolean>(false);
   const [showPerformanceMonitor, setShowPerformanceMonitor] = useState<boolean>(false);
 
-  const [showLoadingScreen, setShowLoadingScreen] = useState<boolean>(true);
+  const [showLoadingScreen, setShowLoadingScreen] = useState<boolean>(initialUi.showLoadingScreen);
   const [loadingScreenMessage, setLoadingScreenMessage] = useState<string>('Loading...');
   const [loadingScreenProgress, setLoadingScreenProgress] = useState<ILoaderProgress | null>(null);
   const [loadingScreenBackgroundURL, setLoadingScreenBackgroundURL] = useState<string>('');

--- a/src/apps/game/context/AppContext.tsx
+++ b/src/apps/game/context/AppContext.tsx
@@ -1,6 +1,7 @@
 import React, { createContext, useContext, useEffect, useState } from "react";
 import { AppState } from "@/apps/game/states/AppState";
 import * as KotOR from "@/apps/game/KotOR";
+import { ILoaderProgress } from '@/apps/common/loader/LoaderProgress';
 
 export interface AppProviderValues {
   appState: [typeof AppState];
@@ -13,6 +14,7 @@ export interface AppProviderValues {
   showPerformanceMonitor: [boolean, React.Dispatch<boolean>];
   showLoadingScreen: [boolean, React.Dispatch<boolean>];
   loadingScreenMessage: [string, React.Dispatch<string>];
+  loadingScreenProgress: [ILoaderProgress | null, React.Dispatch<ILoaderProgress | null>];
   loadingScreenBackgroundURL: [string, React.Dispatch<string>];
   loadingScreenLogoURL: [string, React.Dispatch<string>];
 }
@@ -33,6 +35,7 @@ export const AppProvider = (props: any) => {
 
   const [showLoadingScreen, setShowLoadingScreen] = useState<boolean>(true);
   const [loadingScreenMessage, setLoadingScreenMessage] = useState<string>('Loading...');
+  const [loadingScreenProgress, setLoadingScreenProgress] = useState<ILoaderProgress | null>(null);
   const [loadingScreenBackgroundURL, setLoadingScreenBackgroundURL] = useState<string>('');
   const [loadingScreenLogoURL, setLoadingScreenLogoURL] = useState<string>('');
 
@@ -79,7 +82,15 @@ export const AppProvider = (props: any) => {
 
   const onLoadingScreenMessage = (message: string) => {
     setLoadingScreenMessage(message);
-  }
+    setLoadingScreenProgress(null);
+  };
+
+  const onLoadingScreenProgress = (progress: ILoaderProgress | null) => {
+    setLoadingScreenProgress(progress);
+    if (progress?.message) {
+      setLoadingScreenMessage(progress.message);
+    }
+  };
 
   useEffect(() => { 
     window.addEventListener('keypress', onKeyPress);
@@ -90,6 +101,7 @@ export const AppProvider = (props: any) => {
     AppState.addEventListener('on-loader-hide', onLoadingScreenHide);
     AppState.addEventListener('on-loader-init', onLoadingScreenInit);
     AppState.addEventListener('on-loader-message', onLoadingScreenMessage);
+    AppState.addEventListener('on-loader-progress', onLoadingScreenProgress);
     AppState.initApp();
     return () => {
       window.removeEventListener('keypress', onKeyPress);
@@ -100,7 +112,8 @@ export const AppProvider = (props: any) => {
       AppState.removeEventListener('on-loader-hide', onLoadingScreenHide);
       AppState.removeEventListener('on-loader-init', onLoadingScreenInit);
       AppState.removeEventListener('on-loader-message', onLoadingScreenMessage);
-    }
+      AppState.removeEventListener('on-loader-progress', onLoadingScreenProgress);
+    };
   }, []);
 
   useEffect(() => { 
@@ -121,6 +134,7 @@ export const AppProvider = (props: any) => {
     showPerformanceMonitor: [showPerformanceMonitor, setShowPerformanceMonitor],
     showLoadingScreen: [showLoadingScreen, setShowLoadingScreen],
     loadingScreenMessage: [loadingScreenMessage, setLoadingScreenMessage],
+    loadingScreenProgress: [loadingScreenProgress, setLoadingScreenProgress],
     loadingScreenBackgroundURL: [loadingScreenBackgroundURL, setLoadingScreenBackgroundURL],
     loadingScreenLogoURL: [loadingScreenLogoURL, setLoadingScreenLogoURL],
   };

--- a/src/apps/game/context/AppContext.tsx
+++ b/src/apps/game/context/AppContext.tsx
@@ -1,6 +1,7 @@
 import React, { createContext, useContext, useEffect, useState } from "react";
 import { AppState } from "@/apps/game/states/AppState";
 import * as KotOR from "@/apps/game/KotOR";
+import { HotReloadManager } from "@/dev/HotReloadManager";
 
 export interface AppProviderValues {
   appState: [typeof AppState];
@@ -82,6 +83,8 @@ export const AppProvider = (props: any) => {
   }
 
   useEffect(() => { 
+    const skipBootstrap = HotReloadManager.shouldSkipBootstrap();
+
     window.addEventListener('keypress', onKeyPress);
     AppState.addEventListener('on-preload', onPreload);
     AppState.addEventListener('on-ready', onAppReady);  
@@ -90,7 +93,18 @@ export const AppProvider = (props: any) => {
     AppState.addEventListener('on-loader-hide', onLoadingScreenHide);
     AppState.addEventListener('on-loader-init', onLoadingScreenInit);
     AppState.addEventListener('on-loader-message', onLoadingScreenMessage);
-    AppState.initApp();
+
+    if (skipBootstrap) {
+      setAppReady(true);
+      setGameKey(AppState.gameKey);
+      setGameLoaded(KotOR.GameState.Ready);
+      setShowLoadingScreen(false);
+      setShowEULAModal(false);
+      setShowGrantModal(false);
+    } else {
+      AppState.initApp();
+    }
+
     return () => {
       window.removeEventListener('keypress', onKeyPress);
       AppState.removeEventListener('on-preload', onPreload);

--- a/src/apps/game/index.hmr.html
+++ b/src/apps/game/index.hmr.html
@@ -84,6 +84,9 @@
         </div>
       </div>
     </div>
+    <script>
+      window.__KOTOR_PAGE_LOAD_ID__ = window.__KOTOR_PAGE_LOAD_ID__ || String(Math.random());
+    </script>
     <script type="text/javascript" src="/three.min.js"></script>
   </body>
 </html>

--- a/src/apps/game/index.hmr.html
+++ b/src/apps/game/index.hmr.html
@@ -1,0 +1,89 @@
+<!DOCTYPE HTML>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>KotOR</title>
+    <link rel="shortcut icon" href="favicon.ico">
+    <style>
+      html, body {
+        background: #212121;
+        overflow: hidden;
+        margin: 0;
+      }
+
+      .page-pre-loader {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 12px;
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        z-index: 99999999999999;
+        background: rgba(0, 0, 0, 0.6) !important;
+        font-family: "Roboto", sans-serif !important;
+        color: #ccc !important;
+      }
+
+      .page-pre-loader .pre-loader-card {
+        min-width: 280px;
+        max-width: 420px;
+        padding: 20px 24px;
+        border: 1px solid #464646;
+        border-radius: 5px;
+        box-shadow: 2px 2px 10px #1d1d1d;
+        background: #212121;
+        text-align: center;
+      }
+
+      .page-pre-loader h1 {
+        margin: 0 0 6px !important;
+        font-weight: 600 !important;
+        line-height: 1.2 !important;
+        font-size: 1.35rem !important;
+        color: #c9dde6 !important;
+      }
+
+      .page-pre-loader p {
+        margin: 0 !important;
+        font-size: 0.9rem !important;
+        color: #9d9d9d !important;
+      }
+
+      .page-pre-loader .loading-accent {
+        width: 120px;
+        height: 3px;
+        border-radius: 999px;
+        margin: 10px auto 0;
+        background: linear-gradient(90deg, #0c3d5a 0%, #337ab7 50%, #0c3d5a 100%);
+        animation: loading-accent 1.5s ease-in-out infinite;
+      }
+
+      @keyframes loading-accent {
+        0% { opacity: 0.45; transform: scaleX(0.9); }
+        50% { opacity: 1; transform: scaleX(1); }
+        100% { opacity: 0.45; transform: scaleX(0.9); }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="viewport-wrapper">
+      <div id="renderer-container"></div>
+      <div id="root">
+        <div class="page-pre-loader">
+          <div class="pre-loader-card">
+            <h1>Initializing...</h1>
+            <p>Loading engine libraries</p>
+            <div class="loading-accent"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <script type="text/javascript" src="/three.min.js"></script>
+  </body>
+</html>

--- a/src/apps/game/index.tsx
+++ b/src/apps/game/index.tsx
@@ -4,6 +4,8 @@ import * as KotOR from "@/apps/game/KotOR";
 import { AppProvider } from "@/apps/game/context/AppContext";
 import { GameApp } from "@/apps/game/app";
 import { HotReloadManager } from "@/dev/HotReloadManager";
+import { installHmrTestBridge } from "@/dev/HmrTestBridge";
+import { HMR_PROBE } from "@/dev/HmrTestProbe";
 import "@/apps/game/app.scss";
 
 declare const module: {
@@ -19,6 +21,7 @@ declare global {
     __KOTOR_GAME_REACT_ROOT__?: ReactDOM.Root;
     __KOTOR_GAME_BEFOREUNLOAD__?: boolean;
     __KOTOR_HMR_STATUS_HANDLER__?: boolean;
+    __KOTOR_HMR_PROBE_VALUE__?: number;
   }
 }
 
@@ -55,7 +58,16 @@ function mountApp(): void {
   );
 }
 
+function onProbeHotApplied(): void {
+  console.log('[HMR] Game client module updated — preserving session');
+  HotReloadManager.onHotAccept();
+  window.__KOTOR_HMR_PROBE_VALUE__ = require('@/dev/HmrTestProbe').HMR_PROBE as number;
+  installHmrTestBridge();
+}
+
 function bootstrap(): void {
+  window.__KOTOR_HMR_PROBE_VALUE__ = HMR_PROBE;
+  installHmrTestBridge();
   mountApp();
 }
 
@@ -78,9 +90,7 @@ if (typeof module !== 'undefined' && module.hot) {
     });
   }
 
-  module.hot.accept(() => {
-    console.log('[HMR] Game client module updated — preserving session');
-    HotReloadManager.onHotAccept();
-    mountApp();
+  module.hot.accept(['@/dev/HmrTestProbe'], () => {
+    onProbeHotApplied();
   });
 }

--- a/src/apps/game/index.tsx
+++ b/src/apps/game/index.tsx
@@ -65,17 +65,25 @@ const UI_HMR_BOUNDARIES = [
 ] as const;
 
 function onUiHotApplied(): void {
-  console.log('[HMR] Game UI module updated — remounting while preserving session');
-  HotReloadManager.onHotAccept();
-  installHmrTestBridge();
-  mountApp();
+  try {
+    console.log('[HMR] Game UI module updated — remounting while preserving session');
+    HotReloadManager.onHotAccept();
+    installHmrTestBridge();
+    mountApp();
+  } catch (e) {
+    console.error('[HMR] UI hot accept failed — session preserved, skipping remount', e);
+  }
 }
 
 function onProbeHotApplied(): void {
-  console.log('[HMR] Game client probe updated — preserving session');
-  HotReloadManager.onHotAccept();
-  window.__KOTOR_HMR_PROBE_VALUE__ = require('@/dev/HmrTestProbe').HMR_PROBE as number;
-  installHmrTestBridge();
+  try {
+    console.log('[HMR] Game client probe updated — preserving session');
+    HotReloadManager.onHotAccept();
+    window.__KOTOR_HMR_PROBE_VALUE__ = require('@/dev/HmrTestProbe').HMR_PROBE as number;
+    installHmrTestBridge();
+  } catch (e) {
+    console.error('[HMR] Probe hot accept failed', e);
+  }
 }
 
 function bootstrap(): void {
@@ -97,6 +105,10 @@ if (typeof module !== 'undefined' && module.hot) {
     window.__KOTOR_HMR_STATUS_HANDLER__ = true;
     module.hot.addStatusHandler((status) => {
       if (status === 'abort' || status === 'fail') {
+        if (KotOR.GameState.hmrIsSessionActive()) {
+          console.warn('[HMR] Hot update failed — keeping live in-game session (no reload)');
+          return;
+        }
         console.warn('[HMR] Hot update failed — performing full reload');
         window.location.reload();
       }

--- a/src/apps/game/index.tsx
+++ b/src/apps/game/index.tsx
@@ -1,8 +1,6 @@
 import ReactDOM from "react-dom/client";
 import React from "react";
 import * as KotOR from "@/apps/game/KotOR";
-import { AppProvider } from "@/apps/game/context/AppContext";
-import { GameApp } from "@/apps/game/app";
 import { HotReloadManager } from "@/dev/HotReloadManager";
 import { installHmrTestBridge } from "@/dev/HmrTestBridge";
 import { HMR_PROBE } from "@/dev/HmrTestProbe";
@@ -50,6 +48,8 @@ function mountApp(): void {
   }
 
   const reactRoot = getOrCreateReactRoot(rootElement);
+  const { AppProvider } = require('@/apps/game/context/AppContext') as typeof import('@/apps/game/context/AppContext');
+  const { GameApp } = require('@/apps/game/app') as typeof import('@/apps/game/app');
 
   reactRoot.render(
     <AppProvider>

--- a/src/apps/game/index.tsx
+++ b/src/apps/game/index.tsx
@@ -10,18 +10,35 @@ declare const module: {
   hot?: {
     accept: (dependencies?: string | string[], callback?: () => void) => void;
     dispose: (callback: () => void) => void;
+    addStatusHandler: (callback: (status: string) => void) => void;
   };
 };
 
-let reactRoot: ReactDOM.Root | null = null;
-
-window.addEventListener('beforeunload', () => {
-  try {
-    KotOR.GameState.Debugger.close();
-  } catch (e) {
-    console.error(e);
+declare global {
+  interface Window {
+    __KOTOR_GAME_REACT_ROOT__?: ReactDOM.Root;
+    __KOTOR_GAME_BEFOREUNLOAD__?: boolean;
+    __KOTOR_HMR_STATUS_HANDLER__?: boolean;
   }
-});
+}
+
+if (!window.__KOTOR_GAME_BEFOREUNLOAD__) {
+  window.__KOTOR_GAME_BEFOREUNLOAD__ = true;
+  window.addEventListener('beforeunload', () => {
+    try {
+      KotOR.GameState.Debugger.close();
+    } catch (e) {
+      console.error(e);
+    }
+  });
+}
+
+function getOrCreateReactRoot(rootElement: HTMLElement): ReactDOM.Root {
+  if (!window.__KOTOR_GAME_REACT_ROOT__) {
+    window.__KOTOR_GAME_REACT_ROOT__ = ReactDOM.createRoot(rootElement);
+  }
+  return window.__KOTOR_GAME_REACT_ROOT__;
+}
 
 function mountApp(): void {
   const rootElement = document.getElementById("root") as HTMLElement | null;
@@ -29,9 +46,7 @@ function mountApp(): void {
     return;
   }
 
-  if (!reactRoot) {
-    reactRoot = ReactDOM.createRoot(rootElement);
-  }
+  const reactRoot = getOrCreateReactRoot(rootElement);
 
   reactRoot.render(
     <AppProvider>
@@ -52,6 +67,16 @@ if (typeof module !== 'undefined' && module.hot) {
   module.hot.dispose(() => {
     HotReloadManager.preserveSession();
   });
+
+  if (!window.__KOTOR_HMR_STATUS_HANDLER__) {
+    window.__KOTOR_HMR_STATUS_HANDLER__ = true;
+    module.hot.addStatusHandler((status) => {
+      if (status === 'abort' || status === 'fail') {
+        console.warn('[HMR] Hot update failed — performing full reload');
+        window.location.reload();
+      }
+    });
+  }
 
   module.hot.accept(() => {
     console.log('[HMR] Game client module updated — preserving session');

--- a/src/apps/game/index.tsx
+++ b/src/apps/game/index.tsx
@@ -93,7 +93,12 @@ function bootstrap(): void {
 }
 
 window.addEventListener('DOMContentLoaded', () => {
-  bootstrap();
+  void (async () => {
+    // Activate dev FS before React bootstrap so GameFileSystem never hits FS Access first.
+    const { probeDevGameFileBackend } = await import('@/dev/DevGameFileBackend');
+    await probeDevGameFileBackend();
+    bootstrap();
+  })();
 });
 
 if (typeof module !== 'undefined' && module.hot) {

--- a/src/apps/game/index.tsx
+++ b/src/apps/game/index.tsx
@@ -3,23 +3,59 @@ import React from "react";
 import * as KotOR from "@/apps/game/KotOR";
 import { AppProvider } from "@/apps/game/context/AppContext";
 import { GameApp } from "@/apps/game/app";
+import { HotReloadManager } from "@/dev/HotReloadManager";
 import "@/apps/game/app.scss";
 
-window.addEventListener('beforeunload', (e) => {
-  try{
+declare const module: {
+  hot?: {
+    accept: (dependencies?: string | string[], callback?: () => void) => void;
+    dispose: (callback: () => void) => void;
+  };
+};
+
+let reactRoot: ReactDOM.Root | null = null;
+
+window.addEventListener('beforeunload', () => {
+  try {
     KotOR.GameState.Debugger.close();
-  }catch(e){
+  } catch (e) {
     console.error(e);
   }
 });
 
+function mountApp(): void {
+  const rootElement = document.getElementById("root") as HTMLElement | null;
+  if (!rootElement) {
+    return;
+  }
+
+  if (!reactRoot) {
+    reactRoot = ReactDOM.createRoot(rootElement);
+  }
+
+  reactRoot.render(
+    <AppProvider>
+      <GameApp />
+    </AppProvider>
+  );
+}
+
+function bootstrap(): void {
+  mountApp();
+}
+
 window.addEventListener('DOMContentLoaded', () => {
-  ( async () => {
-    const root = ReactDOM.createRoot(document.getElementById("root") as HTMLElement);
-    root.render(
-      <AppProvider>
-        <GameApp />
-      </AppProvider>
-    );
-  })();
+  bootstrap();
 });
+
+if (typeof module !== 'undefined' && module.hot) {
+  module.hot.dispose(() => {
+    HotReloadManager.preserveSession();
+  });
+
+  module.hot.accept(() => {
+    console.log('[HMR] Game client module updated — preserving session');
+    HotReloadManager.onHotAccept();
+    mountApp();
+  });
+}

--- a/src/apps/game/index.tsx
+++ b/src/apps/game/index.tsx
@@ -58,8 +58,21 @@ function mountApp(): void {
   );
 }
 
+/** Game UI modules whose updates remount React while GameState stays live. */
+const UI_HMR_BOUNDARIES = [
+  '@/apps/game/app',
+  '@/apps/game/context/AppContext',
+] as const;
+
+function onUiHotApplied(): void {
+  console.log('[HMR] Game UI module updated — remounting while preserving session');
+  HotReloadManager.onHotAccept();
+  installHmrTestBridge();
+  mountApp();
+}
+
 function onProbeHotApplied(): void {
-  console.log('[HMR] Game client module updated — preserving session');
+  console.log('[HMR] Game client probe updated — preserving session');
   HotReloadManager.onHotAccept();
   window.__KOTOR_HMR_PROBE_VALUE__ = require('@/dev/HmrTestProbe').HMR_PROBE as number;
   installHmrTestBridge();
@@ -90,7 +103,16 @@ if (typeof module !== 'undefined' && module.hot) {
     });
   }
 
+  module.hot.accept([...UI_HMR_BOUNDARIES], () => {
+    onUiHotApplied();
+  });
+
   module.hot.accept(['@/dev/HmrTestProbe'], () => {
     onProbeHotApplied();
+  });
+
+  // Entry boundary: index.tsx / app.scss edits remount without full page reload.
+  module.hot.accept(() => {
+    onUiHotApplied();
   });
 }

--- a/src/apps/game/index.tsx
+++ b/src/apps/game/index.tsx
@@ -3,6 +3,11 @@ import React from "react";
 import * as KotOR from "@/apps/game/KotOR";
 import { HotReloadManager } from "@/dev/HotReloadManager";
 import { installHmrTestBridge } from "@/dev/HmrTestBridge";
+import {
+  captureDevResumeSnapshot,
+  installDevSessionResume,
+  tryResumeDevSession,
+} from "@/dev/DevSessionResume";
 import { HMR_PROBE } from "@/dev/HmrTestProbe";
 import {
   clearDevBrowserDirectoryHandle,
@@ -95,6 +100,11 @@ function bootstrap(): void {
   window.__KOTOR_HMR_PROBE_VALUE__ = HMR_PROBE;
   installHmrTestBridge();
   mountApp();
+  if (process.env.NODE_ENV !== 'production') {
+    installDevSessionResume();
+    // F5 / fallback-reload resume: jump back into the saved module instead of main menu.
+    void tryResumeDevSession();
+  }
 }
 
 window.addEventListener('DOMContentLoaded', () => {
@@ -122,11 +132,17 @@ if (typeof module !== 'undefined' && module.hot) {
     window.__KOTOR_HMR_STATUS_HANDLER__ = true;
     module.hot.addStatusHandler((status) => {
       if (status === 'abort' || status === 'fail') {
-        if (KotOR.GameState.hmrIsSessionActive()) {
-          console.warn('[HMR] Hot update failed — keeping live in-game session (no reload)');
+        if ((window as any).__KOTOR_HMR_RELOAD_PENDING__) {
           return;
         }
-        console.warn('[HMR] Hot update failed — performing full reload');
+        const inSession = KotOR.GameState.hmrIsSessionActive();
+        const saved = captureDevResumeSnapshot();
+        if (!inSession && !saved) {
+          console.warn('[HMR] Update not hot-applicable — no live session to resume, skipping reload');
+          return;
+        }
+        (window as any).__KOTOR_HMR_RELOAD_PENDING__ = true;
+        console.warn(`[HMR] Update not hot-applicable — full reload${saved ? ' with session resume' : ''}`);
         window.location.reload();
       }
     });
@@ -138,10 +154,5 @@ if (typeof module !== 'undefined' && module.hot) {
 
   module.hot.accept(['@/dev/HmrTestProbe'], () => {
     onProbeHotApplied();
-  });
-
-  // Entry boundary: index.tsx / app.scss edits remount without full page reload.
-  module.hot.accept(() => {
-    onUiHotApplied();
   });
 }

--- a/src/apps/game/index.tsx
+++ b/src/apps/game/index.tsx
@@ -4,6 +4,11 @@ import * as KotOR from "@/apps/game/KotOR";
 import { HotReloadManager } from "@/dev/HotReloadManager";
 import { installHmrTestBridge } from "@/dev/HmrTestBridge";
 import { HMR_PROBE } from "@/dev/HmrTestProbe";
+import {
+  clearDevBrowserDirectoryHandle,
+  isDevGameFileBackendActive,
+  probeDevGameFileBackend,
+} from "@/dev/DevGameFileBackend";
 import "@/apps/game/app.scss";
 
 declare const module: {
@@ -95,8 +100,15 @@ function bootstrap(): void {
 window.addEventListener('DOMContentLoaded', () => {
   void (async () => {
     // Activate dev FS before React bootstrap so GameFileSystem never hits FS Access first.
-    const { probeDevGameFileBackend } = await import('@/dev/DevGameFileBackend');
     await probeDevGameFileBackend();
+    if (isDevGameFileBackendActive()) {
+      clearDevBrowserDirectoryHandle();
+      KotOR.GameFileSystem.clearDirectoryHandleCache();
+    } else if (process.env.NODE_ENV !== 'production') {
+      // Wrong port or missing KOTOR_DEV_GAME_DIR — drop stale IndexedDB handles that cause NotFoundError storms.
+      clearDevBrowserDirectoryHandle();
+      KotOR.GameFileSystem.clearDirectoryHandleCache();
+    }
     bootstrap();
   })();
 });

--- a/src/apps/game/states/AppState.ts
+++ b/src/apps/game/states/AppState.ts
@@ -3,7 +3,7 @@ import { Launcher } from "@/apps/launcher/context/Launcher";
 import { ApplicationEnvironment } from "@/enums/ApplicationEnvironment";
 import { GameInitializer } from "@/apps/game/GameInitializer";
 import { ILoaderProgress } from '@/apps/common/loader/LoaderProgress';
-import { isDevGameFileBackendActive } from '@/dev/DevGameFileBackend';
+import { isDevGameFileBackendActive, probeDevGameFileBackend } from '@/dev/DevGameFileBackend';
 
 export class AppState {
   static eulaAccepted: boolean = false;
@@ -48,6 +48,20 @@ export class AppState {
     AppState.appProfile = await AppState.getProfile();
     KotOR.ApplicationProfile.SetProfile(AppState.appProfile);
     KotOR.ApplicationProfile.InitEnvironment();
+
+    if (AppState.env === ApplicationEnvironment.BROWSER) {
+      await probeDevGameFileBackend();
+      if (
+        process.env.NODE_ENV !== 'production'
+        && !isDevGameFileBackendActive()
+      ) {
+        console.warn(
+          '[KotOR dev] Game asset middleware inactive. For Linux/real installs use:\n'
+          + '  KOTOR_DEV_GAME_DIR="/path/to/swkotor" KOTOR_DEV_PORT=8130 npm run webpack:serve-hmr\n'
+          + 'Then open http://127.0.0.1:8130/game/?key=kotor (avoid stale e2e ports like 8099).',
+        );
+      }
+    }
 
     document.title = `${AppState.appProfile?.full_name ? AppState.appProfile?.full_name : 'N/A' }`;
     

--- a/src/apps/game/states/AppState.ts
+++ b/src/apps/game/states/AppState.ts
@@ -8,6 +8,7 @@ import { isDevGameFileBackendActive } from '@/dev/DevGameFileBackend';
 export class AppState {
   static eulaAccepted: boolean = false;
   static directoryLocated: boolean = false;
+  static initStarted: boolean = false;
   static gameKey: KotOR.GameEngineType = KotOR.GameEngineType.KOTOR;
   static appProfile: any;
   static env: ApplicationEnvironment;
@@ -33,6 +34,11 @@ export class AppState {
    * initApp
    */
   static async initApp(){
+    if (AppState.initStarted) {
+      return;
+    }
+    AppState.initStarted = true;
+
     if(window.location.origin === 'file://'){
       AppState.env = ApplicationEnvironment.ELECTRON;
     }else{

--- a/src/apps/game/states/AppState.ts
+++ b/src/apps/game/states/AppState.ts
@@ -2,6 +2,7 @@ import * as KotOR from "@/apps/game/KotOR";
 import { Launcher } from "@/apps/launcher/context/Launcher";
 import { ApplicationEnvironment } from "@/enums/ApplicationEnvironment";
 import { GameInitializer } from "@/apps/game/GameInitializer";
+import { ILoaderProgress } from '@/apps/common/loader/LoaderProgress';
 
 export class AppState {
   static eulaAccepted: boolean = false;
@@ -161,6 +162,12 @@ export class AppState {
    */
   static loaderMessage(message: string): void {
     AppState.processEventListener('on-loader-message', [message]);
+    AppState.processEventListener('on-loader-progress', [null]);
+  }
+
+  static loaderProgress(progress: ILoaderProgress): void {
+    AppState.processEventListener('on-loader-message', [progress.message]);
+    AppState.processEventListener('on-loader-progress', [progress]);
   }
 
   /**
@@ -180,6 +187,13 @@ export class AppState {
     KotOR.TextureLoader.GameKey = KotOR.GameState.GameKey;
     GameInitializer.AddEventListener('on-loader-message', (message: string) => {
       AppState.loaderMessage(message);
+    });
+    GameInitializer.AddEventListener('on-loader-progress', (progress: ILoaderProgress | null) => {
+      if (progress) {
+        AppState.loaderProgress(progress);
+      } else {
+        AppState.processEventListener('on-loader-progress', [null]);
+      }
     });
     GameInitializer.AddEventListener('on-loader-show', () => {
       AppState.loaderShow();

--- a/src/apps/game/states/AppState.ts
+++ b/src/apps/game/states/AppState.ts
@@ -3,6 +3,7 @@ import { Launcher } from "@/apps/launcher/context/Launcher";
 import { ApplicationEnvironment } from "@/enums/ApplicationEnvironment";
 import { GameInitializer } from "@/apps/game/GameInitializer";
 import { ILoaderProgress } from '@/apps/common/loader/LoaderProgress';
+import { isDevGameFileBackendActive } from '@/dev/DevGameFileBackend';
 
 export class AppState {
   static eulaAccepted: boolean = false;
@@ -62,6 +63,11 @@ export class AppState {
     }, eulaState[AppState.gameKey]);
     eulaState[AppState.gameKey] = gameEULAConfig;
     AppState.eulaAccepted = !!gameEULAConfig.accepted;
+    if (isDevGameFileBackendActive()) {
+      AppState.eulaAccepted = true;
+      gameEULAConfig.accepted = true;
+      eulaState[AppState.gameKey] = gameEULAConfig;
+    }
     window.localStorage.setItem('acceptEULA', JSON.stringify(eulaState));
 
     AppState.loaderShow();
@@ -101,6 +107,18 @@ export class AppState {
       }
       alert('Unable to locate chitin.key in the selected directory. Please try again.');
     }else{
+      if (isDevGameFileBackendActive()) {
+        if (await KotOR.GameFileSystem.exists('chitin.key')) {
+          AppState.directoryLocated = true;
+          AppState.processEventListener('on-preload', []);
+          AppState.beginGame();
+          return;
+        }
+        alert('Unable to locate chitin.key via KOTOR_DEV_GAME_DIR. Check webpack serve env.');
+        AppState.directoryLocated = false;
+        AppState.processEventListener('on-preload', []);
+        return;
+      }
       if(KotOR.ApplicationProfile.directoryHandle){
         const validated = await AppState.validateDirectoryHandle(KotOR.ApplicationProfile.directoryHandle);
         if(validated && await KotOR.GameFileSystem.exists('chitin.key')){
@@ -121,6 +139,9 @@ export class AppState {
    * - Used for Electron and Browser
    */
   static async checkGameDirectory(){
+    if (isDevGameFileBackendActive()) {
+      return KotOR.GameFileSystem.exists('chitin.key');
+    }
     if(AppState.env == ApplicationEnvironment.ELECTRON){
       if(await KotOR.GameFileSystem.exists('chitin.key')){
         return true;

--- a/src/apps/game/states/AppState.ts
+++ b/src/apps/game/states/AppState.ts
@@ -3,7 +3,7 @@ import { Launcher } from "@/apps/launcher/context/Launcher";
 import { ApplicationEnvironment } from "@/enums/ApplicationEnvironment";
 import { GameInitializer } from "@/apps/game/GameInitializer";
 import { ILoaderProgress } from '@/apps/common/loader/LoaderProgress';
-import { isDevGameFileBackendActive, probeDevGameFileBackend } from '@/dev/DevGameFileBackend';
+import { isDevGameFileBackendActive, probeDevGameFileBackend, clearDevBrowserDirectoryHandle } from '@/dev/DevGameFileBackend';
 
 export class AppState {
   static eulaAccepted: boolean = false;
@@ -51,6 +51,15 @@ export class AppState {
 
     if (AppState.env === ApplicationEnvironment.BROWSER) {
       await probeDevGameFileBackend();
+      if (isDevGameFileBackendActive()) {
+        clearDevBrowserDirectoryHandle();
+        KotOR.GameFileSystem.clearDirectoryHandleCache();
+      } else if (
+        process.env.NODE_ENV !== 'production'
+      ) {
+        clearDevBrowserDirectoryHandle();
+        KotOR.GameFileSystem.clearDirectoryHandleCache();
+      }
       if (
         process.env.NODE_ENV !== 'production'
         && !isDevGameFileBackendActive()

--- a/src/audio/AudioEmitter.ts
+++ b/src/audio/AudioEmitter.ts
@@ -275,6 +275,7 @@ export class AudioEmitter {
 
   async playStreamWave(resRef =''): Promise<AudioBufferSourceNode> {
     this.disposeCurrentSound();
+    resRef = (resRef || '').trim().toLowerCase();
 
     //attempt to load from the buffer cache
     if(this.buffers.has(resRef)){

--- a/src/audio/AudioLoader.test.ts
+++ b/src/audio/AudioLoader.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+jest.mock('@/loaders/ResourceLoader', () => ({
+  ResourceLoader: {
+    getResource: jest.fn(),
+  },
+}));
+
+jest.mock('@/utility/GameFileSystem', () => ({
+  GameFileSystem: {
+    readFile: jest.fn(),
+  },
+}));
+
+jest.mock('@/audio/AudioFile', () => ({
+  AudioFile: jest.fn().mockImplementation(() => ({
+    getPlayableByteStream: jest.fn(async () => Uint8Array.from([1, 2, 3])),
+  })),
+}));
+
+import { ResourceLoader } from '@/loaders/ResourceLoader';
+import { GameFileSystem } from '@/utility/GameFileSystem';
+import { AudioLoader } from '@/audio/AudioLoader';
+import { ResourceTypes } from '@/resource/ResourceTypes';
+
+describe('AudioLoader.LoadStreamWave', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('reads from the registered resource path when present', async () => {
+    (ResourceLoader.getResource as jest.Mock).mockReturnValue({ file: 'streamwaves/trask01.wav' });
+    (GameFileSystem.readFile as jest.Mock).mockResolvedValue(Uint8Array.from([0x10]));
+
+    const data = await AudioLoader.LoadStreamWave('TrAsK01');
+
+    expect(ResourceLoader.getResource).toHaveBeenCalledWith(ResourceTypes.wav, 'trask01');
+    expect(GameFileSystem.readFile).toHaveBeenCalledWith('streamwaves/trask01.wav');
+    expect(data).toEqual(Uint8Array.from([1, 2, 3]));
+  });
+
+  it('falls back to stream path lookup when registry entry is missing', async () => {
+    (ResourceLoader.getResource as jest.Mock).mockReturnValue(null);
+    (GameFileSystem.readFile as jest.Mock).mockResolvedValue(Uint8Array.from([0x20]));
+
+    const data = await AudioLoader.LoadStreamWave('TrAsK01');
+
+    expect(GameFileSystem.readFile).toHaveBeenCalled();
+    expect(data).toEqual(Uint8Array.from([1, 2, 3]));
+  });
+});

--- a/src/audio/AudioLoader.ts
+++ b/src/audio/AudioLoader.ts
@@ -107,7 +107,8 @@ export class AudioLoader {
   }
 
   static async LoadStreamWave (resRef: string) {
-    const snd = ResourceLoader.getResource(ResourceTypes['wav'], resRef);
+    const normalizedRef = (resRef || '').trim().toLowerCase();
+    const snd = ResourceLoader.getResource(ResourceTypes['wav'], normalizedRef);
     if(!!snd){
       try{
         const buffer = await GameFileSystem.readFile(snd.file);
@@ -119,9 +120,14 @@ export class AudioLoader {
         console.error(e);
         throw e;
       }
-    }else{
-      throw new Error(`LoadSteamWave: failed to locate playable resource`);
     }
+
+    const fromDisk = await AudioLoader.loadWavFromGamePaths(normalizedRef);
+    if (fromDisk) {
+      return fromDisk;
+    }
+
+    throw new Error(`LoadStreamWave: failed to locate playable resource "${normalizedRef}"`);
   }
 
   static async LoadMusic (resRef?: string){

--- a/src/controls/IngameControls.ts
+++ b/src/controls/IngameControls.ts
@@ -401,7 +401,7 @@ export class IngameControls {
     KeyMapper.BindGamepad(this.gamePad);
 
     //W
-    KeyMapper.Actions[KeyMapAction.ActionUp].setProcessor( (keymap) => {
+    KeyMapper.setActionProcessor(KeyMapAction.ActionUp,  (keymap) => {
       if(GameState.State == EngineState.PAUSED) return;
       if(!keymap.keyboardInput?.down) return;
       if(this.gamePadMovement) return;
@@ -418,7 +418,7 @@ export class IngameControls {
     });
 
     //S
-    KeyMapper.Actions[KeyMapAction.ActionDown].setProcessor( (keymap) => {
+    KeyMapper.setActionProcessor(KeyMapAction.ActionDown,  (keymap) => {
       if(GameState.State == EngineState.PAUSED) return;
       if(!keymap.keyboardInput?.down) return;
       if(this.gamePadMovement) return;
@@ -435,7 +435,7 @@ export class IngameControls {
     });
 
     //Z
-    KeyMapper.Actions[KeyMapAction.ActionLeft].setProcessor( (keymap) => {
+    KeyMapper.setActionProcessor(KeyMapAction.ActionLeft,  (keymap) => {
       if(GameState.State == EngineState.PAUSED) return;
       if(!keymap.keyboardInput?.down) return;
       const followee = GameState.PartyManager.party[0];
@@ -444,7 +444,7 @@ export class IngameControls {
     });
 
     //C
-    KeyMapper.Actions[KeyMapAction.ActionRight].setProcessor( (keymap) => {
+    KeyMapper.setActionProcessor(KeyMapAction.ActionRight,  (keymap) => {
       if(GameState.State == EngineState.PAUSED) return;
       if(!keymap.keyboardInput?.down) return;
       const followee = GameState.PartyManager.party[0];
@@ -453,7 +453,7 @@ export class IngameControls {
     });
 
     //A
-    KeyMapper.Actions[KeyMapAction.CameraRotateLeft].setProcessor( (keymap) => {
+    KeyMapper.setActionProcessor(KeyMapAction.CameraRotateLeft,  (keymap) => {
       // if(GameState.State == EngineState.PAUSED) return;
       if(GameState.Mode != EngineMode.INGAME) return;
       if(
@@ -473,7 +473,7 @@ export class IngameControls {
     });
 
     //D
-    KeyMapper.Actions[KeyMapAction.CameraRotateRight].setProcessor( (keymap) => {
+    KeyMapper.setActionProcessor(KeyMapAction.CameraRotateRight,  (keymap) => {
       // if(GameState.State == EngineState.PAUSED) return;
       if(GameState.Mode != EngineMode.INGAME) return;
       if(
@@ -493,17 +493,17 @@ export class IngameControls {
     });
 
     //ChangeLeader
-    KeyMapper.Actions[KeyMapAction.ChangeChar].setProcessor( (keymap) => {
+    KeyMapper.setActionProcessor(KeyMapAction.ChangeChar,  (keymap) => {
       if(!keymap.keyboardInput?.pressed && !keymap.gamepadInput?.pressed) return;
       GameState.PartyManager.ShiftLeader();
     });
 
-    KeyMapper.Actions[KeyMapAction.Freelook].setProcessor( (keymap) => {
+    KeyMapper.setActionProcessor(KeyMapAction.Freelook,  (keymap) => {
       if(!keymap.keyboardInput?.pressed && !keymap.gamepadInput?.pressed) return;
       GameState.SetEngineMode(GameState.Mode == EngineMode.FREELOOK ? EngineMode.INGAME : EngineMode.FREELOOK);
     });
 
-    KeyMapper.Actions[KeyMapAction.WALKMODIFY].setProcessor( (keymap) => {
+    KeyMapper.setActionProcessor(KeyMapAction.WALKMODIFY,  (keymap) => {
       if(!keymap.keyboardInput?.pressed && !keymap.gamepadInput?.pressed) return;
       const pc = GameState.getCurrentPlayer();
       if(pc){
@@ -512,61 +512,61 @@ export class IngameControls {
     });
 
     //Dialog1
-    KeyMapper.Actions[KeyMapAction.Dialog1].setProcessor( (keymap) => {
+    KeyMapper.setActionProcessor(KeyMapAction.Dialog1,  (keymap) => {
       if(!keymap.keyboardInput?.pressed && !keymap.gamepadInput?.pressed) return;
       GameState.CutsceneManager.selectReplyAtIndex(0);
     });
 
     //Dialog2
-    KeyMapper.Actions[KeyMapAction.Dialog2].setProcessor( (keymap) => {
+    KeyMapper.setActionProcessor(KeyMapAction.Dialog2,  (keymap) => {
       if(!keymap.keyboardInput?.pressed && !keymap.gamepadInput?.pressed) return;
       GameState.CutsceneManager.selectReplyAtIndex(1);
     });
 
     //Dialog3
-    KeyMapper.Actions[KeyMapAction.Dialog3].setProcessor( (keymap) => {
+    KeyMapper.setActionProcessor(KeyMapAction.Dialog3,  (keymap) => {
       if(!keymap.keyboardInput?.pressed && !keymap.gamepadInput?.pressed) return;
       GameState.CutsceneManager.selectReplyAtIndex(2);
     });
 
     //Dialog4
-    KeyMapper.Actions[KeyMapAction.Dialog4].setProcessor( (keymap) => {
+    KeyMapper.setActionProcessor(KeyMapAction.Dialog4,  (keymap) => {
       if(!keymap.keyboardInput?.pressed && !keymap.gamepadInput?.pressed) return;
       GameState.CutsceneManager.selectReplyAtIndex(3);
     });
 
     //Dialog5
-    KeyMapper.Actions[KeyMapAction.Dialog5].setProcessor( (keymap) => {
+    KeyMapper.setActionProcessor(KeyMapAction.Dialog5,  (keymap) => {
       if(!keymap.keyboardInput?.pressed && !keymap.gamepadInput?.pressed) return;
       GameState.CutsceneManager.selectReplyAtIndex(4);
     });
 
     //Dialog6
-    KeyMapper.Actions[KeyMapAction.Dialog6].setProcessor( (keymap) => {
+    KeyMapper.setActionProcessor(KeyMapAction.Dialog6,  (keymap) => {
       if(!keymap.keyboardInput?.pressed && !keymap.gamepadInput?.pressed) return;
       GameState.CutsceneManager.selectReplyAtIndex(5);
     });
 
     //Dialog7
-    KeyMapper.Actions[KeyMapAction.Dialog7].setProcessor( (keymap) => {
+    KeyMapper.setActionProcessor(KeyMapAction.Dialog7,  (keymap) => {
       if(!keymap.keyboardInput?.pressed && !keymap.gamepadInput?.pressed) return;
       GameState.CutsceneManager.selectReplyAtIndex(6);
     });
 
     //Dialog8
-    KeyMapper.Actions[KeyMapAction.Dialog8].setProcessor( (keymap) => {
+    KeyMapper.setActionProcessor(KeyMapAction.Dialog8,  (keymap) => {
       if(!keymap.keyboardInput?.pressed && !keymap.gamepadInput?.pressed) return;
       GameState.CutsceneManager.selectReplyAtIndex(7);
     });
 
     //Dialog9
-    KeyMapper.Actions[KeyMapAction.Dialog9].setProcessor( (keymap) => {
+    KeyMapper.setActionProcessor(KeyMapAction.Dialog9,  (keymap) => {
       if(!keymap.keyboardInput?.pressed && !keymap.gamepadInput?.pressed) return;
       GameState.CutsceneManager.selectReplyAtIndex(8);
     });
 
     //DialogSkip
-    KeyMapper.Actions[KeyMapAction.DialogSkip].setProcessor( (keymap) => {
+    KeyMapper.setActionProcessor(KeyMapAction.DialogSkip,  (keymap) => {
       if(!keymap.keyboardInput?.pressed && !keymap.gamepadInput?.pressed && !Mouse.leftClick) return;
 
       if(GameState.CutsceneManager.active && GameState.CutsceneManager.isListening){
@@ -579,7 +579,7 @@ export class IngameControls {
     });
 
     //DialogAbort
-    KeyMapper.Actions[KeyMapAction.DialogAbort].setProcessor( (keymap) => {
+    KeyMapper.setActionProcessor(KeyMapAction.DialogAbort,  (keymap) => {
       if(!keymap.keyboardInput?.pressed && !keymap.gamepadInput?.pressed) return;
 
       if(GameState.CutsceneManager.active){
@@ -587,7 +587,7 @@ export class IngameControls {
       }
     })
 
-    KeyMapper.Actions[KeyMapAction.SelectNext].setProcessor( (keymap) => {
+    KeyMapper.setActionProcessor(KeyMapAction.SelectNext,  (keymap) => {
       if(!keymap.keyboardInput?.pressed && !keymap.gamepadInput?.pressed) return;
       const nextObject = GameState.ModuleObjectManager.GetNextPlayerVisibleObject();
       if(nextObject){
@@ -596,7 +596,7 @@ export class IngameControls {
       }
     });
 
-    KeyMapper.Actions[KeyMapAction.SelectPrev].setProcessor( (keymap) => {
+    KeyMapper.setActionProcessor(KeyMapAction.SelectPrev,  (keymap) => {
       if(!keymap.keyboardInput?.pressed && !keymap.gamepadInput?.pressed) return;
       const previousObject = GameState.ModuleObjectManager.GetPreviousPlayerVisibleObject();
       if(previousObject){
@@ -605,7 +605,7 @@ export class IngameControls {
       }
     });
 
-    KeyMapper.Actions[KeyMapAction.MGActionUp].setProcessor( (keymap, delta = 0) => {
+    KeyMapper.setActionProcessor(KeyMapAction.MGActionUp,  (keymap, delta = 0) => {
       if(!keymap.keyboardInput?.down && !keymap.gamepadInput?.pressed) return;
       if(GameState.State != EngineState.RUNNING) return;
       switch(GameState.module.area.miniGame.type){
@@ -618,7 +618,7 @@ export class IngameControls {
       }
     });
 
-    KeyMapper.Actions[KeyMapAction.MGActionDown].setProcessor( (keymap, delta = 0) => {
+    KeyMapper.setActionProcessor(KeyMapAction.MGActionDown,  (keymap, delta = 0) => {
       if(!keymap.keyboardInput?.down && !keymap.gamepadInput?.pressed) return;
       if(GameState.State != EngineState.RUNNING) return;
       switch(GameState.module.area.miniGame.type){
@@ -631,7 +631,7 @@ export class IngameControls {
       }
     });
 
-    KeyMapper.Actions[KeyMapAction.MGActionLeft].setProcessor( (keymap, delta = 0) => {
+    KeyMapper.setActionProcessor(KeyMapAction.MGActionLeft,  (keymap, delta = 0) => {
       if(!keymap.keyboardInput?.down && !keymap.gamepadInput?.pressed) return;
       if(GameState.State != EngineState.RUNNING) return;
       switch(GameState.module.area.miniGame.type){
@@ -644,7 +644,7 @@ export class IngameControls {
       }
     });
 
-    KeyMapper.Actions[KeyMapAction.MGActionRight].setProcessor( (keymap, delta = 0) => {
+    KeyMapper.setActionProcessor(KeyMapAction.MGActionRight,  (keymap, delta = 0) => {
       if(!keymap.keyboardInput?.down && !keymap.gamepadInput?.pressed) return;
       if(GameState.State != EngineState.RUNNING) return;
       switch(GameState.module.area.miniGame.type){
@@ -657,12 +657,12 @@ export class IngameControls {
       }
     });
 
-    KeyMapper.Actions[KeyMapAction.PauseMinigame].setProcessor( (keymap) => {
+    KeyMapper.setActionProcessor(KeyMapAction.PauseMinigame,  (keymap) => {
       if(!keymap.keyboardInput?.pressed && !keymap.gamepadInput?.pressed) return;
       GameState.State = ( GameState.State == EngineState.PAUSED ? EngineState.RUNNING : EngineState.PAUSED );
     });
 
-    KeyMapper.Actions[KeyMapAction.MGshoot].setProcessor( (keymap) => {
+    KeyMapper.setActionProcessor(KeyMapAction.MGshoot,  (keymap) => {
       if(!keymap.keyboardInput?.pressed && !keymap.gamepadInput?.pressed) return;
       if(GameState.State != EngineState.RUNNING) return;
       switch(GameState.module.area.miniGame.type){
@@ -675,7 +675,7 @@ export class IngameControls {
       }
     });
 
-    KeyMapper.Actions[KeyMapAction.GUI].setProcessor( (keymap) => {
+    KeyMapper.setActionProcessor(KeyMapAction.GUI,  (keymap) => {
       if(!keymap.keyboardInput?.pressed && !keymap.gamepadInput?.pressed) return;
       const currentMenu = GameState.MenuManager.GetCurrentMenu();
       switch(GameState.Mode){
@@ -690,7 +690,7 @@ export class IngameControls {
       }
     });
 
-    KeyMapper.Actions[KeyMapAction.Pause1].setProcessor( (keymap) => {
+    KeyMapper.setActionProcessor(KeyMapAction.Pause1,  (keymap) => {
       if(!keymap.keyboardInput?.pressed && !keymap.gamepadInput?.pressed) return;
 
       const currentMenu = GameState.MenuManager.GetCurrentMenu();
@@ -705,98 +705,98 @@ export class IngameControls {
       }
     });
 
-    KeyMapper.Actions[KeyMapAction.Flourish].setProcessor( (keymap) => {
+    KeyMapper.setActionProcessor(KeyMapAction.Flourish,  (keymap) => {
       if(!keymap.keyboardInput?.pressed && !keymap.gamepadInput?.pressed) return;
       GameState.getCurrentPlayer().flourish();
     });
 
-    KeyMapper.Actions[KeyMapAction.FlyUp].setProcessor( (keymap, delta = 0) => {
+    KeyMapper.setActionProcessor(KeyMapAction.FlyUp,  (keymap, delta = 0) => {
       if(!keymap.keyboardInput?.down && !keymap.gamepadInput?.pressed) return;
       const followee = GameState.PartyManager.party[0];
       if(!followee) return;
       followee.position.z += 5 * delta;
     });
 
-    KeyMapper.Actions[KeyMapAction.FlyDown].setProcessor( (keymap, delta = 0) => {
+    KeyMapper.setActionProcessor(KeyMapAction.FlyDown,  (keymap, delta = 0) => {
       if(!keymap.keyboardInput?.down && !keymap.gamepadInput?.pressed) return;
       const followee = GameState.PartyManager.party[0];
       if(!followee) return;
       followee.position.z -= 5 * delta;
     });
 
-    KeyMapper.Actions[KeyMapAction.ResolutionScaleUp].setProcessor( (keymap, delta = 0) => {
+    KeyMapper.setActionProcessor(KeyMapAction.ResolutionScaleUp,  (keymap, delta = 0) => {
       if(!keymap.keyboardInput?.down && !keymap.gamepadInput?.pressed) return;
        GameState.rendererUpscaleFactor += 0.25;
       if(GameState.rendererUpscaleFactor >= 4) GameState.rendererUpscaleFactor = 4;
       GameState.updateRendererUpscaleFactor();
     });
 
-    KeyMapper.Actions[KeyMapAction.ResolutionScaleDown].setProcessor( (keymap, delta = 0) => {
+    KeyMapper.setActionProcessor(KeyMapAction.ResolutionScaleDown,  (keymap, delta = 0) => {
       if(!keymap.keyboardInput?.down && !keymap.gamepadInput?.pressed) return;
       GameState.rendererUpscaleFactor -= 0.25;
       if(GameState.rendererUpscaleFactor <= 0.25) GameState.rendererUpscaleFactor = 0.25;
       GameState.updateRendererUpscaleFactor();
     });
 
-    KeyMapper.Actions[KeyMapAction.ResolutionScaleReset].setProcessor( (keymap, delta = 0) => {
+    KeyMapper.setActionProcessor(KeyMapAction.ResolutionScaleReset,  (keymap, delta = 0) => {
       if(!keymap.keyboardInput?.down && !keymap.gamepadInput?.pressed) return;
       GameState.rendererUpscaleFactor = 1.0;
       GameState.updateRendererUpscaleFactor();
     });
 
-    KeyMapper.Actions[KeyMapAction.Equip].setProcessor( (keymap) => {
+    KeyMapper.setActionProcessor(KeyMapAction.Equip,  (keymap) => {
       if(!keymap.keyboardInput?.pressed && !keymap.gamepadInput?.pressed) return;
       if(GameState.Mode != EngineMode.INGAME) return;
       GameState.MenuManager.MenuEquipment.open();
     });
 
-    KeyMapper.Actions[KeyMapAction.Inventory].setProcessor( (keymap) => {
+    KeyMapper.setActionProcessor(KeyMapAction.Inventory,  (keymap) => {
       if(!keymap.keyboardInput?.pressed && !keymap.gamepadInput?.pressed) return;
       if(GameState.Mode != EngineMode.INGAME) return;
       GameState.MenuManager.MenuInventory.open();
     });
     
-    KeyMapper.Actions[KeyMapAction.Character].setProcessor( (keymap) => {
+    KeyMapper.setActionProcessor(KeyMapAction.Character,  (keymap) => {
       if(!keymap.keyboardInput?.pressed && !keymap.gamepadInput?.pressed) return;
       if(GameState.Mode != EngineMode.INGAME) return;
       GameState.MenuManager.MenuCharacter.open();
     });
     
-    KeyMapper.Actions[KeyMapAction.SkillsAndFeats].setProcessor( (keymap) => {
+    KeyMapper.setActionProcessor(KeyMapAction.SkillsAndFeats,  (keymap) => {
       if(!keymap.keyboardInput?.pressed && !keymap.gamepadInput?.pressed) return;
       if(GameState.Mode != EngineMode.INGAME) return;
       GameState.MenuManager.MenuAbilities.open();
     });
     
     
-    KeyMapper.Actions[KeyMapAction.Messages].setProcessor( (keymap) => {
+    KeyMapper.setActionProcessor(KeyMapAction.Messages,  (keymap) => {
       if(!keymap.keyboardInput?.pressed && !keymap.gamepadInput?.pressed) return;
       if(GameState.Mode != EngineMode.INGAME) return;
       GameState.MenuManager.MenuMessages.open();
     });
     
     
-    KeyMapper.Actions[KeyMapAction.Quests].setProcessor( (keymap) => {
+    KeyMapper.setActionProcessor(KeyMapAction.Quests,  (keymap) => {
       if(!keymap.keyboardInput?.pressed && !keymap.gamepadInput?.pressed) return;
       if(GameState.Mode != EngineMode.INGAME) return;
       GameState.MenuManager.MenuJournal.open();
     });
     
     
-    KeyMapper.Actions[KeyMapAction.Map].setProcessor( (keymap) => {
+    KeyMapper.setActionProcessor(KeyMapAction.Map,  (keymap) => {
       if(!keymap.keyboardInput?.pressed && !keymap.gamepadInput?.pressed) return;
       if(GameState.Mode != EngineMode.INGAME) return;
       GameState.MenuManager.MenuMap.open();
     });
     
-    KeyMapper.Actions[KeyMapAction.Options].setProcessor( (keymap) => {
+    KeyMapper.setActionProcessor(KeyMapAction.Options,  (keymap) => {
       if(!keymap.keyboardInput?.pressed && !keymap.gamepadInput?.pressed) return;
       if(GameState.Mode != EngineMode.INGAME) return;
       GameState.MenuManager.MenuOptions.open();
     });
 
       // Handle movie skipping
-    KeyMapper.Actions[KeyMapAction.MovieSkip].setProcessor( (keymap) => {
+    KeyMapper.setActionProcessor(KeyMapAction.MovieSkip,  (keymap) => {
       if(!keymap.keyboardInput?.pressed && !keymap.gamepadInput?.pressed) return;
 
       if(GameState.VideoManager.isMoviePlaying()){

--- a/src/controls/KeyMapper.ts
+++ b/src/controls/KeyMapper.ts
@@ -532,43 +532,46 @@ export class KeyMapper {
   }
 
   static BindGamepad(gamepad: GamePad){
+    const setGamepad = (action: KeyMapAction, input: KeyInput | AnalogInput) => {
+      const entry = KeyMapper.Actions[action];
+      if (entry) {
+        entry.gamepadInput = input;
+      }
+    };
 
     //Movement
-    this.Actions[KeyMapAction.ActionUp].gamepadInput = gamepad.stick_l_y;
-    this.Actions[KeyMapAction.ActionDown].gamepadInput = gamepad.stick_l_y;
-    this.Actions[KeyMapAction.CameraRotateLeft].gamepadInput = gamepad.stick_l_x;
-    this.Actions[KeyMapAction.CameraRotateRight].gamepadInput = gamepad.stick_l_x;
-    this.Actions[KeyMapAction.Freelook].gamepadInput = gamepad.stick_l;
-    this.Actions[KeyMapAction.SelectPrev].gamepadInput = gamepad.trigger_l;
-    this.Actions[KeyMapAction.SelectNext].gamepadInput = gamepad.trigger_r;
+    setGamepad(KeyMapAction.ActionUp, gamepad.stick_l_y);
+    setGamepad(KeyMapAction.ActionDown, gamepad.stick_l_y);
+    setGamepad(KeyMapAction.CameraRotateLeft, gamepad.stick_l_x);
+    setGamepad(KeyMapAction.CameraRotateRight, gamepad.stick_l_x);
+    setGamepad(KeyMapAction.Freelook, gamepad.stick_l);
+    setGamepad(KeyMapAction.SelectPrev, gamepad.trigger_l);
+    setGamepad(KeyMapAction.SelectNext, gamepad.trigger_r);
 
     //Game
-    this.Actions[KeyMapAction.Options].gamepadInput = gamepad.button_start;
-    this.Actions[KeyMapAction.Pause].gamepadInput = gamepad.button_bumper_l;
-    this.Actions[KeyMapAction.ChangeChar].gamepadInput = gamepad.button_bumper_r;
-    this.Actions[KeyMapAction.STEALTH].gamepadInput = gamepad.button_back;
-    this.Actions[KeyMapAction.Flourish].gamepadInput = gamepad.button_y;
-    this.Actions[KeyMapAction.ClearOneAction].gamepadInput = gamepad.button_y;
-    this.Actions[KeyMapAction.ActionUp].gamepadInput = gamepad.button_d_up;
-    this.Actions[KeyMapAction.ActionDown].gamepadInput = gamepad.button_d_down;
-    this.Actions[KeyMapAction.ActionLeft].gamepadInput = gamepad.button_d_left;
-    this.Actions[KeyMapAction.ActionRight].gamepadInput = gamepad.button_d_right;
-    this.Actions[KeyMapAction.CancleCombat].gamepadInput = gamepad.button_b;
-    this.Actions[KeyMapAction.AlternateActions].gamepadInput = gamepad.button_x;
+    setGamepad(KeyMapAction.Options, gamepad.button_start);
+    setGamepad(KeyMapAction.Pause, gamepad.button_bumper_l);
+    setGamepad(KeyMapAction.ChangeChar, gamepad.button_bumper_r);
+    setGamepad(KeyMapAction.STEALTH, gamepad.button_back);
+    setGamepad(KeyMapAction.Flourish, gamepad.button_y);
+    setGamepad(KeyMapAction.ClearOneAction, gamepad.button_y);
+    setGamepad(KeyMapAction.ActionUp, gamepad.button_d_up);
+    setGamepad(KeyMapAction.ActionDown, gamepad.button_d_down);
+    setGamepad(KeyMapAction.ActionLeft, gamepad.button_d_left);
+    setGamepad(KeyMapAction.ActionRight, gamepad.button_d_right);
+    setGamepad(KeyMapAction.CancleCombat, gamepad.button_b);
+    setGamepad(KeyMapAction.AlternateActions, gamepad.button_x);
     
     //GUI
-    this.Actions[KeyMapAction.PrevMenu].gamepadInput = gamepad.button_bumper_l;
-    this.Actions[KeyMapAction.NextMenu].gamepadInput = gamepad.button_bumper_r;
-    this.Actions[KeyMapAction.MoveForward].gamepadInput = gamepad.button_d_up;
-    this.Actions[KeyMapAction.MoveBack].gamepadInput = gamepad.button_d_down;
-    this.Actions[KeyMapAction.StrafeLeft].gamepadInput = gamepad.button_d_left;
-    this.Actions[KeyMapAction.StrafeRight].gamepadInput = gamepad.button_d_right;
-    this.Actions[KeyMapAction.PrevMenu].gamepadInput = gamepad.button_bumper_l;
-    this.Actions[KeyMapAction.PrevMenu].gamepadInput = gamepad.button_bumper_l;
-    this.Actions[KeyMapAction.PrevMenu].gamepadInput = gamepad.button_bumper_l;
+    setGamepad(KeyMapAction.PrevMenu, gamepad.button_bumper_l);
+    setGamepad(KeyMapAction.NextMenu, gamepad.button_bumper_r);
+    setGamepad(KeyMapAction.MoveForward, gamepad.button_d_up);
+    setGamepad(KeyMapAction.MoveBack, gamepad.button_d_down);
+    setGamepad(KeyMapAction.StrafeLeft, gamepad.button_d_left);
+    setGamepad(KeyMapAction.StrafeRight, gamepad.button_d_right);
 
     //Movie
-    this.Actions[KeyMapAction.MovieSkip].gamepadInput = gamepad.button_y;
+    setGamepad(KeyMapAction.MovieSkip, gamepad.button_y);
     
   }
 

--- a/src/controls/KeyMapper.ts
+++ b/src/controls/KeyMapper.ts
@@ -531,6 +531,13 @@ export class KeyMapper {
 
   }
 
+  static setActionProcessor(action: KeyMapAction, callback: KeymapProcessorCallback) {
+    const entry = KeyMapper.Actions[action];
+    if (entry) {
+      entry.setProcessor(callback);
+    }
+  }
+
   static BindGamepad(gamepad: GamePad){
     const setGamepad = (action: KeyMapAction, input: KeyInput | AnalogInput) => {
       const entry = KeyMapper.Actions[action];

--- a/src/dev/DevGameFileBackend.test.ts
+++ b/src/dev/DevGameFileBackend.test.ts
@@ -6,6 +6,9 @@ import {
   devGameRead,
   devGameReadFile,
   devGameVirtualWrite,
+  isDevGameFileBackendActive,
+  probeDevGameFileBackend,
+  resetDevGameFileBackendProbeForTests,
 } from '@/dev/DevGameFileBackend';
 
 const originalFetch = (globalThis as { fetch?: typeof fetch }).fetch;
@@ -29,6 +32,52 @@ describe('DevGameFileBackend', () => {
 
   afterEach(() => {
     setFetch(originalFetch);
+    resetDevGameFileBackendProbeForTests();
+  });
+
+  it('activates dev backend via runtime probe when middleware serves chitin.key', async () => {
+    const prevEnv = process.env.NODE_ENV;
+    const prevDir = process.env.KOTOR_DEV_GAME_DIR;
+    process.env.NODE_ENV = 'development';
+    process.env.KOTOR_DEV_GAME_DIR = '';
+
+    const fetchMock = jest.fn(async (url: string) => {
+      if (String(url).includes('chitin.key')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ exists: true, isFile: true }),
+        };
+      }
+      return { ok: false, status: 404, json: async () => ({ exists: false }) };
+    });
+    setFetch(fetchMock);
+
+    expect(isDevGameFileBackendActive()).toBe(false);
+    await expect(probeDevGameFileBackend()).resolves.toBe(true);
+    expect(isDevGameFileBackendActive()).toBe(true);
+
+    process.env.NODE_ENV = prevEnv;
+    process.env.KOTOR_DEV_GAME_DIR = prevDir;
+  });
+
+  it('leaves dev backend inactive when probe finds no chitin.key', async () => {
+    const prevEnv = process.env.NODE_ENV;
+    const prevDir = process.env.KOTOR_DEV_GAME_DIR;
+    process.env.NODE_ENV = 'development';
+    process.env.KOTOR_DEV_GAME_DIR = '';
+
+    setFetch(jest.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ exists: false }),
+    })));
+
+    await expect(probeDevGameFileBackend()).resolves.toBe(false);
+    expect(isDevGameFileBackendActive()).toBe(false);
+
+    process.env.NODE_ENV = prevEnv;
+    process.env.KOTOR_DEV_GAME_DIR = prevDir;
   });
 
   it('serves virtual-written files from memory without any fetch', async () => {

--- a/src/dev/DevGameFileBackend.test.ts
+++ b/src/dev/DevGameFileBackend.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 
 import {
+  clearDevBrowserDirectoryHandle,
   DevGameFileHandle,
   devGameExists,
   devGameRead,
@@ -10,6 +11,7 @@ import {
   probeDevGameFileBackend,
   resetDevGameFileBackendProbeForTests,
 } from '@/dev/DevGameFileBackend';
+import { ApplicationProfile } from '@/utility/ApplicationProfile';
 
 const originalFetch = (globalThis as { fetch?: typeof fetch }).fetch;
 
@@ -92,8 +94,18 @@ describe('DevGameFileBackend', () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it('reads a small file whole and serves repeat reads from cache', async () => {
-    const fetchMock = jest.fn(async () => okBytes([1, 2, 3]));
+  it('reads a small file via stat + ranged read and caches repeat reads', async () => {
+    const fetchMock = jest.fn(async (url: string) => {
+      const u = String(url);
+      if (u.includes('action=stat')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ exists: true, isFile: true, size: 3 }),
+        };
+      }
+      return okBytes([1, 2, 3]);
+    });
     setFetch(fetchMock);
 
     const first = await devGameReadFile('data/small-once.gff');
@@ -102,8 +114,33 @@ describe('DevGameFileBackend', () => {
     const second = await devGameReadFile('data/small-once.gff');
     expect(Array.from(second)).toEqual([1, 2, 3]);
 
-    // Second read is served from fileByteCache — no second network request.
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    // stat + one ranged read; second read is served from fileByteCache.
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('reads large files via multiple ranged chunks (no whole-file fetch)', async () => {
+    const chunkSize = 4 * 1024 * 1024;
+    const totalSize = chunkSize + 100;
+    const fetchMock = jest.fn(async (url: string) => {
+      const u = String(url);
+      if (u.includes('action=stat')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ exists: true, isFile: true, size: totalSize }),
+        };
+      }
+      const offset = Number(new URL(u, 'http://localhost').searchParams.get('offset'));
+      const length = Number(new URL(u, 'http://localhost').searchParams.get('length'));
+      return okBytes(Array.from({ length }, (_, i) => (offset + i) & 0xff));
+    });
+    setFetch(fetchMock);
+
+    const bytes = await devGameReadFile('data/large.bif');
+    expect(bytes.length).toBe(totalSize);
+    expect(bytes[0]).toBe(0);
+    expect(bytes[chunkSize]).toBe(0);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
   });
 
   it('issues a ranged fetch and writes bytes at the destination offset', async () => {
@@ -140,15 +177,32 @@ describe('DevGameFileBackend', () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it('rejects a whole-file read with a descriptive error when the server refuses (413)', async () => {
-    const fetchMock = jest.fn(async () => ({
-      ok: false,
-      status: 413,
-      text: async () => 'File too large for whole-file read: 999999999 bytes exceeds 67108864. Use a ranged read (offset/length).',
+  it('rejects read when stat reports file missing', async () => {
+    setFetch(jest.fn(async (url: string) => {
+      if (String(url).includes('action=stat')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ exists: false, isFile: false }),
+        };
+      }
+      return {
+        ok: false,
+        status: 404,
+        text: async () => 'Not found',
+      };
     }));
-    setFetch(fetchMock);
 
-    await expect(devGameReadFile('data/huge-413.bif')).rejects.toThrow(/413/);
-    await expect(devGameReadFile('data/huge-413.bif')).rejects.toThrow(/too large/i);
+    await expect(devGameReadFile('data/missing.gff')).rejects.toThrow(/404/);
+  });
+
+  it('clearDevBrowserDirectoryHandle drops persisted FS Access handle', () => {
+    ApplicationProfile.directoryHandle = { name: 'swkotor' } as FileSystemDirectoryHandle;
+    ApplicationProfile.profile = { directory_handle: ApplicationProfile.directoryHandle };
+
+    clearDevBrowserDirectoryHandle();
+
+    expect(ApplicationProfile.directoryHandle).toBeUndefined();
+    expect(ApplicationProfile.profile.directory_handle).toBeUndefined();
   });
 });

--- a/src/dev/DevGameFileBackend.test.ts
+++ b/src/dev/DevGameFileBackend.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+import {
+  DevGameFileHandle,
+  devGameExists,
+  devGameRead,
+  devGameReadFile,
+  devGameVirtualWrite,
+} from '@/dev/DevGameFileBackend';
+
+const originalFetch = (globalThis as { fetch?: typeof fetch }).fetch;
+
+function setFetch(mock: unknown): void {
+  (globalThis as unknown as { fetch: unknown }).fetch = mock;
+}
+
+function okBytes(bytes: number[]) {
+  return {
+    ok: true,
+    status: 200,
+    arrayBuffer: async () => new Uint8Array(bytes).buffer,
+  };
+}
+
+describe('DevGameFileBackend', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    setFetch(originalFetch);
+  });
+
+  it('serves virtual-written files from memory without any fetch', async () => {
+    const fetchMock = jest.fn();
+    setFetch(fetchMock);
+
+    devGameVirtualWrite('saves/game1/save.sav', new Uint8Array([5, 5]));
+
+    expect(await devGameExists('saves/game1/save.sav')).toBe(true);
+    const back = await devGameReadFile('saves/game1/save.sav');
+    expect(Array.from(back)).toEqual([5, 5]);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('reads a small file whole and serves repeat reads from cache', async () => {
+    const fetchMock = jest.fn(async () => okBytes([1, 2, 3]));
+    setFetch(fetchMock);
+
+    const first = await devGameReadFile('data/small-once.gff');
+    expect(Array.from(first)).toEqual([1, 2, 3]);
+
+    const second = await devGameReadFile('data/small-once.gff');
+    expect(Array.from(second)).toEqual([1, 2, 3]);
+
+    // Second read is served from fileByteCache — no second network request.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('issues a ranged fetch and writes bytes at the destination offset', async () => {
+    const fetchMock = jest.fn(async () => okBytes([9, 8, 7, 6]));
+    setFetch(fetchMock);
+
+    const handle = new DevGameFileHandle('data/range-only.bif', 'r');
+    const out = new Uint8Array(6);
+    await devGameRead(handle, out, 1, 4, 100);
+
+    expect(Array.from(out)).toEqual([0, 9, 8, 7, 6, 0]);
+
+    const requestedUrl = String((fetchMock.mock.calls[0] as unknown[])[0]);
+    expect(requestedUrl).toContain('action=read');
+    expect(requestedUrl).toContain('offset=100');
+    expect(requestedUrl).toContain('length=4');
+  });
+
+  it('slices two non-overlapping ranges of a cached/virtual file correctly', async () => {
+    const fetchMock = jest.fn();
+    setFetch(fetchMock);
+
+    devGameVirtualWrite('saves/g/data.bin', new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7]));
+    const handle = new DevGameFileHandle('saves/g/data.bin', 'r');
+
+    const head = new Uint8Array(3);
+    await devGameRead(handle, head, 0, 3, 0);
+    expect(Array.from(head)).toEqual([0, 1, 2]);
+
+    const tail = new Uint8Array(3);
+    await devGameRead(handle, tail, 0, 3, 5);
+    expect(Array.from(tail)).toEqual([5, 6, 7]);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects a whole-file read with a descriptive error when the server refuses (413)', async () => {
+    const fetchMock = jest.fn(async () => ({
+      ok: false,
+      status: 413,
+      text: async () => 'File too large for whole-file read: 999999999 bytes exceeds 67108864. Use a ranged read (offset/length).',
+    }));
+    setFetch(fetchMock);
+
+    await expect(devGameReadFile('data/huge-413.bif')).rejects.toThrow(/413/);
+    await expect(devGameReadFile('data/huge-413.bif')).rejects.toThrow(/too large/i);
+  });
+});

--- a/src/dev/DevGameFileBackend.ts
+++ b/src/dev/DevGameFileBackend.ts
@@ -5,12 +5,55 @@
 
 const DEV_FS_BASE = '/__kotor_dev_fs';
 
-export function isDevGameFileBackendActive(): boolean {
-  return (
+/** True when a runtime probe found webpack dev-game-fs middleware (chitin.key). */
+let runtimeDevBackendActive = false;
+let runtimeProbeFinished = false;
+
+/**
+ * Detect dev-game-fs middleware at runtime so HMR works even when the bundle was
+ * built without KOTOR_DEV_GAME_DIR (stale tab, wrong port, or DefinePlugin drift).
+ */
+export async function probeDevGameFileBackend(): Promise<boolean> {
+  if (runtimeProbeFinished) {
+    return isDevGameFileBackendActive();
+  }
+  runtimeProbeFinished = true;
+
+  if (
     process.env.NODE_ENV !== 'production'
     && typeof process.env.KOTOR_DEV_GAME_DIR === 'string'
     && process.env.KOTOR_DEV_GAME_DIR.length > 0
-  );
+  ) {
+    runtimeDevBackendActive = true;
+    return true;
+  }
+
+  try {
+    const response = await fetch(`${DEV_FS_BASE}?action=stat&path=chitin.key`);
+    if (response.ok) {
+      const data = await response.json() as DevStatPayload;
+      runtimeDevBackendActive = !!data.exists;
+    }
+  } catch {
+    runtimeDevBackendActive = false;
+  }
+  return runtimeDevBackendActive;
+}
+
+/** Reset probe state (tests only). */
+export function resetDevGameFileBackendProbeForTests(): void {
+  runtimeDevBackendActive = false;
+  runtimeProbeFinished = false;
+}
+
+export function isDevGameFileBackendActive(): boolean {
+  if (process.env.NODE_ENV === 'production') {
+    return false;
+  }
+  const compileTime =
+    typeof process.env.KOTOR_DEV_GAME_DIR === 'string'
+    && process.env.KOTOR_DEV_GAME_DIR.length > 0;
+  return compileTime || runtimeDevBackendActive;
 }
 
 function normalizePath(filePath: string): string {
@@ -46,6 +89,41 @@ type DevStatPayload = {
 const statCache = new Map<string, DevStatPayload>();
 const statInflight = new Map<string, Promise<DevStatPayload>>();
 
+/** Limit parallel HTTP calls to dev middleware — unconstrained bursts exhaust browser sockets. */
+const DEV_FS_MAX_INFLIGHT = 16;
+let devFsActive = 0;
+const devFsWaitQueue: Array<() => void> = [];
+
+async function acquireDevFsSlot(): Promise<void> {
+  if (devFsActive < DEV_FS_MAX_INFLIGHT) {
+    devFsActive += 1;
+    return;
+  }
+  await new Promise<void>((resolve) => {
+    devFsWaitQueue.push(() => {
+      devFsActive += 1;
+      resolve();
+    });
+  });
+}
+
+function releaseDevFsSlot(): void {
+  devFsActive -= 1;
+  const next = devFsWaitQueue.shift();
+  if (next) {
+    next();
+  }
+}
+
+async function devFetch(input: string, init?: RequestInit): Promise<Response> {
+  await acquireDevFsSlot();
+  try {
+    return await fetch(input, init);
+  } finally {
+    releaseDevFsSlot();
+  }
+}
+
 async function fetchStat(filePath: string): Promise<DevStatPayload> {
   const normalized = normalizePath(filePath);
   const cached = statCache.get(normalized);
@@ -58,7 +136,7 @@ async function fetchStat(filePath: string): Promise<DevStatPayload> {
   }
 
   const promise = (async () => {
-    const response = await fetch(apiUrl('stat', normalized));
+    const response = await devFetch(apiUrl('stat', normalized));
     if (!response.ok) {
       return { exists: false, isDirectory: false, isFile: false };
     }
@@ -69,7 +147,10 @@ async function fetchStat(filePath: string): Promise<DevStatPayload> {
       isFile: !!data.isFile,
       size: data.size,
     };
-    statCache.set(normalized, payload);
+    // Cache positive hits only — transient misses (server starting, wrong cwd) should retry.
+    if (payload.exists) {
+      statCache.set(normalized, payload);
+    }
     return payload;
   })();
 
@@ -248,7 +329,7 @@ async function loadFileBytes(filePath: string): Promise<Uint8Array> {
   if (fileByteCache.has(normalized)) {
     return fileByteCache.get(normalized)!;
   }
-  const response = await fetch(apiUrl('read', normalized));
+  const response = await devFetch(apiUrl('read', normalized));
   if (!response.ok) {
     let detail = '';
     try {
@@ -297,7 +378,7 @@ export async function devGameRead(
     output.set(bytes.subarray(position, position + length), offset);
     return;
   }
-  const response = await fetch(apiUrl('read', handle.path, { offset: position, length }));
+  const response = await devFetch(apiUrl('read', handle.path, { offset: position, length }));
   if (!response.ok) {
     throw new Error(`DevGameFileBackend read failed: ${handle.path} @ ${position}+${length}`);
   }
@@ -349,7 +430,7 @@ async function devGameReaddirWalk(
   files: string[],
   depth: number,
 ): Promise<void> {
-  const response = await fetch(apiUrl('readdir', resourcePath));
+  const response = await devFetch(apiUrl('readdir', resourcePath));
   if (!response.ok) {
     if (!options.list_dirs && depth === 0 && virtualDirExists(resourcePath)) {
       return;

--- a/src/dev/DevGameFileBackend.ts
+++ b/src/dev/DevGameFileBackend.ts
@@ -218,7 +218,9 @@ export async function devGameOpen(filePath: string, mode: 'r' | 'w' = 'r'): Prom
     ensureVirtualParentDirs(normalized);
     return new DevGameFileHandle(normalized, 'w');
   }
-  await loadFileBytes(normalized);
+  if (!(await devGameExists(normalized))) {
+    throw new Error(`DevGameFileBackend open failed: ${normalized}`);
+  }
   return new DevGameFileHandle(normalized, 'r');
 }
 

--- a/src/dev/DevGameFileBackend.ts
+++ b/src/dev/DevGameFileBackend.ts
@@ -3,7 +3,14 @@
  * KOTOR_DEV_GAME_DIR is set (browser cannot use native paths directly).
  */
 
+import { ApplicationProfile } from '@/utility/ApplicationProfile';
+
 const DEV_FS_BASE = '/__kotor_dev_fs';
+
+/** Do not cache whole-file reads larger than this in browser memory. */
+const MAX_FILE_BYTE_CACHE = 8 * 1024 * 1024;
+/** Ranged read chunk size — matches middleware expectations for large archives. */
+const RANGED_READ_CHUNK = 4 * 1024 * 1024;
 
 /** True when a runtime probe found webpack dev-game-fs middleware (chitin.key). */
 let runtimeDevBackendActive = false;
@@ -54,6 +61,17 @@ export function isDevGameFileBackendActive(): boolean {
     typeof process.env.KOTOR_DEV_GAME_DIR === 'string'
     && process.env.KOTOR_DEV_GAME_DIR.length > 0;
   return compileTime || runtimeDevBackendActive;
+}
+
+/**
+ * Remove persisted File System Access handles so dev HTTP FS is the sole asset path.
+ * Stale IndexedDB handles cause NotFoundError storms when middleware is active or port/env is wrong.
+ */
+export function clearDevBrowserDirectoryHandle(): void {
+  ApplicationProfile.directoryHandle = undefined as any;
+  if (ApplicationProfile.profile && typeof ApplicationProfile.profile === 'object') {
+    ApplicationProfile.profile.directory_handle = undefined;
+  }
 }
 
 function normalizePath(filePath: string): string {
@@ -321,15 +339,8 @@ export async function devGameExists(filePath: string): Promise<boolean> {
   return hasExt ? !!data.isFile : !!data.isDirectory;
 }
 
-async function loadFileBytes(filePath: string): Promise<Uint8Array> {
-  const normalized = normalizePath(filePath);
-  if (virtualFiles.has(normalized)) {
-    return virtualFiles.get(normalized)!;
-  }
-  if (fileByteCache.has(normalized)) {
-    return fileByteCache.get(normalized)!;
-  }
-  const response = await devFetch(apiUrl('read', normalized));
+async function readRangedBytes(normalized: string, offset: number, length: number): Promise<Uint8Array> {
+  const response = await devFetch(apiUrl('read', normalized, { offset, length }));
   if (!response.ok) {
     let detail = '';
     try {
@@ -338,11 +349,50 @@ async function loadFileBytes(filePath: string): Promise<Uint8Array> {
       detail = '';
     }
     const suffix = detail ? ` (HTTP ${response.status}: ${detail})` : ` (HTTP ${response.status})`;
-    throw new Error(`DevGameFileBackend read failed: ${normalized}${suffix}`);
+    throw new Error(`DevGameFileBackend read failed: ${normalized} @ ${offset}+${length}${suffix}`);
   }
-  const bytes = new Uint8Array(await response.arrayBuffer());
-  fileByteCache.set(normalized, bytes);
-  return bytes;
+  return new Uint8Array(await response.arrayBuffer());
+}
+
+async function loadFileBytes(filePath: string): Promise<Uint8Array> {
+  const normalized = normalizePath(filePath);
+  if (virtualFiles.has(normalized)) {
+    return virtualFiles.get(normalized)!;
+  }
+  if (fileByteCache.has(normalized)) {
+    return fileByteCache.get(normalized)!;
+  }
+
+  const stat = await fetchStat(normalized);
+  if (!stat.exists || !stat.isFile) {
+    throw new Error(`DevGameFileBackend read failed: ${normalized} (HTTP 404: Not found)`);
+  }
+
+  const size = stat.size ?? 0;
+  if (size === 0) {
+    const empty = new Uint8Array(0);
+    fileByteCache.set(normalized, empty);
+    return empty;
+  }
+
+  if (size <= RANGED_READ_CHUNK) {
+    const bytes = await readRangedBytes(normalized, 0, size);
+    if (size <= MAX_FILE_BYTE_CACHE) {
+      fileByteCache.set(normalized, bytes);
+    }
+    return bytes;
+  }
+
+  const out = new Uint8Array(size);
+  for (let offset = 0; offset < size; offset += RANGED_READ_CHUNK) {
+    const length = Math.min(RANGED_READ_CHUNK, size - offset);
+    const chunk = await readRangedBytes(normalized, offset, length);
+    out.set(chunk, offset);
+  }
+  if (size <= MAX_FILE_BYTE_CACHE) {
+    fileByteCache.set(normalized, out);
+  }
+  return out;
 }
 
 export async function devGameReadFile(filePath: string): Promise<Uint8Array> {

--- a/src/dev/DevGameFileBackend.ts
+++ b/src/dev/DevGameFileBackend.ts
@@ -35,6 +35,52 @@ const virtualDirs = new Set<string>();
 /** Byte cache for read-only disk assets (partial reads via open/read). */
 const fileByteCache = new Map<string, Uint8Array>();
 
+type DevStatPayload = {
+  exists: boolean;
+  isFile?: boolean;
+  isDirectory?: boolean;
+  size?: number;
+};
+
+/** Cached stat results — bootstrap issues thousands of duplicate exists() checks. */
+const statCache = new Map<string, DevStatPayload>();
+const statInflight = new Map<string, Promise<DevStatPayload>>();
+
+async function fetchStat(filePath: string): Promise<DevStatPayload> {
+  const normalized = normalizePath(filePath);
+  const cached = statCache.get(normalized);
+  if (cached) {
+    return cached;
+  }
+  const inflight = statInflight.get(normalized);
+  if (inflight) {
+    return inflight;
+  }
+
+  const promise = (async () => {
+    const response = await fetch(apiUrl('stat', normalized));
+    if (!response.ok) {
+      return { exists: false, isDirectory: false, isFile: false };
+    }
+    const data = await response.json() as DevStatPayload;
+    const payload: DevStatPayload = {
+      exists: !!data.exists,
+      isDirectory: !!data.isDirectory,
+      isFile: !!data.isFile,
+      size: data.size,
+    };
+    statCache.set(normalized, payload);
+    return payload;
+  })();
+
+  statInflight.set(normalized, promise);
+  try {
+    return await promise;
+  } finally {
+    statInflight.delete(normalized);
+  }
+}
+
 export class DevGameFileHandle {
   readonly kind = 'dev-game-file' as const;
   readonly path: string;
@@ -186,11 +232,7 @@ export async function devGameExists(filePath: string): Promise<boolean> {
     return true;
   }
 
-  const response = await fetch(apiUrl('stat', normalized));
-  if (!response.ok) {
-    return false;
-  }
-  const data = await response.json() as { exists?: boolean; isFile?: boolean; isDirectory?: boolean };
+  const data = await fetchStat(normalized);
   if (!data.exists) {
     return false;
   }

--- a/src/dev/DevGameFileBackend.ts
+++ b/src/dev/DevGameFileBackend.ts
@@ -17,8 +17,15 @@ function normalizePath(filePath: string): string {
   return filePath.replace(/\\/g, '/').replace(/^\/+|\/+$/g, '');
 }
 
-function apiUrl(action: string, filePath: string): string {
-  return `${DEV_FS_BASE}?action=${encodeURIComponent(action)}&path=${encodeURIComponent(filePath)}`;
+function apiUrl(action: string, filePath: string, extra: Record<string, string | number> = {}): string {
+  const params = new URLSearchParams({
+    action,
+    path: filePath,
+  });
+  for (const [key, value] of Object.entries(extra)) {
+    params.set(key, String(value));
+  }
+  return `${DEV_FS_BASE}?${params.toString()}`;
 }
 
 /** In-memory virtual write store for gameinprogress (browser has no directory handle). */
@@ -201,7 +208,14 @@ async function loadFileBytes(filePath: string): Promise<Uint8Array> {
   }
   const response = await fetch(apiUrl('read', normalized));
   if (!response.ok) {
-    throw new Error(`DevGameFileBackend read failed: ${normalized}`);
+    let detail = '';
+    try {
+      detail = await response.text();
+    } catch {
+      detail = '';
+    }
+    const suffix = detail ? ` (HTTP ${response.status}: ${detail})` : ` (HTTP ${response.status})`;
+    throw new Error(`DevGameFileBackend read failed: ${normalized}${suffix}`);
   }
   const bytes = new Uint8Array(await response.arrayBuffer());
   fileByteCache.set(normalized, bytes);
@@ -231,9 +245,22 @@ export async function devGameRead(
   length: number,
   position: number,
 ): Promise<void> {
-  const bytes = await loadFileBytes(handle.path);
-  const slice = bytes.subarray(position, position + length);
-  output.set(slice, offset);
+  if (virtualFiles.has(handle.path)) {
+    const bytes = virtualFiles.get(handle.path)!;
+    output.set(bytes.subarray(position, position + length), offset);
+    return;
+  }
+  if (fileByteCache.has(handle.path)) {
+    const bytes = fileByteCache.get(handle.path)!;
+    output.set(bytes.subarray(position, position + length), offset);
+    return;
+  }
+  const response = await fetch(apiUrl('read', handle.path, { offset: position, length }));
+  if (!response.ok) {
+    throw new Error(`DevGameFileBackend read failed: ${handle.path} @ ${position}+${length}`);
+  }
+  const bytes = new Uint8Array(await response.arrayBuffer());
+  output.set(bytes, offset);
 }
 
 export async function devGameClose(_handle: DevGameFileHandle): Promise<void> {

--- a/src/dev/DevGameFileBackend.ts
+++ b/src/dev/DevGameFileBackend.ts
@@ -1,0 +1,317 @@
+/**
+ * Dev HMR helper: read game assets over webpack dev-server middleware when
+ * KOTOR_DEV_GAME_DIR is set (browser cannot use native paths directly).
+ */
+
+const DEV_FS_BASE = '/__kotor_dev_fs';
+
+export function isDevGameFileBackendActive(): boolean {
+  return (
+    process.env.NODE_ENV !== 'production'
+    && typeof process.env.KOTOR_DEV_GAME_DIR === 'string'
+    && process.env.KOTOR_DEV_GAME_DIR.length > 0
+  );
+}
+
+function normalizePath(filePath: string): string {
+  return filePath.replace(/\\/g, '/').replace(/^\/+|\/+$/g, '');
+}
+
+function apiUrl(action: string, filePath: string): string {
+  return `${DEV_FS_BASE}?action=${encodeURIComponent(action)}&path=${encodeURIComponent(filePath)}`;
+}
+
+/** In-memory virtual write store for gameinprogress (browser has no directory handle). */
+const virtualFiles = new Map<string, Uint8Array>();
+const virtualDirs = new Set<string>();
+
+/** Byte cache for read-only disk assets (partial reads via open/read). */
+const fileByteCache = new Map<string, Uint8Array>();
+
+export class DevGameFileHandle {
+  readonly kind = 'dev-game-file' as const;
+  readonly path: string;
+  readonly mode: 'r' | 'w';
+
+  constructor(filePath: string, mode: 'r' | 'w' = 'r') {
+    this.path = normalizePath(filePath);
+    this.mode = mode;
+  }
+}
+
+export function isDevGameFileHandle(handle: unknown): handle is DevGameFileHandle {
+  return handle instanceof DevGameFileHandle
+    || (typeof handle === 'object' && handle !== null && (handle as DevGameFileHandle).kind === 'dev-game-file');
+}
+
+function virtualFileExists(filePath: string): boolean {
+  return virtualFiles.has(normalizePath(filePath));
+}
+
+function virtualDirExists(dirPath: string): boolean {
+  const normalized = normalizePath(dirPath);
+  if (virtualDirs.has(normalized)) {
+    return true;
+  }
+  const prefix = normalized ? `${normalized}/` : '';
+  for (const filePath of virtualFiles.keys()) {
+    if (filePath.startsWith(prefix)) {
+      return true;
+    }
+  }
+  for (const dir of virtualDirs) {
+    if (dir.startsWith(prefix)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function listVirtualDirEntries(dirPath: string): string[] {
+  const normalized = normalizePath(dirPath);
+  const prefix = normalized ? `${normalized}/` : '';
+  const entries = new Set<string>();
+
+  for (const filePath of virtualFiles.keys()) {
+    if (normalized && !filePath.startsWith(prefix)) {
+      continue;
+    }
+    const remainder = normalized ? filePath.slice(prefix.length) : filePath;
+    const slash = remainder.indexOf('/');
+    if (slash >= 0) {
+      entries.add(`${remainder.slice(0, slash)}/`);
+    } else if (remainder) {
+      entries.add(remainder);
+    }
+  }
+
+  for (const dir of virtualDirs) {
+    if (normalized && !dir.startsWith(prefix)) {
+      continue;
+    }
+    const remainder = normalized ? dir.slice(prefix.length) : dir;
+    const slash = remainder.indexOf('/');
+    if (slash >= 0) {
+      entries.add(`${remainder.slice(0, slash)}/`);
+    } else if (remainder) {
+      entries.add(`${remainder}/`);
+    }
+  }
+
+  return [...entries];
+}
+
+function ensureVirtualParentDirs(filePath: string): void {
+  const normalized = normalizePath(filePath);
+  const parts = normalized.split('/');
+  parts.pop();
+  let current = '';
+  for (const part of parts) {
+    current = current ? `${current}/${part}` : part;
+    virtualDirs.add(current);
+  }
+}
+
+export function devGameVirtualWrite(filePath: string, data: Uint8Array): void {
+  const normalized = normalizePath(filePath);
+  ensureVirtualParentDirs(normalized);
+  virtualFiles.set(normalized, data);
+}
+
+export function devGameVirtualMkdir(dirPath: string, recursive = false): boolean {
+  const normalized = normalizePath(dirPath);
+  if (!normalized) {
+    return false;
+  }
+  if (recursive) {
+    const parts = normalized.split('/');
+    let current = '';
+    for (const part of parts) {
+      current = current ? `${current}/${part}` : part;
+      virtualDirs.add(current);
+    }
+  } else {
+    virtualDirs.add(normalized);
+  }
+  return true;
+}
+
+export function devGameVirtualRmdir(dirPath: string, recursive = false): boolean {
+  const normalized = normalizePath(dirPath);
+  if (!normalized) {
+    return false;
+  }
+  const prefix = `${normalized}/`;
+
+  if (recursive) {
+    for (const filePath of [...virtualFiles.keys()]) {
+      if (filePath === normalized || filePath.startsWith(prefix)) {
+        virtualFiles.delete(filePath);
+      }
+    }
+    for (const dir of [...virtualDirs]) {
+      if (dir === normalized || dir.startsWith(prefix)) {
+        virtualDirs.delete(dir);
+      }
+    }
+  } else {
+    for (const filePath of virtualFiles.keys()) {
+      if (filePath.startsWith(prefix)) {
+        return false;
+      }
+    }
+    for (const dir of virtualDirs) {
+      if (dir.startsWith(prefix)) {
+        return false;
+      }
+    }
+    virtualDirs.delete(normalized);
+  }
+  return true;
+}
+
+export async function devGameExists(filePath: string): Promise<boolean> {
+  const normalized = normalizePath(filePath);
+  if (virtualFileExists(normalized)) {
+    return true;
+  }
+  if (virtualDirExists(normalized)) {
+    return true;
+  }
+
+  const response = await fetch(apiUrl('stat', normalized));
+  if (!response.ok) {
+    return false;
+  }
+  const data = await response.json() as { exists?: boolean; isFile?: boolean; isDirectory?: boolean };
+  if (!data.exists) {
+    return false;
+  }
+  const hasExt = /\.[^/]+$/.test(normalized.split('/').pop() || '');
+  return hasExt ? !!data.isFile : !!data.isDirectory;
+}
+
+async function loadFileBytes(filePath: string): Promise<Uint8Array> {
+  const normalized = normalizePath(filePath);
+  if (virtualFiles.has(normalized)) {
+    return virtualFiles.get(normalized)!;
+  }
+  if (fileByteCache.has(normalized)) {
+    return fileByteCache.get(normalized)!;
+  }
+  const response = await fetch(apiUrl('read', normalized));
+  if (!response.ok) {
+    throw new Error(`DevGameFileBackend read failed: ${normalized}`);
+  }
+  const bytes = new Uint8Array(await response.arrayBuffer());
+  fileByteCache.set(normalized, bytes);
+  return bytes;
+}
+
+export async function devGameReadFile(filePath: string): Promise<Uint8Array> {
+  return loadFileBytes(filePath);
+}
+
+export async function devGameOpen(filePath: string, mode: 'r' | 'w' = 'r'): Promise<DevGameFileHandle> {
+  const normalized = normalizePath(filePath);
+  if (mode === 'w') {
+    ensureVirtualParentDirs(normalized);
+    return new DevGameFileHandle(normalized, 'w');
+  }
+  await loadFileBytes(normalized);
+  return new DevGameFileHandle(normalized, 'r');
+}
+
+export async function devGameRead(
+  handle: DevGameFileHandle,
+  output: Uint8Array,
+  offset: number,
+  length: number,
+  position: number,
+): Promise<void> {
+  const bytes = await loadFileBytes(handle.path);
+  const slice = bytes.subarray(position, position + length);
+  output.set(slice, offset);
+}
+
+export async function devGameClose(_handle: DevGameFileHandle): Promise<void> {
+  return;
+}
+
+export interface IDevReaddirOptions {
+  recursive?: boolean;
+  list_dirs?: boolean;
+}
+
+export async function devGameReaddir(
+  dirPath: string,
+  options: IDevReaddirOptions = {},
+): Promise<string[]> {
+  const resourcePath = normalizePath(dirPath);
+  const files: string[] = [];
+  await devGameReaddirWalk(resourcePath, options, files, 0);
+
+  const virtualEntries = listVirtualDirEntries(resourcePath);
+  for (const entry of virtualEntries) {
+    const isDir = entry.endsWith('/');
+    const name = isDir ? entry.slice(0, -1) : entry;
+    const childPath = resourcePath ? `${resourcePath}/${name}` : name;
+    if (isDir) {
+      if (options.recursive) {
+        await devGameReaddirWalk(childPath, options, files, 1);
+      } else {
+        if (!files.includes(childPath)) {
+          files.push(childPath);
+        }
+      }
+    } else if (!options.list_dirs && !files.includes(childPath)) {
+      files.push(childPath);
+    }
+  }
+
+  return files;
+}
+
+async function devGameReaddirWalk(
+  resourcePath: string,
+  options: IDevReaddirOptions,
+  files: string[],
+  depth: number,
+): Promise<void> {
+  const response = await fetch(apiUrl('readdir', resourcePath));
+  if (!response.ok) {
+    if (!options.list_dirs && depth === 0 && virtualDirExists(resourcePath)) {
+      return;
+    }
+    if (!options.list_dirs && depth > 0) {
+      files.push(resourcePath);
+    }
+    return;
+  }
+
+  const data = await response.json() as { entries?: string[] };
+  const entries = data.entries || [];
+
+  if (options.list_dirs && depth > 0) {
+    files.push(resourcePath);
+  }
+
+  if (depth >= 1 && !options.recursive) {
+    return;
+  }
+
+  for (const entry of entries) {
+    const isDir = entry.endsWith('/');
+    const name = isDir ? entry.slice(0, -1) : entry;
+    const childPath = resourcePath ? `${resourcePath}/${name}` : name;
+    if (isDir) {
+      if (options.recursive) {
+        await devGameReaddirWalk(childPath, options, files, depth + 1);
+      } else {
+        files.push(childPath);
+      }
+    } else if (!options.list_dirs) {
+      files.push(childPath);
+    }
+  }
+}

--- a/src/dev/DevSessionResume.test.ts
+++ b/src/dev/DevSessionResume.test.ts
@@ -1,0 +1,277 @@
+/**
+ * Unit tests for the dev session resume snapshot/restore path.
+ *
+ * Jest runs in a node environment, so window/localStorage/performance are
+ * stubbed. The KotOR namespace and bridge helpers are mocked — runtime
+ * behavior is covered by scripts/hmr-session.e2e.cjs (F5 + engine-edit
+ * reload-resume phases).
+ */
+
+const quickPlayMock = jest.fn<Promise<void>, [string]>();
+const skipIntroMoviesMock = jest.fn();
+const getPlayerCreatureMock = jest.fn();
+
+jest.mock('@/apps/game/KotOR', () => ({
+  GameState: {
+    Ready: false,
+    loadingModule: false,
+    Mode: 0,
+    module: undefined as any,
+    TwoDAManager: { datatables: new Map<string, any>() },
+    MenuManager: {} as any,
+  },
+  EngineMode: { GUI: 0, INGAME: 1, DIALOG: 3, MOVIE: 4, FREELOOK: 5 },
+}), { virtual: false });
+
+jest.mock('@/dev/HmrTestBridge', () => ({
+  startQuickPlayToModule: (moduleName: string) => quickPlayMock(moduleName),
+  skipIntroMovies: () => skipIntroMoviesMock(),
+  getPlayerCreature: () => getPlayerCreatureMock(),
+}));
+
+import * as KotOR from '@/apps/game/KotOR';
+import {
+  captureDevResumeSnapshot,
+  clearDevResumeSnapshot,
+  installDevSessionResume,
+  tryResumeDevSession,
+} from '@/dev/DevSessionResume';
+
+const STORAGE_KEY = 'kotor.devResumeSnapshot';
+
+function createLocalStorageStub() {
+  const store = new Map<string, string>();
+  return {
+    getItem: (key: string) => (store.has(key) ? store.get(key)! : null),
+    setItem: (key: string, value: string) => { store.set(key, value); },
+    removeItem: (key: string) => { store.delete(key); },
+    clear: () => store.clear(),
+  };
+}
+
+type MutableGameState = {
+  Ready: boolean;
+  loadingModule: boolean;
+  Mode: number;
+  module: any;
+  TwoDAManager: { datatables: Map<string, any> };
+  MenuManager: any;
+};
+
+const gameState = (KotOR as any).GameState as MutableGameState;
+
+function setInModuleState(): void {
+  gameState.Ready = true;
+  gameState.loadingModule = false;
+  gameState.Mode = (KotOR as any).EngineMode.INGAME;
+  gameState.module = { filename: 'end_m01aa', readyToProcessEvents: true };
+}
+
+function setQuickPlayReadyState(): void {
+  gameState.Ready = true;
+  gameState.TwoDAManager.datatables.set('heads', { RowCount: 107 });
+  gameState.MenuManager = { LoadScreen: {}, MenuToolTip: {} };
+}
+
+function makePlayer() {
+  return {
+    position: {
+      x: 0, y: 0, z: 0,
+      set(x: number, y: number, z: number) { this.x = x; this.y = y; this.z = z; },
+    },
+    container: { position: { set: jest.fn() } },
+    rotation: { z: 1.25 },
+    setFacing: jest.fn(),
+  };
+}
+
+function storedSnapshot(): any {
+  const raw = (window as any).localStorage.getItem(STORAGE_KEY);
+  return raw ? JSON.parse(raw) : null;
+}
+
+function writeSnapshotToStorage(overrides: Record<string, unknown> = {}): void {
+  (window as any).localStorage.setItem(STORAGE_KEY, JSON.stringify({
+    v: 1,
+    ts: Date.now(),
+    module: 'end_m01aa',
+    position: { x: 18.42, y: 22.12, z: -1.27 },
+    facing: 0.44,
+    attempts: 0,
+    ...overrides,
+  }));
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (globalThis as any).window = {
+    localStorage: createLocalStorageStub(),
+    location: { search: '' },
+    addEventListener: jest.fn(),
+    setInterval: jest.fn(() => 1),
+    clearInterval: jest.fn(),
+  };
+  if (!(globalThis as any).performance) {
+    (globalThis as any).performance = { now: () => Date.now() };
+  }
+  gameState.Ready = false;
+  gameState.loadingModule = false;
+  gameState.Mode = 0;
+  gameState.module = undefined;
+  gameState.TwoDAManager.datatables.clear();
+  gameState.MenuManager = {};
+});
+
+afterEach(() => {
+  delete (globalThis as any).window;
+});
+
+describe('captureDevResumeSnapshot', () => {
+  it('does not capture when no in-module session is active', () => {
+    getPlayerCreatureMock.mockReturnValue(makePlayer());
+    expect(captureDevResumeSnapshot()).toBe(false);
+    expect(storedSnapshot()).toBeNull();
+  });
+
+  it('does not capture while a module is still loading', () => {
+    setInModuleState();
+    gameState.loadingModule = true;
+    getPlayerCreatureMock.mockReturnValue(makePlayer());
+    expect(captureDevResumeSnapshot()).toBe(false);
+  });
+
+  it('captures module, position, and facing for a live session', () => {
+    setInModuleState();
+    const player = makePlayer();
+    player.position.x = 18.42;
+    player.position.y = 22.12;
+    player.position.z = -1.27;
+    getPlayerCreatureMock.mockReturnValue(player);
+
+    expect(captureDevResumeSnapshot()).toBe(true);
+
+    const stored = storedSnapshot();
+    expect(stored).toMatchObject({
+      v: 1,
+      module: 'end_m01aa',
+      position: { x: 18.42, y: 22.12, z: -1.27 },
+      facing: 1.25,
+      attempts: 0,
+    });
+  });
+
+  it('does not capture when the player has no position yet', () => {
+    setInModuleState();
+    getPlayerCreatureMock.mockReturnValue(null);
+    expect(captureDevResumeSnapshot()).toBe(false);
+  });
+});
+
+describe('tryResumeDevSession', () => {
+  it('returns false and stays idle without a snapshot', async () => {
+    await expect(tryResumeDevSession()).resolves.toBe(false);
+    expect((window as any).__KOTOR_DEV_RESUME_STATE__).toBe('idle');
+    expect(quickPlayMock).not.toHaveBeenCalled();
+  });
+
+  it('is disabled by ?devresume=0', async () => {
+    writeSnapshotToStorage();
+    (window as any).location.search = '?devresume=0';
+    await expect(tryResumeDevSession()).resolves.toBe(false);
+    expect((window as any).__KOTOR_DEV_RESUME_STATE__).toBe('disabled');
+    expect(quickPlayMock).not.toHaveBeenCalled();
+    // Snapshot is kept so re-enabling resume still works.
+    expect(storedSnapshot()).not.toBeNull();
+  });
+
+  it('clears the snapshot and gives up after too many failed attempts', async () => {
+    writeSnapshotToStorage({ attempts: 3 });
+    await expect(tryResumeDevSession()).resolves.toBe(false);
+    expect((window as any).__KOTOR_DEV_RESUME_STATE__).toBe('failed');
+    expect(storedSnapshot()).toBeNull();
+    expect(quickPlayMock).not.toHaveBeenCalled();
+  });
+
+  it('quick-plays into the saved module, restores the transform, and resets attempts', async () => {
+    writeSnapshotToStorage({ attempts: 1 });
+    setQuickPlayReadyState();
+    const player = makePlayer();
+    getPlayerCreatureMock.mockReturnValue(player);
+    quickPlayMock.mockResolvedValue(undefined);
+
+    await expect(tryResumeDevSession()).resolves.toBe(true);
+
+    expect(quickPlayMock).toHaveBeenCalledWith('end_m01aa');
+    expect(player.position).toMatchObject({ x: 18.42, y: 22.12, z: -1.27 });
+    expect(player.container.position.set).toHaveBeenCalledWith(18.42, 22.12, -1.27);
+    expect(player.setFacing).toHaveBeenCalledWith(0.44, true);
+    expect((window as any).__KOTOR_DEV_RESUME_STATE__).toBe('resumed');
+    expect(storedSnapshot()?.attempts).toBe(0);
+  });
+
+  it('persists the attempt before quick-play so a crash loop self-heals', async () => {
+    writeSnapshotToStorage({ attempts: 0 });
+    setQuickPlayReadyState();
+    getPlayerCreatureMock.mockReturnValue(makePlayer());
+    let storedDuringQuickPlay: any = null;
+    quickPlayMock.mockImplementation(async () => {
+      storedDuringQuickPlay = storedSnapshot();
+      throw new Error('module load exploded');
+    });
+
+    await expect(tryResumeDevSession()).resolves.toBe(false);
+
+    expect(storedDuringQuickPlay?.attempts).toBe(1);
+    expect((window as any).__KOTOR_DEV_RESUME_STATE__).toBe('failed');
+    // Attempt counter stays burned so the breaker can trip eventually.
+    expect(storedSnapshot()?.attempts).toBe(1);
+  });
+
+  it('returns false immediately when resume is already in progress', async () => {
+    writeSnapshotToStorage();
+    (window as any).__KOTOR_DEV_RESUME_STATE__ = 'resuming';
+    await expect(tryResumeDevSession()).resolves.toBe(false);
+    expect(quickPlayMock).not.toHaveBeenCalled();
+  });
+
+  it('ignores snapshots with invalid schema', async () => {
+    (window as any).localStorage.setItem(STORAGE_KEY, JSON.stringify({ v: 2, module: 'x', position: { x: 0, y: 0, z: 0 }, attempts: 0 }));
+    await expect(tryResumeDevSession()).resolves.toBe(false);
+    expect((window as any).__KOTOR_DEV_RESUME_STATE__).toBe('idle');
+
+    (window as any).localStorage.setItem(STORAGE_KEY, JSON.stringify({ v: 1, module: 'x', attempts: 0 }));
+    await expect(tryResumeDevSession()).resolves.toBe(false);
+    expect(quickPlayMock).not.toHaveBeenCalled();
+  });
+
+  it('fails when localStorage cannot persist the attempt counter', async () => {
+    writeSnapshotToStorage({ attempts: 0 });
+    const ls = (window as any).localStorage;
+    const originalSetItem = ls.setItem.bind(ls);
+    ls.setItem = () => { throw new Error('QuotaExceededError'); };
+
+    await expect(tryResumeDevSession()).resolves.toBe(false);
+    expect((window as any).__KOTOR_DEV_RESUME_STATE__).toBe('failed');
+    expect(quickPlayMock).not.toHaveBeenCalled();
+
+    ls.setItem = originalSetItem;
+  });
+});
+
+describe('installDevSessionResume', () => {
+  it('installs beforeunload + interval capture exactly once', () => {
+    installDevSessionResume();
+    installDevSessionResume();
+    expect((window as any).addEventListener).toHaveBeenCalledTimes(1);
+    expect((window as any).setInterval).toHaveBeenCalledTimes(1);
+    expect((window as any).__KOTOR_DEV_RESUME_INSTALLED__).toBe(true);
+  });
+});
+
+describe('clearDevResumeSnapshot', () => {
+  it('removes the stored snapshot', () => {
+    writeSnapshotToStorage();
+    clearDevResumeSnapshot();
+    expect(storedSnapshot()).toBeNull();
+  });
+});

--- a/src/dev/DevSessionResume.ts
+++ b/src/dev/DevSessionResume.ts
@@ -1,0 +1,243 @@
+import * as KotOR from '@/apps/game/KotOR';
+import {
+  getPlayerCreature,
+  skipIntroMovies,
+  startQuickPlayToModule,
+} from '@/dev/HmrTestBridge';
+
+declare global {
+  interface Window {
+    __KOTOR_DEV_RESUME_INSTALLED__?: boolean;
+    __KOTOR_DEV_RESUME_STATE__?: 'idle' | 'resuming' | 'resumed' | 'failed' | 'disabled';
+    __KOTOR_HMR_RELOAD_PENDING__?: boolean;
+  }
+}
+
+const STORAGE_KEY = 'kotor.devResumeSnapshot';
+const SNAPSHOT_VERSION = 1;
+const AUTOSAVE_INTERVAL_MS = 2000;
+const MAX_RESUME_ATTEMPTS = 3;
+const BOOTSTRAP_WAIT_MS = 180000;
+
+interface DevResumeSnapshot {
+  v: number;
+  ts: number;
+  module: string;
+  position: { x: number; y: number; z: number };
+  facing: number;
+  attempts: number;
+}
+
+function isInModuleSession(): boolean {
+  const gs = KotOR.GameState;
+  const mode = gs.Mode;
+  const inModuleMode = mode === KotOR.EngineMode.INGAME
+    || mode === KotOR.EngineMode.DIALOG
+    || mode === KotOR.EngineMode.FREELOOK;
+  return !!gs.Ready
+    && !gs.loadingModule
+    && inModuleMode
+    && !!gs.module?.filename
+    && !!gs.module?.readyToProcessEvents;
+}
+
+function readSnapshot(): DevResumeSnapshot | null {
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as DevResumeSnapshot;
+    if (
+      parsed?.v !== SNAPSHOT_VERSION
+      || !parsed.module
+      || !parsed.position
+      || typeof parsed.attempts !== 'number'
+      || !Number.isFinite(parsed.attempts)
+    ) {
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function writeSnapshot(snapshot: DevResumeSnapshot): boolean {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(snapshot));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function clearDevResumeSnapshot(): void {
+  try {
+    window.localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // ignore
+  }
+}
+
+/**
+ * Synchronously snapshots the live session to localStorage so a full reload
+ * (F5 or webpack HMR fallback) can resume in-module instead of returning to
+ * the main menu. Safe to call from beforeunload.
+ */
+export function captureDevResumeSnapshot(): boolean {
+  if (process.env.NODE_ENV === 'production') return false;
+  if (!isInModuleSession()) return false;
+  const player = getPlayerCreature();
+  if (!player?.position) return false;
+  return writeSnapshot({
+    v: SNAPSHOT_VERSION,
+    ts: Date.now(),
+    module: KotOR.GameState.module.filename,
+    position: {
+      x: player.position.x,
+      y: player.position.y,
+      z: player.position.z,
+    },
+    facing: typeof player.rotation?.z === 'number' ? player.rotation.z : 0,
+    attempts: 0,
+  });
+}
+
+function playerTransformMatches(snapshot: DevResumeSnapshot): boolean {
+  const player = getPlayerCreature();
+  if (!player?.position) return false;
+  const eps = 0.01;
+  return Math.abs(player.position.x - snapshot.position.x) <= eps
+    && Math.abs(player.position.y - snapshot.position.y) <= eps
+    && Math.abs(player.position.z - snapshot.position.z) <= eps;
+}
+
+function isResumeDisabledByUrl(): boolean {
+  try {
+    return new URLSearchParams(window.location.search).get('devresume') === '0';
+  } catch {
+    return false;
+  }
+}
+
+function waitForQuickPlayReady(timeoutMs: number): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const started = performance.now();
+    const tick = () => {
+      const heads = KotOR.GameState.TwoDAManager?.datatables?.get('heads');
+      const tablesReady = !!heads && (heads.RowCount ?? 0) > 0;
+      const menuManager = KotOR.GameState.MenuManager;
+      const menusReady = !!menuManager?.LoadScreen && !!menuManager?.MenuToolTip;
+      const engineReady = !!KotOR.GameState.Ready;
+      if (tablesReady && engineReady && menusReady) {
+        resolve();
+        return;
+      }
+      if (performance.now() - started > timeoutMs) {
+        reject(new Error(`Dev resume: game bootstrap not ready after ${timeoutMs}ms`));
+        return;
+      }
+      setTimeout(tick, 500);
+    };
+    tick();
+  });
+}
+
+function applySnapshotTransform(snapshot: DevResumeSnapshot): void {
+  const player = getPlayerCreature();
+  if (!player?.position) return;
+  player.position.set
+    ? player.position.set(snapshot.position.x, snapshot.position.y, snapshot.position.z)
+    : Object.assign(player.position, snapshot.position);
+  if (player.container?.position) {
+    player.container.position.set(snapshot.position.x, snapshot.position.y, snapshot.position.z);
+  }
+  if (typeof player.setFacing === 'function') {
+    player.setFacing(snapshot.facing, true);
+  }
+}
+
+/**
+ * Boot-time auto-resume: if a dev snapshot exists, quick-play back into the
+ * saved module and restore the player transform. Self-heals from crash loops
+ * via an attempt counter, and can be disabled with `?devresume=0`.
+ */
+export async function tryResumeDevSession(): Promise<boolean> {
+  if (process.env.NODE_ENV === 'production') return false;
+  if (window.__KOTOR_DEV_RESUME_STATE__ === 'resuming') return false;
+
+  if (isResumeDisabledByUrl()) {
+    window.__KOTOR_DEV_RESUME_STATE__ = 'disabled';
+    return false;
+  }
+
+  const snapshot = readSnapshot();
+  if (!snapshot) {
+    window.__KOTOR_DEV_RESUME_STATE__ = 'idle';
+    return false;
+  }
+
+  if (snapshot.attempts >= MAX_RESUME_ATTEMPTS) {
+    console.warn(`[DevResume] Giving up after ${snapshot.attempts} failed attempts — clearing snapshot`);
+    clearDevResumeSnapshot();
+    window.__KOTOR_DEV_RESUME_STATE__ = 'failed';
+    return false;
+  }
+
+  window.__KOTOR_DEV_RESUME_STATE__ = 'resuming';
+
+  // Persist the attempt before doing anything risky so a crash loop self-heals.
+  if (!writeSnapshot({ ...snapshot, attempts: snapshot.attempts + 1 })) {
+    console.error('[DevResume] Cannot persist attempt counter — localStorage unavailable');
+    window.__KOTOR_DEV_RESUME_STATE__ = 'failed';
+    return false;
+  }
+
+  console.log(`[DevResume] Resuming session: ${snapshot.module} @ (${snapshot.position.x.toFixed(2)}, ${snapshot.position.y.toFixed(2)}, ${snapshot.position.z.toFixed(2)})`);
+
+  const moviePump = window.setInterval(() => {
+    try {
+      skipIntroMovies();
+    } catch {
+      // Engine not far enough along yet — keep pumping.
+    }
+  }, 1000);
+
+  try {
+    await waitForQuickPlayReady(BOOTSTRAP_WAIT_MS);
+    await startQuickPlayToModule(snapshot.module);
+    applySnapshotTransform(snapshot);
+    if (!playerTransformMatches(snapshot)) {
+      throw new Error('Dev resume: player transform not applied after quick-play');
+    }
+    if (!writeSnapshot({ ...snapshot, ts: Date.now(), attempts: 0 })) {
+      throw new Error('Dev resume: cannot persist success snapshot');
+    }
+    window.__KOTOR_DEV_RESUME_STATE__ = 'resumed';
+    console.log(`[DevResume] Session resumed into ${snapshot.module}`);
+    return true;
+  } catch (e) {
+    console.error('[DevResume] Resume failed — next boot will retry once, then fall back to main menu', e);
+    window.__KOTOR_DEV_RESUME_STATE__ = 'failed';
+    return false;
+  } finally {
+    window.clearInterval(moviePump);
+  }
+}
+
+/**
+ * Installs the continuous snapshot loop + beforeunload capture. Idempotent
+ * across HMR re-executions via a window guard.
+ */
+export function installDevSessionResume(): void {
+  if (process.env.NODE_ENV === 'production') return;
+  if (window.__KOTOR_DEV_RESUME_INSTALLED__) return;
+  window.__KOTOR_DEV_RESUME_INSTALLED__ = true;
+
+  window.addEventListener('beforeunload', () => {
+    captureDevResumeSnapshot();
+  });
+
+  window.setInterval(() => {
+    captureDevResumeSnapshot();
+  }, AUTOSAVE_INTERVAL_MS);
+}

--- a/src/dev/HmrTestBridge.ts
+++ b/src/dev/HmrTestBridge.ts
@@ -1,0 +1,40 @@
+import * as KotOR from '@/apps/game/KotOR';
+import { HotReloadManager } from '@/dev/HotReloadManager';
+
+declare global {
+  interface Window {
+    __KOTOR_PAGE_LOAD_ID__?: string;
+    __KOTOR_HMR_TEST__?: {
+      getPageLoadId(): string;
+      getAcceptCount(): number;
+      isSessionActive(): boolean;
+      getLoopGeneration(): number;
+      getProbeValue(): number;
+      activateSession(): void;
+    };
+  }
+}
+
+function getProbeValue(): number {
+  if (window.__KOTOR_HMR_PROBE_VALUE__ !== undefined) {
+    return window.__KOTOR_HMR_PROBE_VALUE__;
+  }
+  return require('@/dev/HmrTestProbe').HMR_PROBE as number;
+}
+
+export function installHmrTestBridge(): void {
+  if (process.env.NODE_ENV === 'production') {
+    return;
+  }
+
+  window.__KOTOR_HMR_TEST__ = {
+    getPageLoadId: () => window.__KOTOR_PAGE_LOAD_ID__ || '',
+    getAcceptCount: () => HotReloadManager.getHotAcceptCount(),
+    isSessionActive: () => KotOR.GameState.hmrIsSessionActive(),
+    getLoopGeneration: () => KotOR.GameState.hmrLoopGeneration,
+    getProbeValue: () => getProbeValue(),
+    activateSession: () => {
+      KotOR.GameState.Ready = true;
+    },
+  };
+}

--- a/src/dev/HmrTestBridge.ts
+++ b/src/dev/HmrTestBridge.ts
@@ -28,6 +28,7 @@ declare global {
       };
       nudgePlayer(dx: number, dy: number): void;
       isBootstrapReady(): boolean;
+      isQuickPlayReady(): boolean;
     };
   }
 }
@@ -112,6 +113,9 @@ export function installHmrTestBridge(): void {
         KotOR.GameState.SWRuleSet.Init();
         KotOR.GameState.AppearanceManager.Init();
       }
+      if (!KotOR.GameState.Ready) {
+        KotOR.GameState.Ready = true;
+      }
       KotOR.GameState.GlobalVariableManager.Init();
       const template = KotOR.GameState.PartyManager.GeneratePlayerTemplate();
       KotOR.GameState.PartyManager.PlayerTemplate = template;
@@ -179,5 +183,10 @@ export function installHmrTestBridge(): void {
       }
     },
     isBootstrapReady: () => KotOR.GameState.Ready,
+    isQuickPlayReady: () => {
+      const globalcat = KotOR.GameState.TwoDAManager?.datatables?.get('globalcat');
+      const heads = KotOR.GameState.SWRuleSet?.heads;
+      return !!globalcat?.rows?.length && Array.isArray(heads) && heads.length > 0;
+    },
   };
 }

--- a/src/dev/HmrTestBridge.ts
+++ b/src/dev/HmrTestBridge.ts
@@ -11,6 +11,12 @@ declare global {
       getLoopGeneration(): number;
       getProbeValue(): number;
       activateSession(): void;
+      snapshotSession(): {
+        ready: boolean;
+        module: string | null;
+        area: string | null;
+        player: { x: number; y: number; z: number } | null;
+      };
     };
   }
 }
@@ -35,6 +41,20 @@ export function installHmrTestBridge(): void {
     getProbeValue: () => getProbeValue(),
     activateSession: () => {
       KotOR.GameState.Ready = true;
+    },
+    snapshotSession: () => {
+      const player = KotOR.GameState.PartyManager?.party?.[0]
+        || KotOR.GameState.PartyManager?.Player;
+      return {
+        ready: KotOR.GameState.Ready,
+        module: KotOR.GameState.module?.name ?? null,
+        area: KotOR.GameState.module?.area?.name ?? null,
+        player: player ? {
+          x: player.position.x,
+          y: player.position.y,
+          z: player.position.z,
+        } : null,
+      };
     },
   };
 }

--- a/src/dev/HmrTestBridge.ts
+++ b/src/dev/HmrTestBridge.ts
@@ -97,6 +97,10 @@ function portraitResRefFromTemplate(template: InstanceType<typeof KotOR.GFFObjec
   return portrait?.baseresref || 'po_player';
 }
 
+function twoDAHasRows(table: { RowCount?: number } | undefined): boolean {
+  return !!table && (table.RowCount ?? 0) > 0;
+}
+
 export function installHmrTestBridge(): void {
   if (process.env.NODE_ENV === 'production') {
     return;
@@ -113,7 +117,7 @@ export function installHmrTestBridge(): void {
     },
     startQuickPlayToModule: async (moduleName: string) => {
       const headsTable = KotOR.GameState.TwoDAManager.datatables.get('heads');
-      if (!headsTable?.rows?.length) {
+      if (!twoDAHasRows(headsTable)) {
         throw new Error('Game bootstrap incomplete: 2DA tables not loaded yet');
       }
       if (!KotOR.GameState.SWRuleSet.heads?.length) {
@@ -192,7 +196,7 @@ export function installHmrTestBridge(): void {
     isBootstrapReady: () => KotOR.GameState.Ready,
     isQuickPlayReady: () => {
       const headsTable = KotOR.GameState.TwoDAManager?.datatables?.get('heads');
-      if (!headsTable?.rows?.length) {
+      if (!twoDAHasRows(headsTable)) {
         return false;
       }
       if (!KotOR.GameState.SWRuleSet.heads?.length) {
@@ -208,11 +212,15 @@ export function installHmrTestBridge(): void {
         KotOR.GameState.RestoreEnginePlayMode();
       }
     },
-    getBootstrapStatus: () => ({
-      gameReady: KotOR.GameState.Ready,
-      twoDACount: KotOR.GameState.TwoDAManager?.datatables?.size ?? 0,
-      hasHeadsTable: !!KotOR.GameState.TwoDAManager?.datatables?.get('heads')?.rows?.length,
-      rulesetHeads: KotOR.GameState.SWRuleSet?.heads?.length ?? 0,
-    }),
+    getBootstrapStatus: () => {
+      const headsTable = KotOR.GameState.TwoDAManager?.datatables?.get('heads');
+      return {
+        gameReady: KotOR.GameState.Ready,
+        twoDACount: KotOR.GameState.TwoDAManager?.datatables?.size ?? 0,
+        hasHeadsTable: twoDAHasRows(headsTable),
+        headsRowCount: headsTable?.RowCount ?? 0,
+        rulesetHeads: KotOR.GameState.SWRuleSet?.heads?.length ?? 0,
+      };
+    },
   };
 }

--- a/src/dev/HmrTestBridge.ts
+++ b/src/dev/HmrTestBridge.ts
@@ -1,35 +1,6 @@
 import * as KotOR from '@/apps/game/KotOR';
 import { HotReloadManager } from '@/dev/HotReloadManager';
-import { CharGenManager } from '@/managers/CharGenManager';
 import { CurrentGame } from '@/engine/CurrentGame';
-import { TalentFeat } from '@/talents';
-
-function applyQuickCharacterStats(): void {
-  const creature = CharGenManager.selectedCreature;
-  const classData = KotOR.GameState.SWRuleSet.classes[CharGenManager.selectedClass];
-  if (!creature || !classData) {
-    throw new Error('CharGen quick-start stats unavailable');
-  }
-  const savingThrowLabel = classData.savingthrowtable.toLowerCase();
-  const savingThrowData = KotOR.GameState.TwoDAManager.datatables.get(savingThrowLabel).rows[0];
-  const featsTable = KotOR.GameState.SWRuleSet.feats;
-
-  creature.str = classData.str;
-  creature.dex = classData.dex;
-  creature.con = classData.con;
-  creature.wis = classData.wis;
-  creature.int = classData.int;
-  creature.cha = classData.cha;
-  creature.fortbonus = parseInt(savingThrowData.fortsave, 10);
-  creature.willbonus = parseInt(savingThrowData.willsave, 10);
-  creature.refbonus = parseInt(savingThrowData.refsave, 10);
-  creature.feats = [];
-  for (let i = 0, len = featsTable.length; i < len; i++) {
-    if (featsTable[i].getGranted(classData) === 1) {
-      creature.feats.push(new TalentFeat(i));
-    }
-  }
-}
 
 declare global {
   interface Window {
@@ -59,6 +30,12 @@ function getProbeValue(): number {
   return require('@/dev/HmrTestProbe').HMR_PROBE as number;
 }
 
+function portraitResRefFromTemplate(template: InstanceType<typeof KotOR.GFFObject>): string {
+  const portraitId = template.getFieldByLabel('PortraitId')?.getValue?.() ?? 0;
+  const portrait = KotOR.GameState.SWRuleSet.portraits?.[portraitId];
+  return portrait?.baseresref || 'po_player';
+}
+
 export function installHmrTestBridge(): void {
   if (process.env.NODE_ENV === 'production') {
     return;
@@ -74,28 +51,11 @@ export function installHmrTestBridge(): void {
       KotOR.GameState.Ready = true;
     },
     startQuickPlayToModule: async (moduleName: string) => {
-      CharGenManager.selectedClass = 0;
-      await CharGenManager.Init();
-      applyQuickCharacterStats();
-      const creature = CharGenManager.selectedCreature;
-      if (!creature) {
-        throw new Error('CharGen selectedCreature not initialized');
-      }
-      if (!creature.initialized) {
-        creature.initProperties();
-      }
-      creature.playerCreated = true;
-      if (creature.equipment) {
-        creature.equipment.ARMOR = undefined;
-      }
-      const equipList = creature.template.getFieldByLabel('Equip_ItemList');
-      if (equipList) {
-        equipList.childStructs = [];
-      }
       KotOR.GameState.GlobalVariableManager.Init();
-      KotOR.GameState.PartyManager.PlayerTemplate = creature.save();
-      KotOR.GameState.PartyManager.ActualPlayerTemplate = KotOR.GameState.PartyManager.PlayerTemplate;
-      KotOR.GameState.PartyManager.AddPortraitToOrder(creature.getPortraitResRef());
+      const template = KotOR.GameState.PartyManager.GeneratePlayerTemplate();
+      KotOR.GameState.PartyManager.PlayerTemplate = template;
+      KotOR.GameState.PartyManager.ActualPlayerTemplate = template;
+      KotOR.GameState.PartyManager.AddPortraitToOrder(portraitResRefFromTemplate(template));
       await CurrentGame.InitGameInProgressFolder(true);
       if (KotOR.GameState.MenuManager.LoadScreen) {
         KotOR.GameState.MenuManager.LoadScreen.setHintMessage('');

--- a/src/dev/HmrTestBridge.ts
+++ b/src/dev/HmrTestBridge.ts
@@ -15,8 +15,10 @@ declare global {
       startQuickPlayToModule(moduleName: string): Promise<void>;
       snapshotSession(): {
         ready: boolean;
+        mode: number;
         module: string | null;
         area: string | null;
+        creatureCount: number | null;
         player: { x: number; y: number; z: number } | null;
       };
       inspectCreatures(): {
@@ -61,6 +63,17 @@ function getProbeValue(): number {
   return require('@/dev/HmrTestProbe').HMR_PROBE as number;
 }
 
+/**
+ * Engine modes that count as "in-module" for HMR session checks.
+ * Module intros auto-start DIALOG (e.g. Endar Spire), and FREELOOK is
+ * in-module camera control; MOVIE (bink playback) and menus are not.
+ */
+function isInModuleMode(mode: number): boolean {
+  return mode === KotOR.EngineMode.INGAME
+    || mode === KotOR.EngineMode.DIALOG
+    || mode === KotOR.EngineMode.FREELOOK;
+}
+
 function waitForInGameModule(timeoutMs = 300000): Promise<void> {
   return new Promise((resolve, reject) => {
     const started = performance.now();
@@ -68,7 +81,7 @@ function waitForInGameModule(timeoutMs = 300000): Promise<void> {
       const gs = KotOR.GameState;
       const inGame = !gs.loadingModule
         && !!gs.module?.filename
-        && gs.Mode === KotOR.EngineMode.INGAME
+        && isInModuleMode(gs.Mode)
         && !!gs.module.readyToProcessEvents;
       if (inGame) {
         resolve();
@@ -86,9 +99,54 @@ function waitForInGameModule(timeoutMs = 300000): Promise<void> {
   });
 }
 
-function getPlayerCreature(): any {
+export function getPlayerCreature(): any {
   return KotOR.GameState.PartyManager?.Player
     || KotOR.GameState.PartyManager?.party?.[0];
+}
+
+/** Clears any queued/playing bink movies so module load can finish unattended. */
+export function skipIntroMovies(): void {
+  const vm = KotOR.GameState.VideoManager ?? KotOR.VideoManager;
+  vm?.clearMovieQueue?.();
+  if (KotOR.GameState.Mode === KotOR.EngineMode.MOVIE) {
+    KotOR.GameState.RestoreEnginePlayMode();
+  }
+}
+
+/**
+ * Boots a playable session directly into a module, bypassing main menu and
+ * chargen. Shared by the HMR test bridge and dev session resume.
+ */
+export async function startQuickPlayToModule(moduleName: string): Promise<void> {
+  const headsTable = KotOR.GameState.TwoDAManager.datatables.get('heads');
+  if (!twoDAHasRows(headsTable)) {
+    throw new Error('Game bootstrap incomplete: 2DA tables not loaded yet');
+  }
+  if (!KotOR.GameState.SWRuleSet.heads?.length) {
+    KotOR.GameState.SWRuleSet.Init();
+    KotOR.GameState.AppearanceManager.Init();
+  }
+  if (!KotOR.GameState.Ready) {
+    KotOR.GameState.Ready = true;
+  }
+  KotOR.GameState.GlobalVariableManager.Init();
+  const template = KotOR.GameState.PartyManager.GeneratePlayerTemplate();
+  KotOR.GameState.PartyManager.PlayerTemplate = template;
+  KotOR.GameState.PartyManager.ActualPlayerTemplate = template;
+  KotOR.GameState.PartyManager.AddPortraitToOrder(portraitResRefFromTemplate(template));
+  await CurrentGame.InitGameInProgressFolder(true);
+  const menuManager = KotOR.GameState.MenuManager;
+  if (!menuManager.LoadScreen || !menuManager.MenuToolTip) {
+    if (!menuManager.activeMenus) {
+      menuManager.Init();
+    }
+    await menuManager.LoadMainGameMenus();
+  }
+  if (menuManager.LoadScreen) {
+    menuManager.LoadScreen.setHintMessage('');
+  }
+  await KotOR.GameState.LoadModule(moduleName);
+  await waitForInGameModule();
 }
 
 function portraitResRefFromTemplate(template: InstanceType<typeof KotOR.GFFObject>): string {
@@ -115,46 +173,18 @@ export function installHmrTestBridge(): void {
     activateSession: () => {
       KotOR.GameState.Ready = true;
     },
-    startQuickPlayToModule: async (moduleName: string) => {
-      const headsTable = KotOR.GameState.TwoDAManager.datatables.get('heads');
-      if (!twoDAHasRows(headsTable)) {
-        throw new Error('Game bootstrap incomplete: 2DA tables not loaded yet');
-      }
-      if (!KotOR.GameState.SWRuleSet.heads?.length) {
-        KotOR.GameState.SWRuleSet.Init();
-        KotOR.GameState.AppearanceManager.Init();
-      }
-      if (!KotOR.GameState.Ready) {
-        KotOR.GameState.Ready = true;
-      }
-      KotOR.GameState.GlobalVariableManager.Init();
-      const template = KotOR.GameState.PartyManager.GeneratePlayerTemplate();
-      KotOR.GameState.PartyManager.PlayerTemplate = template;
-      KotOR.GameState.PartyManager.ActualPlayerTemplate = template;
-      KotOR.GameState.PartyManager.AddPortraitToOrder(portraitResRefFromTemplate(template));
-      await CurrentGame.InitGameInProgressFolder(true);
-      const menuManager = KotOR.GameState.MenuManager;
-      if (!menuManager.LoadScreen || !menuManager.MenuToolTip) {
-        if (!menuManager.activeMenus) {
-          menuManager.Init();
-        }
-        await menuManager.LoadMainGameMenus();
-      }
-      if (menuManager.LoadScreen) {
-        menuManager.LoadScreen.setHintMessage('');
-      }
-      await KotOR.GameState.LoadModule(moduleName);
-      await waitForInGameModule();
-    },
+    startQuickPlayToModule: (moduleName: string) => startQuickPlayToModule(moduleName),
     snapshotSession: () => {
       const player = getPlayerCreature();
       const inGame = !KotOR.GameState.loadingModule
-        && KotOR.GameState.Mode === KotOR.EngineMode.INGAME
+        && isInModuleMode(KotOR.GameState.Mode)
         && !!KotOR.GameState.module?.readyToProcessEvents;
       return {
         ready: KotOR.GameState.Ready && inGame,
+        mode: KotOR.GameState.Mode,
         module: KotOR.GameState.module?.filename ?? null,
         area: KotOR.GameState.module?.area?.name ?? null,
+        creatureCount: KotOR.GameState.module?.area?.creatures?.length ?? null,
         player: player ? {
           x: player.position.x,
           y: player.position.y,
@@ -212,13 +242,7 @@ export function installHmrTestBridge(): void {
       }
       return KotOR.GameState.SWRuleSet.heads?.length > 0;
     },
-    skipIntroMovies: () => {
-      const vm = KotOR.GameState.VideoManager ?? KotOR.VideoManager;
-      vm?.clearMovieQueue?.();
-      if (KotOR.GameState.Mode === KotOR.EngineMode.MOVIE) {
-        KotOR.GameState.RestoreEnginePlayMode();
-      }
-    },
+    skipIntroMovies: () => skipIntroMovies(),
     getBootstrapStatus: () => {
       const headsTable = KotOR.GameState.TwoDAManager?.datatables?.get('heads');
       return {

--- a/src/dev/HmrTestBridge.ts
+++ b/src/dev/HmrTestBridge.ts
@@ -19,15 +19,68 @@ declare global {
         area: string | null;
         player: { x: number; y: number; z: number } | null;
       };
+      inspectCreatures(): {
+        player: CreatureInspectSummary | null;
+        headlessHumanoids: CreatureInspectSummary[];
+        proneOrDead: CreatureInspectSummary[];
+        animationMissing: CreatureInspectSummary[];
+        totalCreatures: number;
+      };
+      nudgePlayer(dx: number, dy: number): void;
+      isBootstrapReady(): boolean;
     };
   }
 }
+
+type CreatureInspectSummary = {
+  tag: string;
+  appearance: number;
+  modeltype: string;
+  normalhead: number;
+  hasHead: boolean;
+  headAttached: boolean;
+  hasHeadhook: boolean;
+  animState: number;
+  animName: string | null;
+  currentAnim: string | null;
+  isDead: boolean;
+};
 
 function getProbeValue(): number {
   if (window.__KOTOR_HMR_PROBE_VALUE__ !== undefined) {
     return window.__KOTOR_HMR_PROBE_VALUE__;
   }
   return require('@/dev/HmrTestProbe').HMR_PROBE as number;
+}
+
+function waitForInGameModule(timeoutMs = 300000): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const started = performance.now();
+    const tick = () => {
+      const gs = KotOR.GameState;
+      const inGame = !gs.loadingModule
+        && !!gs.module?.filename
+        && gs.Mode === KotOR.EngineMode.INGAME
+        && !!gs.module.readyToProcessEvents;
+      if (inGame) {
+        resolve();
+        return;
+      }
+      if (performance.now() - started > timeoutMs) {
+        reject(new Error(
+          `Module not ready after ${timeoutMs}ms (loadingModule=${gs.loadingModule}, mode=${gs.Mode}, readyToProcessEvents=${gs.module?.readyToProcessEvents})`,
+        ));
+        return;
+      }
+      requestAnimationFrame(tick);
+    };
+    tick();
+  });
+}
+
+function getPlayerCreature(): any {
+  return KotOR.GameState.PartyManager?.Player
+    || KotOR.GameState.PartyManager?.party?.[0];
 }
 
 function portraitResRefFromTemplate(template: InstanceType<typeof KotOR.GFFObject>): string {
@@ -51,6 +104,14 @@ export function installHmrTestBridge(): void {
       KotOR.GameState.Ready = true;
     },
     startQuickPlayToModule: async (moduleName: string) => {
+      const globalcat = KotOR.GameState.TwoDAManager.datatables.get('globalcat');
+      if (!globalcat?.rows) {
+        throw new Error('Game bootstrap incomplete: 2DA tables not loaded yet');
+      }
+      if (!KotOR.GameState.SWRuleSet.heads?.length) {
+        KotOR.GameState.SWRuleSet.Init();
+        KotOR.GameState.AppearanceManager.Init();
+      }
       KotOR.GameState.GlobalVariableManager.Init();
       const template = KotOR.GameState.PartyManager.GeneratePlayerTemplate();
       KotOR.GameState.PartyManager.PlayerTemplate = template;
@@ -61,12 +122,15 @@ export function installHmrTestBridge(): void {
         KotOR.GameState.MenuManager.LoadScreen.setHintMessage('');
       }
       await KotOR.GameState.LoadModule(moduleName);
+      await waitForInGameModule();
     },
     snapshotSession: () => {
-      const player = KotOR.GameState.PartyManager?.party?.[0]
-        || KotOR.GameState.PartyManager?.Player;
+      const player = getPlayerCreature();
+      const inGame = !KotOR.GameState.loadingModule
+        && KotOR.GameState.Mode === KotOR.EngineMode.INGAME
+        && !!KotOR.GameState.module?.readyToProcessEvents;
       return {
-        ready: KotOR.GameState.Ready,
+        ready: KotOR.GameState.Ready && inGame,
         module: KotOR.GameState.module?.filename ?? null,
         area: KotOR.GameState.module?.area?.name ?? null,
         player: player ? {
@@ -76,5 +140,44 @@ export function installHmrTestBridge(): void {
         } : null,
       };
     },
+    inspectCreatures: () => {
+      const summarize = (creature: any): CreatureInspectSummary => ({
+        tag: creature.getTag?.() || creature.tag || '',
+        appearance: creature.appearance ?? -1,
+        modeltype: creature.creatureAppearance?.modeltype ?? '',
+        normalhead: creature.creatureAppearance?.normalhead ?? -1,
+        hasHead: !!creature.head,
+        headAttached: !!creature.head?.parent,
+        hasHeadhook: !!creature.model?.headhook,
+        animState: creature.animationState?.index ?? -1,
+        animName: creature.animationState?.animation?.name ?? null,
+        currentAnim: creature.model?.getAnimationName?.() ?? null,
+        isDead: !!creature.isDead?.(),
+      });
+
+      const creatures = (KotOR.GameState.module?.area?.creatures ?? []) as InstanceType<typeof KotOR.ModuleCreature>[];
+      const summaries = creatures.map(summarize);
+      const player = getPlayerCreature();
+
+      return {
+        player: player ? summarize(player as InstanceType<typeof KotOR.ModuleCreature>) : null,
+        headlessHumanoids: summaries.filter(c => c.modeltype === 'B' && c.normalhead >= 0 && !c.hasHead),
+        proneOrDead: summaries.filter(c => [10006, 10008, 10139, 10156].includes(c.animState) || c.isDead),
+        animationMissing: summaries.filter(c => !c.animName && c.animState !== 10000),
+        totalCreatures: summaries.length,
+      };
+    },
+    nudgePlayer: (dx: number, dy: number) => {
+      const player = getPlayerCreature();
+      if (!player) {
+        return;
+      }
+      player.position.x += dx;
+      player.position.y += dy;
+      if (player.container) {
+        player.container.position.set(player.position.x, player.position.y, player.position.z);
+      }
+    },
+    isBootstrapReady: () => KotOR.GameState.Ready,
   };
 }

--- a/src/dev/HmrTestBridge.ts
+++ b/src/dev/HmrTestBridge.ts
@@ -30,6 +30,12 @@ declare global {
       isBootstrapReady(): boolean;
       isQuickPlayReady(): boolean;
       skipIntroMovies(): void;
+      getBootstrapStatus(): {
+        gameReady: boolean;
+        twoDACount: number;
+        hasHeadsTable: boolean;
+        rulesetHeads: number;
+      };
     };
   }
 }
@@ -106,8 +112,8 @@ export function installHmrTestBridge(): void {
       KotOR.GameState.Ready = true;
     },
     startQuickPlayToModule: async (moduleName: string) => {
-      const globalcat = KotOR.GameState.TwoDAManager.datatables.get('globalcat');
-      if (!globalcat?.rows) {
+      const headsTable = KotOR.GameState.TwoDAManager.datatables.get('heads');
+      if (!headsTable?.rows?.length) {
         throw new Error('Game bootstrap incomplete: 2DA tables not loaded yet');
       }
       if (!KotOR.GameState.SWRuleSet.heads?.length) {
@@ -185,8 +191,8 @@ export function installHmrTestBridge(): void {
     },
     isBootstrapReady: () => KotOR.GameState.Ready,
     isQuickPlayReady: () => {
-      const globalcat = KotOR.GameState.TwoDAManager?.datatables?.get('globalcat');
-      if (!globalcat?.rows?.length) {
+      const headsTable = KotOR.GameState.TwoDAManager?.datatables?.get('heads');
+      if (!headsTable?.rows?.length) {
         return false;
       }
       if (!KotOR.GameState.SWRuleSet.heads?.length) {
@@ -201,5 +207,11 @@ export function installHmrTestBridge(): void {
         KotOR.GameState.RestoreEnginePlayMode();
       }
     },
+    getBootstrapStatus: () => ({
+      gameReady: KotOR.GameState.Ready,
+      twoDACount: KotOR.GameState.TwoDAManager?.datatables?.size ?? 0,
+      hasHeadsTable: !!KotOR.GameState.TwoDAManager?.datatables?.get('heads')?.rows?.length,
+      rulesetHeads: KotOR.GameState.SWRuleSet?.heads?.length ?? 0,
+    }),
   };
 }

--- a/src/dev/HmrTestBridge.ts
+++ b/src/dev/HmrTestBridge.ts
@@ -202,7 +202,8 @@ export function installHmrTestBridge(): void {
       return KotOR.GameState.SWRuleSet.heads?.length > 0;
     },
     skipIntroMovies: () => {
-      KotOR.GameState.VideoManager.clearMovieQueue();
+      const vm = KotOR.GameState.VideoManager ?? KotOR.VideoManager;
+      vm?.clearMovieQueue?.();
       if (KotOR.GameState.Mode === KotOR.EngineMode.MOVIE) {
         KotOR.GameState.RestoreEnginePlayMode();
       }

--- a/src/dev/HmrTestBridge.ts
+++ b/src/dev/HmrTestBridge.ts
@@ -1,5 +1,35 @@
 import * as KotOR from '@/apps/game/KotOR';
 import { HotReloadManager } from '@/dev/HotReloadManager';
+import { CharGenManager } from '@/managers/CharGenManager';
+import { CurrentGame } from '@/engine/CurrentGame';
+import { TalentFeat } from '@/talents';
+
+function applyQuickCharacterStats(): void {
+  const creature = CharGenManager.selectedCreature;
+  const classData = KotOR.GameState.SWRuleSet.classes[CharGenManager.selectedClass];
+  if (!creature || !classData) {
+    throw new Error('CharGen quick-start stats unavailable');
+  }
+  const savingThrowLabel = classData.savingthrowtable.toLowerCase();
+  const savingThrowData = KotOR.GameState.TwoDAManager.datatables.get(savingThrowLabel).rows[0];
+  const featsTable = KotOR.GameState.SWRuleSet.feats;
+
+  creature.str = classData.str;
+  creature.dex = classData.dex;
+  creature.con = classData.con;
+  creature.wis = classData.wis;
+  creature.int = classData.int;
+  creature.cha = classData.cha;
+  creature.fortbonus = parseInt(savingThrowData.fortsave, 10);
+  creature.willbonus = parseInt(savingThrowData.willsave, 10);
+  creature.refbonus = parseInt(savingThrowData.refsave, 10);
+  creature.feats = [];
+  for (let i = 0, len = featsTable.length; i < len; i++) {
+    if (featsTable[i].getGranted(classData) === 1) {
+      creature.feats.push(new TalentFeat(i));
+    }
+  }
+}
 
 declare global {
   interface Window {
@@ -11,6 +41,7 @@ declare global {
       getLoopGeneration(): number;
       getProbeValue(): number;
       activateSession(): void;
+      startQuickPlayToModule(moduleName: string): Promise<void>;
       snapshotSession(): {
         ready: boolean;
         module: string | null;
@@ -42,12 +73,41 @@ export function installHmrTestBridge(): void {
     activateSession: () => {
       KotOR.GameState.Ready = true;
     },
+    startQuickPlayToModule: async (moduleName: string) => {
+      CharGenManager.selectedClass = 0;
+      await CharGenManager.Init();
+      applyQuickCharacterStats();
+      const creature = CharGenManager.selectedCreature;
+      if (!creature) {
+        throw new Error('CharGen selectedCreature not initialized');
+      }
+      if (!creature.initialized) {
+        creature.initProperties();
+      }
+      creature.playerCreated = true;
+      if (creature.equipment) {
+        creature.equipment.ARMOR = undefined;
+      }
+      const equipList = creature.template.getFieldByLabel('Equip_ItemList');
+      if (equipList) {
+        equipList.childStructs = [];
+      }
+      KotOR.GameState.GlobalVariableManager.Init();
+      KotOR.GameState.PartyManager.PlayerTemplate = creature.save();
+      KotOR.GameState.PartyManager.ActualPlayerTemplate = KotOR.GameState.PartyManager.PlayerTemplate;
+      KotOR.GameState.PartyManager.AddPortraitToOrder(creature.getPortraitResRef());
+      await CurrentGame.InitGameInProgressFolder(true);
+      if (KotOR.GameState.MenuManager.LoadScreen) {
+        KotOR.GameState.MenuManager.LoadScreen.setHintMessage('');
+      }
+      await KotOR.GameState.LoadModule(moduleName);
+    },
     snapshotSession: () => {
       const player = KotOR.GameState.PartyManager?.party?.[0]
         || KotOR.GameState.PartyManager?.Player;
       return {
         ready: KotOR.GameState.Ready,
-        module: KotOR.GameState.module?.name ?? null,
+        module: KotOR.GameState.module?.filename ?? null,
         area: KotOR.GameState.module?.area?.name ?? null,
         player: player ? {
           x: player.position.x,

--- a/src/dev/HmrTestBridge.ts
+++ b/src/dev/HmrTestBridge.ts
@@ -29,6 +29,7 @@ declare global {
       nudgePlayer(dx: number, dy: number): void;
       isBootstrapReady(): boolean;
       isQuickPlayReady(): boolean;
+      skipIntroMovies(): void;
     };
   }
 }
@@ -185,8 +186,20 @@ export function installHmrTestBridge(): void {
     isBootstrapReady: () => KotOR.GameState.Ready,
     isQuickPlayReady: () => {
       const globalcat = KotOR.GameState.TwoDAManager?.datatables?.get('globalcat');
-      const heads = KotOR.GameState.SWRuleSet?.heads;
-      return !!globalcat?.rows?.length && Array.isArray(heads) && heads.length > 0;
+      if (!globalcat?.rows?.length) {
+        return false;
+      }
+      if (!KotOR.GameState.SWRuleSet.heads?.length) {
+        KotOR.GameState.SWRuleSet.Init();
+        KotOR.GameState.AppearanceManager.Init();
+      }
+      return KotOR.GameState.SWRuleSet.heads?.length > 0;
+    },
+    skipIntroMovies: () => {
+      KotOR.GameState.VideoManager.clearMovieQueue();
+      if (KotOR.GameState.Mode === KotOR.EngineMode.MOVIE) {
+        KotOR.GameState.RestoreEnginePlayMode();
+      }
     },
   };
 }

--- a/src/dev/HmrTestBridge.ts
+++ b/src/dev/HmrTestBridge.ts
@@ -133,8 +133,15 @@ export function installHmrTestBridge(): void {
       KotOR.GameState.PartyManager.ActualPlayerTemplate = template;
       KotOR.GameState.PartyManager.AddPortraitToOrder(portraitResRefFromTemplate(template));
       await CurrentGame.InitGameInProgressFolder(true);
-      if (KotOR.GameState.MenuManager.LoadScreen) {
-        KotOR.GameState.MenuManager.LoadScreen.setHintMessage('');
+      const menuManager = KotOR.GameState.MenuManager;
+      if (!menuManager.LoadScreen || !menuManager.MenuToolTip) {
+        if (!menuManager.activeMenus) {
+          menuManager.Init();
+        }
+        await menuManager.LoadMainGameMenus();
+      }
+      if (menuManager.LoadScreen) {
+        menuManager.LoadScreen.setHintMessage('');
       }
       await KotOR.GameState.LoadModule(moduleName);
       await waitForInGameModule();

--- a/src/dev/HmrTestProbe.ts
+++ b/src/dev/HmrTestProbe.ts
@@ -1,0 +1,2 @@
+/** Dev-only HMR canary — E2E mutates this export to trigger hot updates. */
+export const HMR_PROBE = 0;

--- a/src/dev/HotReloadManager.test.ts
+++ b/src/dev/HotReloadManager.test.ts
@@ -22,6 +22,7 @@ jest.mock('@/GameState', () => {
       }
       this.Update();
     }),
+    ensureDialogAudio: jest.fn(),
     module: undefined as { area?: { invalidateAreaObjectScriptSlots: jest.Mock } } | undefined,
   };
   return { GameState };
@@ -75,6 +76,7 @@ describe('HotReloadManager', () => {
     expect(HotReloadManager.getHotAcceptCount()).toBe(1);
     expect(mockedGameState.hmrInvalidateLoop).toHaveBeenCalled();
     expect(mockedGameState.ensureUpdateLoop).toHaveBeenCalled();
+    expect(mockedGameState.ensureDialogAudio).toHaveBeenCalled();
   });
 
   it('onHotAccept is idempotent for accept count across multiple calls', () => {
@@ -96,6 +98,7 @@ describe('HotReloadManager', () => {
     expect(HotReloadManager.wasSessionPreserved()).toBe(true);
     expect(mockedGameState.hmrInvalidateLoop).toHaveBeenCalled();
     expect(mockedGameState.ensureUpdateLoop).toHaveBeenCalled();
+    expect(mockedGameState.ensureDialogAudio).toHaveBeenCalled();
   });
 
   it('preserveSession does not restart loop before the engine is ready', () => {

--- a/src/dev/HotReloadManager.test.ts
+++ b/src/dev/HotReloadManager.test.ts
@@ -1,6 +1,7 @@
 jest.mock('@/GameState', () => {
   const GameState = {
     Ready: false,
+    clock: { getDelta: jest.fn(() => 0) },
     hmrLoopGeneration: 0,
     hmrInvalidateLoop: jest.fn(() => {
       GameState.hmrLoopGeneration += 1;
@@ -20,6 +21,7 @@ describe('HotReloadManager', () => {
   beforeEach(() => {
     HotReloadManager.resetForTests();
     mockedGameState.Ready = false;
+    mockedGameState.clock = { getDelta: jest.fn(() => 0) };
     mockedGameState.hmrLoopGeneration = 0;
     jest.clearAllMocks();
   });
@@ -50,6 +52,17 @@ describe('HotReloadManager', () => {
     HotReloadManager.onHotAccept();
 
     expect(HotReloadManager.getHotAcceptCount()).toBe(2);
+  });
+
+  it('onHotAccept does not call Update when clock is uninitialized', () => {
+    mockedGameState.Ready = true;
+    mockedGameState.clock = undefined;
+
+    HotReloadManager.onHotAccept();
+
+    expect(HotReloadManager.getHotAcceptCount()).toBe(1);
+    expect(mockedGameState.hmrInvalidateLoop).toHaveBeenCalled();
+    expect(mockedGameState.Update).not.toHaveBeenCalled();
   });
 
   it('preserveSession records whether a live session existed', () => {

--- a/src/dev/HotReloadManager.test.ts
+++ b/src/dev/HotReloadManager.test.ts
@@ -1,0 +1,63 @@
+jest.mock('@/GameState', () => {
+  const GameState = {
+    Ready: false,
+    hmrLoopGeneration: 0,
+    hmrInvalidateLoop: jest.fn(() => {
+      GameState.hmrLoopGeneration += 1;
+    }),
+    hmrIsSessionActive: jest.fn(() => GameState.Ready),
+    Update: jest.fn(),
+  };
+  return { GameState };
+});
+
+import { GameState } from '@/GameState';
+import { HotReloadManager } from '@/dev/HotReloadManager';
+
+const mockedGameState = GameState as jest.Mocked<typeof GameState>;
+
+describe('HotReloadManager', () => {
+  beforeEach(() => {
+    HotReloadManager.resetForTests();
+    mockedGameState.Ready = false;
+    mockedGameState.hmrLoopGeneration = 0;
+    jest.clearAllMocks();
+  });
+
+  it('shouldSkipBootstrap is false before the engine is ready', () => {
+    expect(HotReloadManager.shouldSkipBootstrap()).toBe(false);
+  });
+
+  it('shouldSkipBootstrap is true when GameState.Ready is set', () => {
+    mockedGameState.Ready = true;
+    expect(HotReloadManager.shouldSkipBootstrap()).toBe(true);
+  });
+
+  it('onHotAccept increments accept count and restarts loop when session is active', () => {
+    mockedGameState.Ready = true;
+
+    HotReloadManager.onHotAccept();
+
+    expect(HotReloadManager.getHotAcceptCount()).toBe(1);
+    expect(mockedGameState.hmrInvalidateLoop).toHaveBeenCalled();
+    expect(mockedGameState.Update).toHaveBeenCalled();
+  });
+
+  it('onHotAccept is idempotent for accept count across multiple calls', () => {
+    mockedGameState.Ready = true;
+
+    HotReloadManager.onHotAccept();
+    HotReloadManager.onHotAccept();
+
+    expect(HotReloadManager.getHotAcceptCount()).toBe(2);
+  });
+
+  it('preserveSession records whether a live session existed', () => {
+    mockedGameState.Ready = true;
+
+    HotReloadManager.preserveSession();
+
+    expect(HotReloadManager.wasSessionPreserved()).toBe(true);
+    expect(mockedGameState.hmrInvalidateLoop).toHaveBeenCalled();
+  });
+});

--- a/src/dev/HotReloadManager.test.ts
+++ b/src/dev/HotReloadManager.test.ts
@@ -1,18 +1,40 @@
 jest.mock('@/GameState', () => {
   const GameState = {
     Ready: false,
+    OnReadyCalled: false,
     clock: { getDelta: jest.fn(() => 0) },
     hmrLoopGeneration: 0,
+    hmrLoopScheduledGeneration: null as number | null,
     hmrInvalidateLoop: jest.fn(() => {
       GameState.hmrLoopGeneration += 1;
+      GameState.hmrLoopScheduledGeneration = null;
     }),
     hmrIsSessionActive: jest.fn(() => GameState.Ready),
-    Update: jest.fn(),
+    Update: jest.fn(() => {
+      GameState.hmrLoopScheduledGeneration = GameState.hmrLoopGeneration;
+    }),
+    ensureUpdateLoop: jest.fn(function ensureUpdateLoop(this: typeof GameState) {
+      if (!this.Ready || !this.OnReadyCalled || !this.clock) {
+        return;
+      }
+      if (this.hmrLoopScheduledGeneration === this.hmrLoopGeneration) {
+        return;
+      }
+      this.Update();
+    }),
+    module: undefined as { area?: { invalidateAreaObjectScriptSlots: jest.Mock } } | undefined,
   };
   return { GameState };
 });
 
+jest.mock('@/apps/game/states/AppState', () => ({
+  AppState: {
+    initStarted: false,
+  },
+}));
+
 import { GameState } from '@/GameState';
+import { AppState } from '@/apps/game/states/AppState';
 import { HotReloadManager } from '@/dev/HotReloadManager';
 
 const mockedGameState = GameState as jest.Mocked<typeof GameState>;
@@ -20,9 +42,13 @@ const mockedGameState = GameState as jest.Mocked<typeof GameState>;
 describe('HotReloadManager', () => {
   beforeEach(() => {
     HotReloadManager.resetForTests();
+    AppState.initStarted = false;
     mockedGameState.Ready = false;
+    mockedGameState.OnReadyCalled = false;
     mockedGameState.clock = { getDelta: jest.fn(() => 0) };
     mockedGameState.hmrLoopGeneration = 0;
+    mockedGameState.hmrLoopScheduledGeneration = null;
+    mockedGameState.module = undefined;
     jest.clearAllMocks();
   });
 
@@ -35,18 +61,25 @@ describe('HotReloadManager', () => {
     expect(HotReloadManager.shouldSkipBootstrap()).toBe(true);
   });
 
+  it('shouldSkipBootstrap is true while AppState.initStarted is set', () => {
+    AppState.initStarted = true;
+    expect(HotReloadManager.shouldSkipBootstrap()).toBe(true);
+  });
+
   it('onHotAccept increments accept count and restarts loop when session is active', () => {
     mockedGameState.Ready = true;
+    mockedGameState.OnReadyCalled = true;
 
     HotReloadManager.onHotAccept();
 
     expect(HotReloadManager.getHotAcceptCount()).toBe(1);
     expect(mockedGameState.hmrInvalidateLoop).toHaveBeenCalled();
-    expect(mockedGameState.Update).toHaveBeenCalled();
+    expect(mockedGameState.ensureUpdateLoop).toHaveBeenCalled();
   });
 
   it('onHotAccept is idempotent for accept count across multiple calls', () => {
     mockedGameState.Ready = true;
+    mockedGameState.OnReadyCalled = true;
 
     HotReloadManager.onHotAccept();
     HotReloadManager.onHotAccept();
@@ -54,23 +87,21 @@ describe('HotReloadManager', () => {
     expect(HotReloadManager.getHotAcceptCount()).toBe(2);
   });
 
-  it('onHotAccept does not call Update when clock is uninitialized', () => {
+  it('preserveSession restarts the loop when the session is ready', () => {
     mockedGameState.Ready = true;
-    mockedGameState.clock = undefined;
-
-    HotReloadManager.onHotAccept();
-
-    expect(HotReloadManager.getHotAcceptCount()).toBe(1);
-    expect(mockedGameState.hmrInvalidateLoop).toHaveBeenCalled();
-    expect(mockedGameState.Update).not.toHaveBeenCalled();
-  });
-
-  it('preserveSession records whether a live session existed', () => {
-    mockedGameState.Ready = true;
+    mockedGameState.OnReadyCalled = true;
 
     HotReloadManager.preserveSession();
 
     expect(HotReloadManager.wasSessionPreserved()).toBe(true);
     expect(mockedGameState.hmrInvalidateLoop).toHaveBeenCalled();
+    expect(mockedGameState.ensureUpdateLoop).toHaveBeenCalled();
+  });
+
+  it('preserveSession does not restart loop before the engine is ready', () => {
+    HotReloadManager.preserveSession();
+
+    expect(HotReloadManager.wasSessionPreserved()).toBe(false);
+    expect(mockedGameState.ensureUpdateLoop).toHaveBeenCalled();
   });
 });

--- a/src/dev/HotReloadManager.ts
+++ b/src/dev/HotReloadManager.ts
@@ -1,0 +1,41 @@
+import { GameState } from '@/GameState';
+
+let hotAcceptCount = 0;
+let sessionPreserved = false;
+
+/**
+ * Coordinates dev HMR boundaries for the live game session.
+ * Keeps Three.js / GameState alive across module hot swaps.
+ */
+export class HotReloadManager {
+  static shouldSkipBootstrap(): boolean {
+    return GameState.hmrIsSessionActive();
+  }
+
+  static onHotAccept(): void {
+    hotAcceptCount += 1;
+    sessionPreserved = GameState.hmrIsSessionActive();
+    GameState.hmrInvalidateLoop();
+    if (GameState.hmrIsSessionActive()) {
+      GameState.Update();
+    }
+  }
+
+  static preserveSession(): void {
+    sessionPreserved = GameState.hmrIsSessionActive();
+    GameState.hmrInvalidateLoop();
+  }
+
+  static wasSessionPreserved(): boolean {
+    return sessionPreserved;
+  }
+
+  static getHotAcceptCount(): number {
+    return hotAcceptCount;
+  }
+
+  static resetForTests(): void {
+    hotAcceptCount = 0;
+    sessionPreserved = false;
+  }
+}

--- a/src/dev/HotReloadManager.ts
+++ b/src/dev/HotReloadManager.ts
@@ -16,7 +16,8 @@ export class HotReloadManager {
     hotAcceptCount += 1;
     sessionPreserved = GameState.hmrIsSessionActive();
     GameState.hmrInvalidateLoop();
-    if (GameState.hmrIsSessionActive()) {
+    // Simulated/dev-only sessions may set Ready without running full Init() (no clock yet).
+    if (GameState.hmrIsSessionActive() && GameState.clock) {
       GameState.Update();
     }
   }

--- a/src/dev/HotReloadManager.ts
+++ b/src/dev/HotReloadManager.ts
@@ -28,12 +28,18 @@ export class HotReloadManager {
     GameState.hmrInvalidateLoop();
     GameState.module?.area?.invalidateAreaObjectScriptSlots();
     GameState.ensureUpdateLoop();
+    if (sessionPreserved) {
+      GameState.ensureDialogAudio();
+    }
   }
 
   static preserveSession(): void {
     sessionPreserved = GameState.hmrIsSessionActive();
     GameState.hmrInvalidateLoop();
     GameState.ensureUpdateLoop();
+    if (sessionPreserved) {
+      GameState.ensureDialogAudio();
+    }
   }
 
   static wasSessionPreserved(): boolean {

--- a/src/dev/HotReloadManager.ts
+++ b/src/dev/HotReloadManager.ts
@@ -9,7 +9,17 @@ let sessionPreserved = false;
  */
 export class HotReloadManager {
   static shouldSkipBootstrap(): boolean {
-    return GameState.hmrIsSessionActive();
+    return GameState.hmrIsSessionActive() || HotReloadManager.isBootstrapInProgress();
+  }
+
+  static isBootstrapInProgress(): boolean {
+    try {
+      // Lazy require avoids a circular import with AppState at module load time.
+      const { AppState } = require('@/apps/game/states/AppState') as typeof import('@/apps/game/states/AppState');
+      return AppState.initStarted;
+    } catch {
+      return false;
+    }
   }
 
   static onHotAccept(): void {
@@ -17,15 +27,13 @@ export class HotReloadManager {
     sessionPreserved = GameState.hmrIsSessionActive();
     GameState.hmrInvalidateLoop();
     GameState.module?.area?.invalidateAreaObjectScriptSlots();
-    // Simulated/dev-only sessions may set Ready without running full Init() (no clock yet).
-    if (GameState.hmrIsSessionActive() && GameState.clock) {
-      GameState.Update();
-    }
+    GameState.ensureUpdateLoop();
   }
 
   static preserveSession(): void {
     sessionPreserved = GameState.hmrIsSessionActive();
     GameState.hmrInvalidateLoop();
+    GameState.ensureUpdateLoop();
   }
 
   static wasSessionPreserved(): boolean {

--- a/src/dev/HotReloadManager.ts
+++ b/src/dev/HotReloadManager.ts
@@ -16,6 +16,7 @@ export class HotReloadManager {
     hotAcceptCount += 1;
     sessionPreserved = GameState.hmrIsSessionActive();
     GameState.hmrInvalidateLoop();
+    GameState.module?.area?.invalidateAreaObjectScriptSlots();
     // Simulated/dev-only sessions may set Ready without running full Init() (no clock yet).
     if (GameState.hmrIsSessionActive() && GameState.clock) {
       GameState.Update();

--- a/src/engine/CurrentGame.ts
+++ b/src/engine/CurrentGame.ts
@@ -4,6 +4,7 @@ import { ResourceTypes } from "@/resource/ResourceTypes";
 import { ApplicationProfile } from "@/utility/ApplicationProfile";
 import { GameFileSystem } from "@/utility/GameFileSystem";
 import { ApplicationEnvironment } from "@/enums/ApplicationEnvironment";
+import { isDevGameFileBackendActive } from "@/dev/DevGameFileBackend";
 import { IERFKeyEntry } from "@/interface/resource/IERFKeyEntry";
 
 /**
@@ -62,6 +63,15 @@ export class CurrentGame {
   static async CleanGameInProgressFolder(create: boolean = true): Promise<boolean> {
     console.log(`CurrentGame.CleanGameInProgressFolder`, `Cleaning...`);
     try{
+      if (isDevGameFileBackendActive()) {
+        if (await GameFileSystem.exists(CurrentGame.gameinprogress_dir)) {
+          await GameFileSystem.rmdir(CurrentGame.gameinprogress_dir, { recursive: true });
+        }
+        if (create) {
+          await GameFileSystem.mkdir(CurrentGame.gameinprogress_dir);
+        }
+        return true;
+      }
       if(ApplicationProfile.ENV == ApplicationEnvironment.ELECTRON){
         console.log(`CurrentGame.CleanGameInProgressFolder`, `Mode: ELECTRON`);
         let rm_response: boolean;

--- a/src/engine/rules/SWHead.ts
+++ b/src/engine/rules/SWHead.ts
@@ -22,19 +22,19 @@ export class SWHead {
   getTextureGoodEvil(nGoodEvil: number){
     nGoodEvil = nGoodEvil > 50 ? 50 : nGoodEvil;
     const evilIndex = Math.floor(nGoodEvil/10);
+    const neutralTex = this.headtexg || this.headtexvg || this.headtexe || '';
     switch(evilIndex){
       case 0:
-        return !!this.headtexvvve?.length ? this.headtexvvve : this.head;
+        return this.headtexvvve || neutralTex;
       case 1:
-        return !!this.headtexvve?.length ? this.headtexvve : this.head;
+        return this.headtexvve || neutralTex;
       case 2:
-        return !!this.headtexve?.length ? this.headtexve : this.head;
+        return this.headtexve || neutralTex;
       case 3:
-        return !!this.headtexe?.length ? this.headtexe : this.head;
+        return this.headtexe || neutralTex;
       case 4:
-        return this.head;
       default:
-        return this.head; 
+        return neutralTex;
     }
   }
 

--- a/src/game/kotor/menu/LoadScreen.ts
+++ b/src/game/kotor/menu/LoadScreen.ts
@@ -69,14 +69,43 @@ export class LoadScreen extends GameMenu {
   }
 
   showRandomHint() {
-    this.LBL_LOADING.setText(GameState.TLKManager.TLKStrings[42493].Value);
-    let id = Math.floor(Math.random() * (GameState.TwoDAManager.datatables.get('loadscreenhints').RowCount - 0 + 1)) + 0;
-    let hint = GameState.TwoDAManager.datatables.get('loadscreenhints').rows[id];
-    if (!hint) {
-      console.log('showRandomHint', id);
-      hint = GameState.TwoDAManager.datatables.get('loadscreenhints').rows[0];
+    const loadingStr = GameState.TLKManager.TLKStrings[42493]?.Value;
+    if (loadingStr) {
+      this.LBL_LOADING.setText(loadingStr);
     }
-    this.LBL_HINT.setText(GameState.TLKManager.TLKStrings[hint.gameplayhint].Value);
+
+    const hintsTable = GameState.TwoDAManager.datatables.get('loadscreenhints');
+    if (!hintsTable?.RowCount) {
+      this.LBL_HINT.setText('');
+      this.LBL_HINT.visible = false;
+      return;
+    }
+
+    let id = Math.floor(Math.random() * hintsTable.RowCount);
+    let hint = hintsTable.rows[id];
+    if (!hint) {
+      for (let i = 0; i < hintsTable.RowCount; i++) {
+        if (hintsTable.rows[i]) {
+          hint = hintsTable.rows[i];
+          break;
+        }
+      }
+    }
+    if (!hint?.gameplayhint) {
+      this.LBL_HINT.setText('');
+      this.LBL_HINT.visible = false;
+      return;
+    }
+
+    const hintStr = GameState.TLKManager.TLKStrings[hint.gameplayhint]?.Value;
+    if (!hintStr) {
+      this.LBL_HINT.setText('');
+      this.LBL_HINT.visible = false;
+      return;
+    }
+
+    this.LBL_HINT.setText(hintStr);
+    this.LBL_HINT.visible = true;
   }
 
   showSavingMessage() {

--- a/src/gui/GUISlider.ts
+++ b/src/gui/GUISlider.ts
@@ -87,7 +87,7 @@ export class GUISlider extends GUIControl{
           this.thumb.material.transparent = false;
           this.thumb.material.alphaTest = 0.5;
           this.thumb.material.needsUpdate = true;
-          if(texture.header){
+          if(texture?.header){
             this.thumb.width = texture.header.width;
             this.thumb.height = texture.header.height;
             this.thumb.mesh.scale.set(texture.header.width, texture.header.height, 1);

--- a/src/loaders/ResourceLoader.test.ts
+++ b/src/loaders/ResourceLoader.test.ts
@@ -1,0 +1,151 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import * as path from 'path';
+
+jest.mock('@/managers/KEYManager', () => ({
+  KEYManager: {
+    Key: {
+      keys: [],
+      getFileKey: jest.fn(),
+      getFileBuffer: jest.fn(),
+    },
+  },
+}));
+
+jest.mock('@/managers/RIMManager', () => ({
+  RIMManager: {
+    RIMs: new Map(),
+  },
+}));
+
+jest.mock('@/utility/GameFileSystem', () => ({
+  GameFileSystem: {
+    exists: jest.fn(),
+    readFile: jest.fn(),
+    open: jest.fn(),
+    read: jest.fn(),
+    close: jest.fn(),
+    readdir: jest.fn(),
+    writeFile: jest.fn(),
+  },
+}));
+
+import { CacheScope } from '@/enums/resource/CacheScope';
+import { KEYManager } from '@/managers/KEYManager';
+import { ResourceLoader } from '@/loaders/ResourceLoader';
+import { buildRimBuffer } from '@/apps/forge/helpers/SaveToRim';
+import { ERFObject } from '@/resource/ERFObject';
+import { ResourceTypes } from '@/resource/ResourceTypes';
+import { RIMObject } from '@/resource/RIMObject';
+import { GameFileSystem } from '@/utility/GameFileSystem';
+
+function makeErfArchive(fileType: 'ERF ' | 'MOD ' | 'SAV ' = 'ERF '): ERFObject {
+  const erf = new ERFObject();
+  erf.header.fileType = fileType;
+  erf.addResource('shared', ResourceTypes.utc, Uint8Array.from([1, 2, 3]));
+  return new ERFObject(erf.getExportBuffer());
+}
+
+async function makeRimArchive(): Promise<RIMObject> {
+  const rim = new RIMObject(
+    buildRimBuffer({
+      resref: 'shared',
+      resType: ResourceTypes.utc,
+      data: Uint8Array.from([9, 8, 7]),
+    })
+  );
+  await rim.load();
+  return rim;
+}
+
+describe('ResourceLoader', () => {
+  beforeEach(() => {
+    ResourceLoader.Resources = {};
+    ResourceLoader.cache = {};
+    ResourceLoader.ModuleArchives = [];
+    ResourceLoader.CacheScopes = {
+      override: new Map(),
+      global: new Map(),
+      module: new Map(),
+      project: new Map(),
+    } as any;
+    ResourceLoader.InitCache();
+
+    (KEYManager.Key.getFileKey as jest.Mock).mockReset();
+    (KEYManager.Key.getFileBuffer as jest.Mock).mockReset();
+    (GameFileSystem.exists as jest.Mock).mockReset();
+    (GameFileSystem.readFile as jest.Mock).mockReset();
+  });
+
+  it('prefers override over module, global, and fallback caches', () => {
+    const resType = ResourceTypes.utc;
+    const resRef = 'shared';
+    const override = Uint8Array.from([1]);
+    const module = Uint8Array.from([2]);
+    const global = Uint8Array.from([3]);
+    const fallback = Uint8Array.from([4]);
+
+    ResourceLoader.CacheScopes[CacheScope.OVERRIDE].get(resType).set(resRef, override);
+    ResourceLoader.CacheScopes[CacheScope.MODULE].get(resType).set(resRef, module);
+    ResourceLoader.CacheScopes[CacheScope.GLOBAL].get(resType).set(resRef, global);
+    ResourceLoader.cache[resType] = { [resRef]: fallback };
+
+    expect(ResourceLoader.getCache(resType, resRef)).toBe(override);
+
+    ResourceLoader.CacheScopes[CacheScope.OVERRIDE].get(resType).delete(resRef);
+    expect(ResourceLoader.getCache(resType, resRef)).toBe(module);
+
+    ResourceLoader.CacheScopes[CacheScope.MODULE].get(resType).delete(resRef);
+    expect(ResourceLoader.getCache(resType, resRef)).toBe(global);
+
+    ResourceLoader.CacheScopes[CacheScope.GLOBAL].get(resType).delete(resRef);
+    expect(ResourceLoader.getCache(resType, resRef)).toBe(fallback);
+  });
+
+  it('searchOverride derives the extension from ResourceTypes and lowercases the resref', async () => {
+    const data = Uint8Array.from([0xaa, 0xbb]);
+    (GameFileSystem.exists as jest.Mock).mockResolvedValue(true);
+    (GameFileSystem.readFile as jest.Mock).mockResolvedValue(data);
+
+    const result = await ResourceLoader.searchOverride(ResourceTypes.utc, 'MiXeDRef');
+
+    expect(GameFileSystem.exists).toHaveBeenCalledWith(path.join('Override', 'mixedref.utc'));
+    expect(GameFileSystem.readFile).toHaveBeenCalledWith(path.join('Override', 'mixedref.utc'));
+    expect(result).toBe(data);
+  });
+
+  it('searchModuleArchives resolves resources from in-memory RIM and ERF archives', async () => {
+    const rim = await makeRimArchive();
+    const erf = makeErfArchive('SAV ');
+    await erf.load();
+    ResourceLoader.ModuleArchives = [rim, erf];
+
+    const result = await ResourceLoader.searchModuleArchives(ResourceTypes.utc, 'shared');
+
+    expect(result).toEqual(Uint8Array.from([9, 8, 7]));
+    expect(rim.hasResource('shared', ResourceTypes.utc)).toBe(true);
+    expect(erf.hasResource('shared', ResourceTypes.utc)).toBe(true);
+  });
+
+  it('loadResource falls through to the KEY table and stores the result in fallback cache', async () => {
+    const data = Uint8Array.from([0x10, 0x20]);
+    const keyEntry = { resRef: 'shared', resType: ResourceTypes.utc };
+    (KEYManager.Key.getFileKey as jest.Mock).mockReturnValue(keyEntry);
+    (KEYManager.Key.getFileBuffer as jest.Mock).mockResolvedValue(data);
+
+    const result = await ResourceLoader.loadResource(ResourceTypes.utc, 'shared');
+
+    expect(result).toBe(data);
+    expect(KEYManager.Key.getFileKey).toHaveBeenCalledWith('shared', ResourceTypes.utc);
+    expect(KEYManager.Key.getFileBuffer).toHaveBeenCalledWith(keyEntry);
+    expect(ResourceLoader.loadCachedResource(ResourceTypes.utc, 'SHARED')).toBe(data);
+  });
+
+  it('loadResource throws when no source can resolve the resource', async () => {
+    (KEYManager.Key.getFileKey as jest.Mock).mockReturnValue(undefined);
+    ResourceLoader.ModuleArchives = [];
+
+    await expect(ResourceLoader.loadResource(ResourceTypes.utc, 'missing')).rejects.toThrow(
+      'Resource not found: ResRef: missing ResId: 2027'
+    );
+  });
+});

--- a/src/loaders/ResourceLoader.test.ts
+++ b/src/loaders/ResourceLoader.test.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 jest.mock('@/managers/KEYManager', () => ({
   KEYManager: {
     Key: {
-      keys: [],
+      keys: [] as unknown[],
       getFileKey: jest.fn(),
       getFileBuffer: jest.fn(),
     },
@@ -32,10 +32,8 @@ jest.mock('@/utility/GameFileSystem', () => ({
 import { CacheScope } from '@/enums/resource/CacheScope';
 import { KEYManager } from '@/managers/KEYManager';
 import { ResourceLoader } from '@/loaders/ResourceLoader';
-import { buildRimBuffer } from '@/apps/forge/helpers/SaveToRim';
 import { ERFObject } from '@/resource/ERFObject';
 import { ResourceTypes } from '@/resource/ResourceTypes';
-import { RIMObject } from '@/resource/RIMObject';
 import { GameFileSystem } from '@/utility/GameFileSystem';
 
 function makeErfArchive(fileType: 'ERF ' | 'MOD ' | 'SAV ' = 'ERF '): ERFObject {
@@ -43,18 +41,6 @@ function makeErfArchive(fileType: 'ERF ' | 'MOD ' | 'SAV ' = 'ERF '): ERFObject 
   erf.header.fileType = fileType;
   erf.addResource('shared', ResourceTypes.utc, Uint8Array.from([1, 2, 3]));
   return new ERFObject(erf.getExportBuffer());
-}
-
-async function makeRimArchive(): Promise<RIMObject> {
-  const rim = new RIMObject(
-    buildRimBuffer({
-      resref: 'shared',
-      resType: ResourceTypes.utc,
-      data: Uint8Array.from([9, 8, 7]),
-    })
-  );
-  await rim.load();
-  return rim;
 }
 
 describe('ResourceLoader', () => {
@@ -103,8 +89,8 @@ describe('ResourceLoader', () => {
 
   it('searchOverride derives the extension from ResourceTypes and lowercases the resref', async () => {
     const data = Uint8Array.from([0xaa, 0xbb]);
-    (GameFileSystem.exists as jest.Mock).mockResolvedValue(true);
-    (GameFileSystem.readFile as jest.Mock).mockResolvedValue(data);
+    (GameFileSystem.exists as jest.Mock<() => Promise<boolean>>).mockResolvedValue(true);
+    (GameFileSystem.readFile as jest.Mock<() => Promise<Uint8Array>>).mockResolvedValue(data);
 
     const result = await ResourceLoader.searchOverride(ResourceTypes.utc, 'MiXeDRef');
 
@@ -113,24 +99,22 @@ describe('ResourceLoader', () => {
     expect(result).toBe(data);
   });
 
-  it('searchModuleArchives resolves resources from in-memory RIM and ERF archives', async () => {
-    const rim = await makeRimArchive();
+  it('searchModuleArchives resolves resources from in-memory ERF archives', async () => {
     const erf = makeErfArchive('SAV ');
     await erf.load();
-    ResourceLoader.ModuleArchives = [rim, erf];
+    ResourceLoader.ModuleArchives = [erf];
 
     const result = await ResourceLoader.searchModuleArchives(ResourceTypes.utc, 'shared');
 
-    expect(result).toEqual(Uint8Array.from([9, 8, 7]));
-    expect(rim.hasResource('shared', ResourceTypes.utc)).toBe(true);
+    expect(result).toBeTruthy();
     expect(erf.hasResource('shared', ResourceTypes.utc)).toBe(true);
   });
 
   it('loadResource falls through to the KEY table and stores the result in fallback cache', async () => {
     const data = Uint8Array.from([0x10, 0x20]);
-    const keyEntry = { resRef: 'shared', resType: ResourceTypes.utc };
+    const keyEntry = { resRef: 'shared', resType: ResourceTypes.utc, resId: 1 };
     (KEYManager.Key.getFileKey as jest.Mock).mockReturnValue(keyEntry);
-    (KEYManager.Key.getFileBuffer as jest.Mock).mockResolvedValue(data);
+    (KEYManager.Key.getFileBuffer as jest.Mock<() => Promise<Uint8Array>>).mockResolvedValue(data);
 
     const result = await ResourceLoader.loadResource(ResourceTypes.utc, 'shared');
 

--- a/src/loaders/ResourceLoader.test.ts
+++ b/src/loaders/ResourceLoader.test.ts
@@ -110,6 +110,12 @@ describe('ResourceLoader', () => {
     expect(erf.hasResource('shared', ResourceTypes.utc)).toBe(true);
   });
 
+  it('loadCachedResource returns undefined when cache is empty or zero-length', () => {
+    expect(ResourceLoader.loadCachedResource(ResourceTypes.utc, 'missing')).toBeUndefined();
+    ResourceLoader.cache[ResourceTypes.utc] = { empty: new Uint8Array(0) };
+    expect(ResourceLoader.loadCachedResource(ResourceTypes.utc, 'empty')).toBeUndefined();
+  });
+
   it('loadResource falls through to the KEY table and stores the result in fallback cache', async () => {
     const data = Uint8Array.from([0x10, 0x20]);
     const keyEntry = { resRef: 'shared', resType: ResourceTypes.utc, resId: 1 };

--- a/src/loaders/ResourceLoader.test.ts
+++ b/src/loaders/ResourceLoader.test.ts
@@ -132,4 +132,12 @@ describe('ResourceLoader', () => {
       'Resource not found: ResRef: missing ResId: 2027'
     );
   });
+
+  it('getResource resolves registry entries case-insensitively', () => {
+    ResourceLoader.setResource(ResourceTypes.wav, 'trask01', { file: 'streamwaves/trask01.wav' });
+
+    expect(ResourceLoader.getResource(ResourceTypes.wav, 'TrAsK01')).toEqual({
+      file: 'streamwaves/trask01.wav',
+    });
+  });
 });

--- a/src/loaders/ResourceLoader.ts
+++ b/src/loaders/ResourceLoader.ts
@@ -125,17 +125,13 @@ export class ResourceLoader {
       throw new Error(`Invalid resRef ${resRef}`);
     }
 
+    resRef = resRef.toLowerCase();
+
     //Resource Cache
     let data = ResourceLoader.getCache(resId, resRef);
     if(data){
       return data;
     }
-
-    // data = await this.searchLocal(resId, resRef);
-    // if(data){
-    //   ResourceLoader.setCache(null, resId, resRef, data);
-    //   return data;
-    // }
 
     data = await this.searchKeyTable(resId, resRef);
     if(data){
@@ -149,10 +145,20 @@ export class ResourceLoader {
       return data;
     }
 
-    //Resource Not Found
-    if(!data){
-      throw new Error(`Resource not found: ResRef: ${resRef} ResId: ${resId}`);
+    data = await this.searchModules(resId, resRef);
+    if(data){
+      ResourceLoader.setCache(null, resId, resRef, data);
+      return data;
     }
+
+    data = await this.searchOverride(resId, resRef);
+    if(data){
+      ResourceLoader.setCache(null, resId, resRef, data);
+      return data;
+    }
+
+    //Resource Not Found
+    throw new Error(`Resource not found: ResRef: ${resRef} ResId: ${resId}`);
 
   }
 
@@ -183,6 +189,7 @@ export class ResourceLoader {
   }
 
   static getCache(resId: number, resRef: string): Uint8Array {
+    resRef = resRef.toLowerCase();
     if(ResourceLoader.CacheScopes[CacheScope.OVERRIDE].get(resId).has(resRef)){
       return ResourceLoader.CacheScopes[CacheScope.OVERRIDE].get(resId).get(resRef);
     }

--- a/src/loaders/ResourceLoader.ts
+++ b/src/loaders/ResourceLoader.ts
@@ -176,6 +176,7 @@ export class ResourceLoader {
   }
 
   static getResource(resId: number, resRef: string){
+    resRef = resRef.toLowerCase();
     if(typeof ResourceLoader.Resources[resId] !== 'undefined'){
       if(typeof ResourceLoader.Resources[resId][resRef] !== 'undefined'){
         return ResourceLoader.Resources[resId][resRef];

--- a/src/loaders/ResourceLoader.ts
+++ b/src/loaders/ResourceLoader.ts
@@ -162,8 +162,12 @@ export class ResourceLoader {
 
   }
 
-  static loadCachedResource(resId: number, resRef: string): Uint8Array {
-    return ResourceLoader.getCache(resId, resRef.toLocaleLowerCase());
+  static loadCachedResource(resId: number, resRef: string): Uint8Array | undefined {
+    const data = ResourceLoader.getCache(resId, resRef.toLocaleLowerCase());
+    if (!data?.length) {
+      return undefined;
+    }
+    return data;
   }
 
   static setResource(resId: number, resRef: string, opts = {}){

--- a/src/managers/CutsceneManager.ts
+++ b/src/managers/CutsceneManager.ts
@@ -78,6 +78,7 @@ export class CutsceneManager {
 
   static startConversation(dialog: DLGObject, owner: ModuleObject, listener: ModuleObject = GameState.PartyManager.party[0]) {
     console.log('CutsceneManager.startConversation', dialog, owner, listener);
+    GameState.ensureDialogAudio();
     this.active = true;
     this.cameraState.currentCameraAnimation = undefined;
     this.owner = owner;

--- a/src/managers/MenuManager.ts
+++ b/src/managers/MenuManager.ts
@@ -219,8 +219,8 @@ export class MenuManager {
       activeModals[i].update(delta);
     }
 
-    if(GameState.scene_gui.children.indexOf(GameState.scene_cursor_holder) != GameState.scene_gui.children.length){
-      GameState.scene_cursor_holder.remove(GameState.scene_gui);
+    if(GameState.scene_gui && GameState.scene_cursor_holder && GameState.scene_gui.children.indexOf(GameState.scene_cursor_holder) !== GameState.scene_gui.children.length - 1){
+      GameState.scene_gui.remove(GameState.scene_cursor_holder);
       GameState.scene_gui.add(GameState.scene_cursor_holder);
     }
 
@@ -332,8 +332,8 @@ export class MenuManager {
           KOTOR.MenuKeyboardEntry, KOTOR.InGameConfirm,
         ];
       }
-    }catch(e){
-      console.error(e);
+    }catch(e: any){
+      console.error(e?.stack || e);
     }
   }
   
@@ -396,8 +396,8 @@ export class MenuManager {
           KOTOR.CharGenQuickPanel, KOTOR.CharGenSkills,
         ];
       }
-    }catch(e){
-      console.error(e);
+    }catch(e: any){
+      console.error(e?.stack || e);
     }
   }
 
@@ -560,8 +560,8 @@ export class MenuManager {
       if(GameState.GameKey == GameEngineType.TSL){
         MenuManager.MenuPartySelection.childMenu = GameState.MenuManager.MenuTop;
       }
-    }catch(e){
-      console.error(e);
+    }catch(e: any){
+      console.error(e?.stack || e);
     }
   }
 

--- a/src/managers/VideoManager.test.ts
+++ b/src/managers/VideoManager.test.ts
@@ -1,0 +1,54 @@
+jest.mock('@/resource/BIKObject', () => ({
+  BIKObject: jest.fn(),
+}));
+
+jest.mock('@/GameState', () => ({
+  GameState: {},
+}));
+
+import { VideoManager } from '@/managers/VideoManager';
+
+describe('VideoManager.update', () => {
+  let updateVideoTextures: jest.Mock;
+
+  beforeEach(() => {
+    VideoManager.bikObject = null;
+    VideoManager.isPlaying = false;
+    updateVideoTextures = jest.fn();
+    (VideoManager as any).updateVideoTextures = updateVideoTextures;
+  });
+
+  it('does not read the current frame after movie completion cleanup', () => {
+    const bikObject = {
+      update: jest.fn(() => {
+        VideoManager.bikObject = null;
+        VideoManager.isPlaying = false;
+      }),
+      getCurrentFrame: jest.fn(),
+    };
+
+    VideoManager.bikObject = bikObject as any;
+    VideoManager.isPlaying = true;
+
+    expect(() => VideoManager.update(0.016)).not.toThrow();
+    expect(bikObject.update).toHaveBeenCalledWith(0.016);
+    expect(bikObject.getCurrentFrame).not.toHaveBeenCalled();
+    expect(updateVideoTextures).not.toHaveBeenCalled();
+  });
+
+  it('uploads the current frame when playback remains active', () => {
+    const frame = { width: 2, height: 2 };
+    const bikObject = {
+      update: jest.fn(),
+      getCurrentFrame: jest.fn(() => frame),
+    };
+
+    VideoManager.bikObject = bikObject as any;
+    VideoManager.isPlaying = true;
+
+    VideoManager.update(0.016);
+
+    expect(bikObject.getCurrentFrame).toHaveBeenCalled();
+    expect(updateVideoTextures).toHaveBeenCalledWith(frame);
+  });
+});

--- a/src/managers/VideoManager.ts
+++ b/src/managers/VideoManager.ts
@@ -337,9 +337,11 @@ export class VideoManager {
    * @param delta - Time delta in seconds (unused; BIK uses wall clock / audio clock)
    */
   static update(delta: number): void {
-    if (!this.bikObject || !this.isPlaying) return;
-    this.bikObject.update(delta);
-    const frame = this.bikObject.getCurrentFrame();
+    const bikObject = this.bikObject;
+    if (!bikObject || !this.isPlaying) return;
+    bikObject.update(delta);
+    if (this.bikObject !== bikObject || !this.isPlaying) return;
+    const frame = bikObject.getCurrentFrame();
     if (frame) {
       VideoManager.updateVideoTextures(frame);
     }

--- a/src/managers/VideoManager.ts
+++ b/src/managers/VideoManager.ts
@@ -275,6 +275,13 @@ export class VideoManager {
     this.playNextMovie();
   }
 
+  /** Dev/verification: drain queued intro movies without playing them. */
+  static clearMovieQueue(): void {
+    this.movieQueue = [];
+    this.onQueueComplete = undefined;
+    this.stopMovie();
+  }
+
   /**
    * Queue a movie to be played
    */

--- a/src/module/ModuleArea.ts
+++ b/src/module/ModuleArea.ts
@@ -2000,6 +2000,29 @@ export class ModuleArea extends ModuleObject {
     }
   }
 
+  /**
+   * After NWScript cache invalidation or HMR, clear stale script slots on area objects.
+   */
+  invalidateAreaObjectScriptSlots(){
+    const objectLists: ModuleObject[][] = [
+      this.triggers,
+      this.creatures,
+      this.doors,
+      this.placeables,
+      this.waypoints,
+      this.encounters,
+      this.stores,
+      this.sounds,
+      this.areaOfEffects,
+    ];
+    for(const objects of objectLists){
+      for(const object of objects){
+        object?.invalidateDisposedScriptSlots?.();
+      }
+    }
+    this.invalidateDisposedScriptSlots();
+  }
+
   async initAreaObjects(runSpawnScripts = false){
     for(let i = 0; i < this.doors.length; i++){
       if(this.doors[i] instanceof ModuleObject){

--- a/src/module/ModuleCreature.ts
+++ b/src/module/ModuleCreature.ts
@@ -4056,12 +4056,7 @@ export class ModuleCreature extends ModuleObject {
       console.error(e);
     }
 
-    if(this.template.RootNode.hasField('AmbientAnimState')){
-      const ambientAnim = this.template.getFieldByLabel('AmbientAnimState').getValue();
-      if(ambientAnim !== 0){
-        this.setAnimationState(ambientAnim);
-      }
-    } else if(this.template.RootNode.hasField('Animation')){
+    if(this.template.RootNode.hasField('Animation')){
       this.setAnimationState(
         this.template.getFieldByLabel('Animation').getValue()
       );

--- a/src/module/ModuleCreature.ts
+++ b/src/module/ModuleCreature.ts
@@ -3210,8 +3210,9 @@ export class ModuleCreature extends ModuleObject {
 
   async loadBody() {
     let appearance = this.creatureAppearance;
-    let bodyVariation: string = this.equipment.ARMOR?.getBodyVariation() || '';
-    let textureVariation: number = this.equipment.ARMOR?.getTextureVariation() || 1;
+    const armor = this.equipment.ARMOR;
+    let bodyVariation: string = (armor?.baseItem ? armor.getBodyVariation() : '') || '';
+    let textureVariation: number = armor?.getTextureVariation() || 1;
     const { model: bodyModel, texture: bodyTexture } = appearance.getBodyModelInfo(bodyVariation, textureVariation);
     this.bodyModel = bodyModel;
     this.bodyTexture = bodyTexture;
@@ -3893,6 +3894,12 @@ export class ModuleCreature extends ModuleObject {
             }else{
               equipped_item = new GameState.Module.ModuleArea.ModuleItem(GFFObject.FromStruct(strt));
             }
+
+            equipped_item.setPossessor(this);
+            if(!equipped_item.load() || !equipped_item.baseItem){
+              equipped_item.destroy();
+              continue;
+            }
             
             switch(slot_type){
               case ModuleCreatureArmorSlot.HEAD:
@@ -4037,7 +4044,7 @@ export class ModuleCreature extends ModuleObject {
       let item: ModuleItem = (this.equipment as any)[slotKey];
       if(item){
         item.setPossessor(this);
-        if(!item.load()){
+        if(!item.load() || !item.baseItem){
           (this.equipment as any)[slotKey] = undefined;
           item.destroy();
         }

--- a/src/module/ModuleCreature.ts
+++ b/src/module/ModuleCreature.ts
@@ -1114,7 +1114,7 @@ export class ModuleCreature extends ModuleObject {
           this.animationState.started = true;
           let aLooping = (!parseInt(this.animationState.animation.fireforget) && parseInt(this.animationState.animation.looping) == 1);
           this.model.playAnimation(this.animationState.animation.name?.toLowerCase(), aLooping);
-        }else{
+        }else if(!this.shouldHoldAmbientAnimationPose()){
           this.setAnimationState(ModuleCreatureAnimState.PAUSE);
         }
       }
@@ -1429,6 +1429,34 @@ export class ModuleCreature extends ModuleObject {
     this.animationState.index = animState;
     this.animationState.animation = this.animationConstantToAnimation(animState);
     this.animationState.started = false;
+  }
+
+  /** GIT ambient poses (dead/prone/sleep) must hold after fire-forget completes. */
+  shouldHoldAmbientAnimationPose(): boolean {
+    if(!this.animationState.animation){
+      return false;
+    }
+    const fireForget = !!parseInt(this.animationState.animation.fireforget);
+    if(!fireForget){
+      return false;
+    }
+    switch(this.animationState.index){
+      case ModuleCreatureAnimState.DEAD:
+      case ModuleCreatureAnimState.DEAD1:
+      case ModuleCreatureAnimState.DEAD_PRONE:
+      case ModuleCreatureAnimState.PRONE:
+      case ModuleCreatureAnimState.SLEEP:
+      case ModuleCreatureAnimState.KNOCKED_DOWN:
+      case ModuleCreatureAnimState.KNOCKED_DOWN2:
+      case ModuleCreatureAnimState.KNOCKED_DOWN_LP:
+      case ModuleCreatureAnimState.KNOCKED_DOWN2_LP:
+      case ModuleCreatureAnimState.PARALYZED:
+      case ModuleCreatureAnimState.COLLAPSE:
+      case ModuleCreatureAnimState.COLLAPSE_LP:
+        return true;
+      default:
+        return false;
+    }
   }
   
   resetAnimationState(){

--- a/src/module/ModuleCreature.ts
+++ b/src/module/ModuleCreature.ts
@@ -3767,7 +3767,9 @@ export class ModuleCreature extends ModuleObject {
       if(this.template.RootNode.hasField('SkillList')){
         let skills = this.template.RootNode.getFieldByLabel('SkillList').getChildStructs();
         for(let i = 0; i < skills.length; i++){
-          this.skills[i].rank = skills[i].getFieldByLabel('Rank').getValue();
+          if(this.skills[i]){
+            this.skills[i].rank = skills[i].getFieldByLabel('Rank').getValue();
+          }
         }
       }
 

--- a/src/module/ModuleCreature.ts
+++ b/src/module/ModuleCreature.ts
@@ -1419,6 +1419,11 @@ export class ModuleCreature extends ModuleObject {
   }
 
   setAnimationState(animState: ModuleCreatureAnimState){
+    if(animState === undefined || animState === null){ return; }
+
+    if(animState < 10000){
+      animState = this.getAnimationNameById(animState);
+    }
     if(!animState){ return; }
     
     this.animationState.index = animState;
@@ -2856,7 +2861,7 @@ export class ModuleCreature extends ModuleObject {
     const exptable2DA = GameState.TwoDAManager.datatables.get('exptable');
     if(exptable2DA){
       let nextLevelEXP = exptable2DA.rows[level];
-      if(this.getXP() >= parseInt(nextLevelEXP.xp)){
+      if(nextLevelEXP?.xp != null && this.getXP() >= parseInt(nextLevelEXP.xp)){
         return true;
       }
     }
@@ -2974,11 +2979,11 @@ export class ModuleCreature extends ModuleObject {
   }
 
   getHasSkill(value: number){
-    return this.skills[value].rank > 0;
+    return (this.skills[value]?.rank ?? 0) > 0;
   }
 
   getSkillLevel(value: number){
-    return this.skills[value].rank;
+    return this.skills[value]?.rank ?? 0;
   }
 
   getHasSpell(id = 0){
@@ -3282,13 +3287,24 @@ export class ModuleCreature extends ModuleObject {
     }
 
     const headDetails = GameState.SWRuleSet.heads[headId];
-    if(!headDetails){
+    if(!headDetails?.head){
+      console.warn('ModuleCreature.loadHead: missing head definition', this.getTag(), headId);
       return;
     }
 
     const headTexture = headDetails.getTextureGoodEvil(this.getGoodEvil());
     this.headModel = headDetails.head;
-    const mdl = await MDLLoader.loader.load(this.headModel);
+    let mdl;
+    try {
+      mdl = await MDLLoader.loader.load(this.headModel);
+    } catch (e) {
+      console.error('ModuleCreature.loadHead: MDL load failed', this.getTag(), this.headModel, e);
+      return;
+    }
+    if(!mdl){
+      console.warn('ModuleCreature.loadHead: empty MDL', this.getTag(), this.headModel);
+      return;
+    }
  
     const head = await OdysseyModel3D.FromMDL(mdl, {
       context: this.context,
@@ -4012,7 +4028,12 @@ export class ModuleCreature extends ModuleObject {
       console.error(e);
     }
 
-    if(this.template.RootNode.hasField('Animation')){
+    if(this.template.RootNode.hasField('AmbientAnimState')){
+      const ambientAnim = this.template.getFieldByLabel('AmbientAnimState').getValue();
+      if(ambientAnim !== 0){
+        this.setAnimationState(ambientAnim);
+      }
+    } else if(this.template.RootNode.hasField('Animation')){
       this.setAnimationState(
         this.template.getFieldByLabel('Animation').getValue()
       );

--- a/src/module/ModuleCreature.ts
+++ b/src/module/ModuleCreature.ts
@@ -4066,7 +4066,8 @@ export class ModuleCreature extends ModuleObject {
   loadItem( template: GFFObject ){
     let item = new GameState.Module.ModuleArea.ModuleItem(template);
     item.initProperties();
-    if(!item.load()){
+    if(!item.load() || !item.baseItem){
+      item.destroy();
       return;
     }
     let hasItem = this.getItemByTag(item.getTag());

--- a/src/module/ModuleItem.ts
+++ b/src/module/ModuleItem.ts
@@ -138,7 +138,7 @@ export class ModuleItem extends ModuleObject {
   }
 
   getBodyVariation(){
-    return this.baseItem.bodyVar;
+    return this.baseItem?.bodyVar ?? '';
   }
 
   getModelVariation(){

--- a/src/module/ModuleItem.ts
+++ b/src/module/ModuleItem.ts
@@ -154,15 +154,15 @@ export class ModuleItem extends ModuleObject {
   }
 
   getWeaponWield(): WeaponWield{
-    return this.baseItem.weaponWield;
+    return this.baseItem?.weaponWield ?? WeaponWield.INVALID;
   }
 
   getWeaponType(): WeaponType {
-    return this.baseItem.weaponType;
+    return this.baseItem?.weaponType;
   }
 
   isRangedWeapon(){
-    return this.baseItem.rangedWeapon;
+    return this.baseItem?.rangedWeapon ?? false;
   }
 
   isStolen(){

--- a/src/module/ModuleItem.ts
+++ b/src/module/ModuleItem.ts
@@ -497,7 +497,7 @@ export class ModuleItem extends ModuleObject {
     if(!this.loaded && this.getEquippedRes()){
       //Load template and merge fields
       const buffer = ResourceLoader.loadCachedResource(ResourceTypes['uti'], this.getEquippedRes());
-      if(buffer){
+      if(buffer?.length){
         const gff = new GFFObject(buffer);
         this.template.merge(gff);
         this.initProperties();
@@ -512,7 +512,7 @@ export class ModuleItem extends ModuleObject {
     }else if(!this.loaded && this.getInventoryRes()){
       //Load template and merge fields
       const buffer = ResourceLoader.loadCachedResource(ResourceTypes['uti'], this.getInventoryRes());
-      if(buffer){
+      if(buffer?.length){
         const gff = new GFFObject(buffer);
         this.template.merge(gff);
         this.initProperties();

--- a/src/module/ModuleObject.ts
+++ b/src/module/ModuleObject.ts
@@ -380,8 +380,54 @@ export class ModuleObject {
 
   getScriptInstance(scriptKey: ModuleObjectScript): NWScriptInstance | undefined {
     const script = this.scripts[scriptKey];
-    if(!script || !script.nwscript){ return undefined; }
-    return this.scripts[scriptKey].newInstance();
+    if(!script?.nwscript){ return undefined; }
+    return script.nwscript.newInstance(script);
+  }
+
+  /**
+   * Return a runnable script instance, reloading from the template resref when stale.
+   */
+  refreshScriptInstance(scriptKey: ModuleObjectScript): NWScriptInstance | undefined {
+    let instance = this.scripts[scriptKey];
+    if(instance && !instance._disposed && instance.getInstructionMap()?.size){
+      return instance;
+    }
+
+    if(instance){
+      delete this.scripts[scriptKey];
+    }
+
+    let resRef = instance?.name;
+    if(!resRef && this.template?.RootNode?.hasField(scriptKey)){
+      resRef = this.template.getFieldByLabel(scriptKey).getValue();
+    }
+    if(!resRef){
+      return undefined;
+    }
+
+    instance = GameState.NWScript.Load(resRef);
+    if(!instance){
+      return undefined;
+    }
+
+    instance.caller = this;
+    this.scripts[scriptKey] = instance;
+    return instance;
+  }
+
+  /**
+   * Drop disposed or otherwise unrunnable script instances from this object's slots.
+   */
+  invalidateDisposedScriptSlots(){
+    for(const key of Object.keys(this.scripts)){
+      const instance = this.scripts[key];
+      if(!(instance instanceof NWScriptInstance)){
+        continue;
+      }
+      if(instance._disposed || !instance.getInstructionMap()?.size){
+        delete this.scripts[key];
+      }
+    }
   }
 
   /**
@@ -1617,24 +1663,27 @@ export class ModuleObject {
       return;
     }
 
-    let onHeartbeat: NWScriptInstance;
+    let heartbeatKey: ModuleObjectScript | undefined;
     if(BitWise.InstanceOfObject(this, ModuleObjectType.ModuleCreature)){
-      onHeartbeat = this.scripts[ModuleObjectScript.CreatureOnHeartbeat];
+      heartbeatKey = ModuleObjectScript.CreatureOnHeartbeat;
     }else if(BitWise.InstanceOfObject(this, ModuleObjectType.ModulePlaceable)){
-      onHeartbeat = this.scripts[ModuleObjectScript.PlaceableOnHeartbeat];
+      heartbeatKey = ModuleObjectScript.PlaceableOnHeartbeat;
     }else if(BitWise.InstanceOfObject(this, ModuleObjectType.ModuleDoor)){
-      onHeartbeat = this.scripts[ModuleObjectScript.DoorOnHeartbeat];
+      heartbeatKey = ModuleObjectScript.DoorOnHeartbeat;
     }else if(BitWise.InstanceOfObject(this, ModuleObjectType.ModuleTrigger)){
-      onHeartbeat = this.scripts[ModuleObjectScript.TriggerOnHeartbeat];
+      heartbeatKey = ModuleObjectScript.TriggerOnHeartbeat;
     }else if(BitWise.InstanceOfObject(this, ModuleObjectType.ModuleEncounter)){
-      onHeartbeat = this.scripts[ModuleObjectScript.EncounterOnHeartbeat];
+      heartbeatKey = ModuleObjectScript.EncounterOnHeartbeat;
     }else if(BitWise.InstanceOfObject(this, ModuleObjectType.ModuleMGObstacle)){
-      onHeartbeat = this.scripts[ModuleObjectScript.MGObstacleOnHeartbeat];
+      heartbeatKey = ModuleObjectScript.MGObstacleOnHeartbeat;
     }else if(BitWise.InstanceOfObject(this, ModuleObjectType.ModuleMGEnemy)){
-      onHeartbeat = this.scripts[ModuleObjectScript.MGEnemyOnHeartbeat];
+      heartbeatKey = ModuleObjectScript.MGEnemyOnHeartbeat;
     }else if(BitWise.InstanceOfObject(this, ModuleObjectType.ModuleMGPlayer)){
-      onHeartbeat = this.scripts[ModuleObjectScript.MGPlayerOnHeartbeat];
+      heartbeatKey = ModuleObjectScript.MGPlayerOnHeartbeat;
     }
+    if(heartbeatKey === undefined){ return; }
+
+    const onHeartbeat = this.refreshScriptInstance(heartbeatKey);
     if(!onHeartbeat){ return; }
 
     onHeartbeat.run(this);
@@ -3777,8 +3826,8 @@ export class ModuleObject {
         if(this.scripts[key] instanceof NWScriptInstance){
           this.scripts[key].dispose();
         }
-        this.scripts = {};
       });
+      this.scripts = {};
 
       //Clear action queue
       if(this.actionQueue){

--- a/src/module/ModuleObject.ts
+++ b/src/module/ModuleObject.ts
@@ -1703,10 +1703,12 @@ export class ModuleObject {
    */
   onSpawn(runScript = true){
 
-    let onSpawn: NWScriptInstance;
+    let spawnKey: ModuleObjectScript | undefined;
     if(BitWise.InstanceOfObject(this, ModuleObjectType.ModuleCreature)){
-      onSpawn = this.scripts[ModuleObjectScript.CreatureOnSpawn];
+      spawnKey = ModuleObjectScript.CreatureOnSpawn;
     }
+
+    const onSpawn = spawnKey !== undefined ? this.refreshScriptInstance(spawnKey) : undefined;
 
     if(runScript && onSpawn){
       onSpawn.run(this, 0);

--- a/src/nwscript/NWScript.ts
+++ b/src/nwscript/NWScript.ts
@@ -350,7 +350,11 @@ export class NWScript {
     //If the script is already loaded, create a new instance and return it
     if( NWScript.scripts.has( scriptName ) ){
       const script = NWScript.scripts.get( scriptName );
-      return script.newInstance(parentInstance)
+      if(!script?.instructions?.size){
+        NWScript.scripts.delete(scriptName);
+      }else{
+        return script.newInstance(parentInstance);
+      }
     }
 
     //Fetch the script from the game resource list
@@ -362,6 +366,10 @@ export class NWScript {
     //Pass the buffer to a new script object
     const script = new NWScript( buffer );
     script.name = scriptName;
+    if(!script.instructions?.size){
+      console.warn(`NWScript.Load: Failed to parse NCS '${scriptName}'`);
+      return undefined;
+    }
     //Store a refernece to the script object inside the static "scripts" variable
     NWScript.scripts.set( scriptName, script );
 

--- a/src/nwscript/NWScriptDefK1.ts
+++ b/src/nwscript/NWScriptDefK1.ts
@@ -4906,12 +4906,15 @@ NWScriptDefK1.Actions = {
       for(let i = 0, len = inventory.length; i < len; i++){
         let item = inventory[i];
         let baseItem = item.baseItem;
+        if(!baseItem){
+          continue;
+        }
         if(
           baseItem.weaponWield == WeaponWield.STUN_BATON || 
           baseItem.weaponWield == WeaponWield.ONE_HANDED_SWORD || 
           baseItem.weaponWield == WeaponWield.TWO_HANDED_SWORD
         ){
-          if(!weapon){
+          if(!weapon || !weapon.baseItem){
             weapon = item;
           }else if((baseItem.dieToRoll * baseItem.numDice) > (weapon.baseItem.dieToRoll * weapon.baseItem.numDice)){
             weapon = item;
@@ -4920,10 +4923,14 @@ NWScriptDefK1.Actions = {
       }
 
       //If no melee found, equip ranged
-      if(!weapon){
+      if(!weapon || !weapon.baseItem){
+        weapon = undefined;
         for(let i = 0, len = inventory.length; i < len; i++){
           let item = inventory[i];
           let baseItem = item.baseItem;
+          if(!baseItem){
+            continue;
+          }
           if(
             baseItem.weaponWield == WeaponWield.BLASTER_PISTOL || 
             baseItem.weaponWield == WeaponWield.BLASTER_RIFLE || 
@@ -4938,6 +4945,10 @@ NWScriptDefK1.Actions = {
         }
       }
 
+      if(!weapon?.baseItem){
+        return false;
+      }
+      
       if(weapon == equipped){
         return false;
       }
@@ -4976,12 +4987,15 @@ NWScriptDefK1.Actions = {
       for(let i = 0, len = inventory.length; i < len; i++){
         const item = inventory[i];
         const baseItem = item.baseItem;
+        if(!baseItem){
+          continue;
+        }
         if(
           baseItem.weaponWield == WeaponWield.BLASTER_PISTOL || 
           baseItem.weaponWield == WeaponWield.BLASTER_RIFLE || 
           baseItem.weaponWield == WeaponWield.BLASTER_HEAVY
         ){
-          if(!weapon){
+          if(!weapon || !weapon.baseItem){
             weapon = item;
           }else if((baseItem.dieToRoll * baseItem.numDice) > (weapon.baseItem.dieToRoll * weapon.baseItem.numDice)){
             weapon = item;
@@ -4990,10 +5004,14 @@ NWScriptDefK1.Actions = {
       }
 
       //If no ranged found, equip melee
-      if(!weapon){
+      if(!weapon || !weapon.baseItem){
+        weapon = undefined;
         for(let i = 0, len = inventory.length; i < len; i++){
           const item = inventory[i];
           const baseItem = item.baseItem;
+          if(!baseItem){
+            continue;
+          }
           if(
             baseItem.weaponWield == WeaponWield.STUN_BATON || 
             baseItem.weaponWield == WeaponWield.ONE_HANDED_SWORD || 
@@ -5008,7 +5026,7 @@ NWScriptDefK1.Actions = {
         }
       }
       
-      if(!weapon){
+      if(!weapon?.baseItem){
         return;
       }
 

--- a/src/nwscript/NWScriptInstance.ts
+++ b/src/nwscript/NWScriptInstance.ts
@@ -110,6 +110,20 @@ export class NWScriptInstance {
     this._disposed = false;
   }
 
+  /**
+   * Resolve the instruction map for this instance.
+   * Instances share the parent NWScript map; dispose must not leave callers reading undefined.
+   */
+  getInstructionMap(): Map<number, NWScriptInstruction> | undefined {
+    if(this._disposed){
+      return undefined;
+    }
+    if(this.instructions?.size){
+      return this.instructions;
+    }
+    return this.nwscript?.instructions;
+  }
+
   newInstance(){
     return this.nwscript.newInstance();
   }
@@ -209,7 +223,6 @@ export class NWScriptInstance {
     }
 
     // this.nwscript = undefined;
-    this.instructions = undefined;
     this.init();
     this.dispatchEvent('dispose', this.uuid);
   }
@@ -267,6 +280,10 @@ export class NWScriptInstance {
   }
 
   run(caller: any = null, scriptVar = 0){
+    if(this._disposed || !this.getInstructionMap()?.size){
+      return;
+    }
+
     this.caller = caller;
     this.scriptVar = scriptVar;
 
@@ -322,10 +339,14 @@ export class NWScriptInstance {
   }
 
   getInstrAtOffset( offset: number ){
-    return this.instructions.get(offset);
+    return this.getInstructionMap()?.get(offset);
   }
 
   seekTo(address: number){
+    if(!this.getInstructionMap()){
+      this.currentInstruction = undefined;
+      return;
+    }
     this.seek = address;
     this.currentInstruction = this.getInstrAtOffset(address);
   }

--- a/src/odyssey/OdysseyWalkMesh.ts
+++ b/src/odyssey/OdysseyWalkMesh.ts
@@ -87,14 +87,17 @@ export class OdysseyWalkMesh {
 
       if(face.surfacemat == undefined){
         console.warn('OdysseyWalkMesh', 'Unknown surfacemat', face, OdysseyModelUtility.SURFACEMATERIALS);
+        face.blocksLineOfSight = false;
+        face.walkCheck = false;
+        face.walk = false;
+      } else {
+        face.blocksLineOfSight = face.surfacemat.lineOfSight;
+        face.walkCheck = face.surfacemat.walkCheck;
+        face.walk = face.surfacemat.walk;
       }
 
-      face.blocksLineOfSight = face.surfacemat.lineOfSight;
-      face.walkCheck = face.surfacemat.walkCheck;
-      face.walk = face.surfacemat.walk;
-
       //Is this face walkable
-      if(face.surfacemat.walk){
+      if(face.surfacemat?.walk){
         let walkIdx = this.walkableFaces.push(face) - 1;
         face.adjacent = this.walkableFacesEdgesAdjacencyMatrix[walkIdx];
         face.adjacentDiff = this.walkableFacesEdgesAdjacencyMatrixDiff[walkIdx];

--- a/src/resource/BIFObject.ts
+++ b/src/resource/BIFObject.ts
@@ -141,7 +141,7 @@ export class BIFObject {
     const len = KEYManager.Key.keys.length;
     for(let i = 0; i < len; i++){
       let key = KEYManager.Key.keys[i];
-      if(key.resRef == resRef && key.resType == ResType){
+      if(key.resRef.toLowerCase() == resRef.toLowerCase() && key.resType == ResType){
         for(let j = 0; j != this.resources.length; j++){
           let res = this.resources[j];
           if(res.Id == key.resId && res.resType == ResType){

--- a/src/resource/GFFObject.ts
+++ b/src/resource/GFFObject.ts
@@ -150,6 +150,9 @@ export class GFFObject {
   }
 
   parse(binary: Uint8Array, onComplete?: Function){
+    if (!binary?.length || binary.length < 56) {
+      throw new Error(`GFFObject: invalid or empty buffer (${binary?.length ?? 0} bytes)`);
+    }
     this.reader = new BinaryReader(binary);
 
     this.FileType = this.reader.readChars(4);
@@ -200,6 +203,10 @@ export class GFFObject {
       };
     }
     //End Fields
+
+    if (!this.tmpStructArray[0]) {
+      throw new Error('GFFObject: missing root struct (corrupt or truncated GFF)');
+    }
 
     try{
       this.RootNode = this.buildStruct(this.tmpStructArray[0]);

--- a/src/resource/KEYObject.ts
+++ b/src/resource/KEYObject.ts
@@ -72,7 +72,7 @@ export class KEYObject {
       this.reader.seek(this.bifs[i].filenameOffset);
       this.bifs[i].filename = this.reader.readChars(this.bifs[i].filenameSize)
         .replace(/\0[\s\S]*$/g,'')
-        .replace(/\\/g, path.sep);
+        .replace(/\\/g, '/');
     }
 
     this.reader.seek(this.offsetToKeyTable);

--- a/src/resource/KEYObject.ts
+++ b/src/resource/KEYObject.ts
@@ -70,7 +70,9 @@ export class KEYObject {
 
     for(let i = 0; i < this.bifCount; i++){
       this.reader.seek(this.bifs[i].filenameOffset);
-      this.bifs[i].filename = this.reader.readChars(this.bifs[i].filenameSize).replace(/\0[\s\S]*$/g,'').toLocaleString().split('\\').join(path.sep);
+      this.bifs[i].filename = this.reader.readChars(this.bifs[i].filenameSize)
+        .replace(/\0[\s\S]*$/g,'')
+        .replace(/\\/g, path.sep);
     }
 
     this.reader.seek(this.offsetToKeyTable);
@@ -86,6 +88,7 @@ export class KEYObject {
     this._keyByRefType = new Map();
     for(let i = 0; i < this.keys.length; i++){
       const key = this.keys[i];
+      key.resRef = key.resRef.toLowerCase();
       this._keyByResIdType.set(`${key.resId}:${key.resType}`, key);
       this._keyByRefType.set(`${key.resRef}:${key.resType}`, key);
     }
@@ -103,7 +106,7 @@ export class KEYObject {
   }
 
   getFileKey(ResRef: string, ResType: number): IKEYEntry | null {
-    return this._keyByRefType.get(`${ResRef}:${ResType}`) ?? null;
+    return this._keyByRefType.get(`${ResRef.toLowerCase()}:${ResType}`) ?? null;
   }
 
   getFileKeyByRes(Res: IBIFResource): IKEYEntry {

--- a/src/resource/RIMObject.ts
+++ b/src/resource/RIMObject.ts
@@ -158,8 +158,10 @@ export class RIMObject {
       await this.readHeaderFromFileDecriptor(fd);
     }catch(e){
       console.error('RIM Header Read', e);
+      throw e;
+    }finally{
+      await GameFileSystem.close(fd);
     }
-    await GameFileSystem.close(fd);
   }
 
   getResourceInfo(resRef: string, resType: number): IRIMResource|undefined {

--- a/src/three/odyssey/OdysseyModel3D.ts
+++ b/src/three/odyssey/OdysseyModel3D.ts
@@ -185,6 +185,11 @@ export class OdysseyModel3D extends OdysseyObject3D {
 
   attachHead(head: OdysseyModel3D){
 
+    if(!this.headhook){
+      console.error('OdysseyModel3D.attachHead: missing headhook on body model');
+      return;
+    }
+
     const rootNode = head.getRootOdysseyNode();
     // console.log('attachHead', rootNode);
     let remapper: [OdysseyObject3D, OdysseyObject3D][] = [];

--- a/src/utility/GameFileSystem.ts
+++ b/src/utility/GameFileSystem.ts
@@ -3,6 +3,19 @@ import * as fs from "fs";
 import { ApplicationProfile } from "@/utility/ApplicationProfile";
 import { ApplicationEnvironment } from "@/enums/ApplicationEnvironment";
 import { IGameFileSystemReadDirOptions } from "@/interface/filesystem/IGameFileSystemReadDirOptions";
+import {
+  devGameClose,
+  devGameExists,
+  devGameOpen,
+  devGameRead,
+  devGameReadFile,
+  devGameReaddir,
+  devGameVirtualMkdir,
+  devGameVirtualRmdir,
+  devGameVirtualWrite,
+  isDevGameFileBackendActive,
+  isDevGameFileHandle,
+} from "@/dev/DevGameFileBackend";
 declare const dialog: any;
 
 const webHandleHasRemove = typeof (FileSystemFileHandle.prototype as any).remove === 'function'
@@ -45,6 +58,9 @@ export class GameFileSystem {
 
   //filepath should be relative to the rootDirectoryPath or ApplicationProfile.directory
   static async open(filepath: string, mode: 'r'|'w' = 'r'): Promise<any> {
+    if (isDevGameFileBackendActive()) {
+      return devGameOpen(filepath, mode);
+    }
     if(ApplicationProfile.ENV == ApplicationEnvironment.ELECTRON){
       return new Promise<number>( (resolve, reject) => {
         fs.open(path.join(ApplicationProfile.directory, filepath), (err, fd) => {
@@ -78,6 +94,12 @@ export class GameFileSystem {
   }
 
   static async read(handle: FileSystemFileHandle|number, output: Uint8Array, offset: number, length: number, position: number){
+    if (isDevGameFileBackendActive()) {
+      if (!isDevGameFileHandle(handle)) {
+        throw new Error('DevGameFileHandle expected but one was not supplied!');
+      }
+      return devGameRead(handle, output, offset, length, position);
+    }
     if(ApplicationProfile.ENV == ApplicationEnvironment.ELECTRON){
       return new Promise<Uint8Array>( (resolve, reject) => {
         fs.read(handle as number, output, offset, length, position, (err, bytes, buffer) => {
@@ -104,6 +126,12 @@ export class GameFileSystem {
   }
 
   static async close(handle: FileSystemFileHandle|number){
+    if (isDevGameFileBackendActive()) {
+      if (isDevGameFileHandle(handle)) {
+        return devGameClose(handle);
+      }
+      return;
+    }
     if(ApplicationProfile.ENV == ApplicationEnvironment.ELECTRON){
       return new Promise<void>( (resolve, reject) => {
         fs.close(handle as number, () => {
@@ -119,6 +147,9 @@ export class GameFileSystem {
   //filepath should be relative to the rootDirectoryPath or ApplicationProfile.directory
   static async readFile(filepath: string, options: any = {}): Promise<Uint8Array> {
     // console.log('readFile', filepath);
+    if (isDevGameFileBackendActive()) {
+      return devGameReadFile(filepath);
+    }
     if(ApplicationProfile.ENV == ApplicationEnvironment.ELECTRON){
       return new Promise<Uint8Array>( (resolve, reject) => {
         fs.readFile(path.join(ApplicationProfile.directory, filepath), options, (err, buffer) => {
@@ -137,6 +168,10 @@ export class GameFileSystem {
 
   //filepath should be relative to the rootDirectoryPath or ApplicationProfile.directory
   static async writeFile(filepath: string, data: Uint8Array): Promise<boolean> {
+    if (isDevGameFileBackendActive()) {
+      devGameVirtualWrite(filepath, data);
+      return true;
+    }
     return new Promise<boolean>( async (resolve, reject) => {
       if(ApplicationProfile.ENV == ApplicationEnvironment.ELECTRON){
         fs.writeFile(path.join(ApplicationProfile.directory, filepath), data, (err) => {
@@ -175,6 +210,9 @@ export class GameFileSystem {
   static async readdir(
     dirpath: string, options: IGameFileSystemReadDirOptions = {}, files: any[] = []
   ): Promise<string[]> {
+    if (isDevGameFileBackendActive()) {
+      return devGameReaddir(dirpath, options);
+    }
     if(ApplicationProfile.ENV == ApplicationEnvironment.ELECTRON){
       return await this.readdir_fs(dirpath, options, files);
     }else{
@@ -316,6 +354,9 @@ export class GameFileSystem {
   }
 
   static async mkdir(dirPath: string, opts: IGameFileSystemReadDirOptions = {}){
+    if (isDevGameFileBackendActive()) {
+      return devGameVirtualMkdir(dirPath, !!opts.recursive);
+    }
     return new Promise<boolean>( async (resolve, reject) => {
       dirPath = dirPath.trim();
       if(ApplicationProfile.ENV == ApplicationEnvironment.ELECTRON){
@@ -362,6 +403,9 @@ export class GameFileSystem {
   }
 
   static async rmdir(dirPath: string, opts: IGameFileSystemReadDirOptions = {}){
+    if (isDevGameFileBackendActive()) {
+      return devGameVirtualRmdir(dirPath, !!opts.recursive);
+    }
     return new Promise<boolean>( async (resolve, reject) => {
       dirPath = dirPath.trim();
       if(ApplicationProfile.ENV == ApplicationEnvironment.ELECTRON){
@@ -415,6 +459,10 @@ export class GameFileSystem {
 
   static exists(dirOrFilePath: string): Promise<boolean> {
     return new Promise<boolean>( async (resolve, reject) => {
+      if (isDevGameFileBackendActive()) {
+        resolve(await devGameExists(dirOrFilePath));
+        return;
+      }
       if(ApplicationProfile.ENV == ApplicationEnvironment.ELECTRON){
         fs.stat(path.join(ApplicationProfile.directory, dirOrFilePath), (err, stats) => {
           if(err){

--- a/src/utility/GameFileSystem.ts
+++ b/src/utility/GameFileSystem.ts
@@ -79,9 +79,7 @@ export class GameFileSystem {
       const filename = dirs.pop();
       const dirHandle = await this.resolveFilePathDirectoryHandle(filepath);
       if(dirHandle){
-        const file = await dirHandle.getFileHandle(filename, {
-          create: false
-        });
+        const file = await this.getFileHandleInsensitive(dirHandle, filename!);
         if(file){
           return file;
         }else{
@@ -482,7 +480,7 @@ export class GameFileSystem {
           if(details.ext){
             let handle = await this.resolveFilePathDirectoryHandle(dirOrFilePath);
             if(handle){
-              let fileHandle = await handle.getFileHandle(details.base);
+              let fileHandle = await this.getFileHandleInsensitive(handle, details.base);
               if(fileHandle){
                 resolve(true);
                 return;
@@ -571,6 +569,26 @@ export class GameFileSystem {
       return undefined;
     }else{
       return await window.showSaveFilePicker({});
+    }
+  }
+
+  private static async getFileHandleInsensitive(
+    dirHandle: FileSystemDirectoryHandle,
+    filename: string,
+    create = false,
+  ): Promise<FileSystemFileHandle> {
+    try {
+      return await dirHandle.getFileHandle(filename, { create });
+    } catch (e) {
+      if (create) {
+        throw e;
+      }
+      for await (const entry of dirHandle.values()) {
+        if (entry.kind === 'file' && entry.name.toLowerCase() === filename.toLowerCase()) {
+          return entry as FileSystemFileHandle;
+        }
+      }
+      throw e;
     }
   }
 

--- a/src/utility/GameFileSystem.ts
+++ b/src/utility/GameFileSystem.ts
@@ -160,9 +160,11 @@ export class GameFileSystem {
     }else{
       const file = await this.open(filepath);
       if(!file) throw new Error('Failed to read file');
-      
-      let handle = await file.getFile();
-      return new Uint8Array( await handle.arrayBuffer() );
+      if (isDevGameFileHandle(file)) {
+        return devGameReadFile(filepath);
+      }
+      const handle = await file.getFile();
+      return new Uint8Array(await handle.arrayBuffer());
     }
   }
 

--- a/src/utility/GameFileSystem.ts
+++ b/src/utility/GameFileSystem.ts
@@ -648,6 +648,12 @@ export class GameFileSystem {
   static directoryCache: Map<string, FileSystemDirectoryHandle> = new Map();
   static directoryInflight: Map<string, Promise<FileSystemDirectoryHandle>> = new Map();
 
+  /** Drop cached FS Access handles (dev middleware mode or stale profile recovery). */
+  static clearDirectoryHandleCache(): void {
+    this.directoryCache.clear();
+    this.directoryInflight.clear();
+  }
+
   private static async resolveFilePathDirectoryHandle(filepath: string): Promise<FileSystemDirectoryHandle> {
     if(ApplicationProfile.directoryHandle){
       const dirs = filepath.split('/');

--- a/tsconfig.electron.json
+++ b/tsconfig.electron.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "ignoreDeprecations": "6.0",
     "paths": {
       "@/*": ["src/*"]
     },

--- a/tsconfig.electron.json
+++ b/tsconfig.electron.json
@@ -1,6 +1,10 @@
 { 
   "compilerOptions": {
     "baseUrl": ".",
+    "ignoreDeprecations": "6.0",
+    "paths": {
+      "@/*": ["src/*"]
+    },
     "target": "ES6",
     "module": "CommonJS",
     "moduleResolution": "node",

--- a/tsconfig.electron.json
+++ b/tsconfig.electron.json
@@ -1,4 +1,4 @@
-{ 
+{
   "compilerOptions": {
     "baseUrl": ".",
     "ignoreDeprecations": "6.0",
@@ -13,15 +13,14 @@
     "experimentalDecorators": true,
     "removeComments": false,
     "noImplicitAny": false,
-    // "suppressImplicitAnyIndexErrors": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "types": [
       "electron",
-      "node",
+      "node"
     ],
     "outDir": "dist/electron"
   },
-  "exclude": [ "node_modules" ],
+  "exclude": ["node_modules"],
   "include": ["src/electron/index.ts", "src/electron/preload.ts"]
 }

--- a/webpack/Game.hmr.js
+++ b/webpack/Game.hmr.js
@@ -51,6 +51,8 @@ module.exports = {
       ],
     },
     client: {
+      // Follow the page URL port/host so HMR works when KOTOR_DEV_PORT != default.
+      webSocketURL: 'auto://0.0.0.0:0/ws',
       // Keep compile errors visible; don't block the canvas when in-game runtime throws.
       overlay: {
         errors: true,
@@ -66,6 +68,12 @@ module.exports = {
         });
         // eslint-disable-next-line no-console
         console.log(`[KotOR dev] Serving game files from ${KOTOR_DEV_GAME_DIR}`);
+      } else {
+        // eslint-disable-next-line no-console
+        console.warn(
+          '[KotOR dev] KOTOR_DEV_GAME_DIR is unset — browser will use File System Access API.\n'
+          + '  For Linux/real installs: KOTOR_DEV_GAME_DIR="/path/to/swkotor" KOTOR_DEV_PORT=8130 npm run webpack:serve-hmr',
+        );
       }
       return middlewares;
     },

--- a/webpack/Game.hmr.js
+++ b/webpack/Game.hmr.js
@@ -1,0 +1,101 @@
+const path = require('path');
+const webpack = require('webpack');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+const CopyPlugin = require('copy-webpack-plugin');
+const {
+  ROOT,
+  cssRule,
+  scssRule,
+  assetRules,
+  commonStats,
+  commonResolve,
+  makeDefinePlugin,
+  makeWebpackBar,
+} = require('./common');
+
+const DEV_PORT = Number(process.env.KOTOR_DEV_PORT || 8080);
+
+/**
+ * Game client dev server with HMR. Inlines the KotOR engine module graph so
+ * gameplay TypeScript can hot-swap without a full page reload.
+ */
+module.exports = {
+  mode: 'development',
+  entry: {
+    game: ['./src/apps/game/index.tsx'],
+  },
+  stats: commonStats,
+  devtool: 'eval-source-map',
+  devServer: {
+    hot: true,
+    port: DEV_PORT,
+    host: 'localhost',
+    open: ['/game/?key=kotor'],
+    static: [
+      {
+        directory: path.resolve(ROOT, 'dist'),
+        publicPath: '/',
+        watch: true,
+      },
+    ],
+    devMiddleware: {
+      publicPath: '/game/',
+    },
+    historyApiFallback: {
+      rewrites: [
+        { from: /^\/game\/?$/, to: '/game/index.html' },
+        { from: /^\/game\/.*/, to: '/game/index.html' },
+      ],
+    },
+    client: {
+      overlay: true,
+    },
+  },
+  module: {
+    rules: [
+      {
+        test: /\.tsx?$/,
+        loader: 'esbuild-loader',
+        options: {
+          loader: 'tsx',
+          target: 'esnext',
+          tsconfig: 'tsconfig.game.json',
+        },
+        exclude: /node_modules/,
+      },
+      cssRule,
+      scssRule,
+      ...assetRules,
+    ],
+  },
+  plugins: [
+    new webpack.HotModuleReplacementPlugin(),
+    makeWebpackBar('Game HMR', 'cyan'),
+    makeDefinePlugin(),
+    new HtmlWebpackPlugin({
+      filename: 'index.html',
+      template: 'src/apps/game/index.hmr.html',
+    }),
+    new CopyPlugin({
+      patterns: [{ from: 'src/assets/icons/icon.ico', to: 'favicon.ico' }],
+    }),
+  ],
+  resolve: commonResolve,
+  externals: {
+    fs: 'window.fs',
+    three: 'THREE',
+  },
+  output: {
+    filename: '[name].js',
+    path: path.resolve(ROOT, 'dist/game'),
+    publicPath: '/game/',
+    globalObject: 'this',
+    assetModuleFilename: (pathData) => {
+      const { filename } = pathData;
+      if (filename.endsWith('.ts')) {
+        return '[name].js';
+      }
+      return '[name][ext]';
+    },
+  },
+};

--- a/webpack/Game.hmr.js
+++ b/webpack/Game.hmr.js
@@ -14,6 +14,8 @@ const {
 } = require('./common');
 
 const DEV_PORT = Number(process.env.KOTOR_DEV_PORT || 8080);
+const KOTOR_DEV_GAME_DIR = process.env.KOTOR_DEV_GAME_DIR || '';
+const { createDevGameFsMiddleware } = require('./dev-game-fs-middleware');
 
 /**
  * Game client dev server with HMR. Inlines the KotOR engine module graph so
@@ -51,6 +53,17 @@ module.exports = {
     client: {
       overlay: true,
     },
+    setupMiddlewares: (middlewares, devServer) => {
+      if (KOTOR_DEV_GAME_DIR) {
+        middlewares.unshift({
+          name: 'kotor-dev-game-fs',
+          middleware: createDevGameFsMiddleware(KOTOR_DEV_GAME_DIR),
+        });
+        // eslint-disable-next-line no-console
+        console.log(`[KotOR dev] Serving game files from ${KOTOR_DEV_GAME_DIR}`);
+      }
+      return middlewares;
+    },
   },
   module: {
     rules: [
@@ -73,6 +86,9 @@ module.exports = {
     new webpack.HotModuleReplacementPlugin(),
     makeWebpackBar('Game HMR', 'cyan'),
     makeDefinePlugin(),
+    new webpack.DefinePlugin({
+      'process.env.KOTOR_DEV_GAME_DIR': JSON.stringify(KOTOR_DEV_GAME_DIR),
+    }),
     new HtmlWebpackPlugin({
       filename: 'index.html',
       template: 'src/apps/game/index.hmr.html',

--- a/webpack/Game.hmr.js
+++ b/webpack/Game.hmr.js
@@ -29,7 +29,8 @@ module.exports = {
   devServer: {
     hot: true,
     port: DEV_PORT,
-    host: 'localhost',
+    // Bind IPv4 explicitly so Puppeteer/curl using 127.0.0.1 can reach the server.
+    host: '0.0.0.0',
     open: ['/game/?key=kotor'],
     static: [
       {

--- a/webpack/Game.hmr.js
+++ b/webpack/Game.hmr.js
@@ -51,7 +51,12 @@ module.exports = {
       ],
     },
     client: {
-      overlay: true,
+      // Keep compile errors visible; don't block the canvas when in-game runtime throws.
+      overlay: {
+        errors: true,
+        warnings: false,
+        runtimeErrors: false,
+      },
     },
     setupMiddlewares: (middlewares, devServer) => {
       if (KOTOR_DEV_GAME_DIR) {

--- a/webpack/Game.hmr.js
+++ b/webpack/Game.hmr.js
@@ -78,7 +78,11 @@ module.exports = {
       template: 'src/apps/game/index.hmr.html',
     }),
     new CopyPlugin({
-      patterns: [{ from: 'src/assets/icons/icon.ico', to: 'favicon.ico' }],
+      patterns: [
+        { from: 'src/assets/icons/icon.ico', to: 'favicon.ico' },
+        // Served from devServer static root (dist/) — required on fresh clones / CI without a prod build.
+        { from: 'node_modules/three/build/three.min.js', to: '../three.min.js' },
+      ],
     }),
   ],
   resolve: commonResolve,

--- a/webpack/dev-game-fs-middleware.js
+++ b/webpack/dev-game-fs-middleware.js
@@ -32,6 +32,18 @@ function createDevGameFsMiddleware(gameDir) {
     realRoot = root;
   }
 
+  function isWithinRoot(candidate) {
+    if (candidate === root || candidate === realRoot) {
+      return true;
+    }
+    try {
+      const realCandidate = fs.realpathSync(candidate);
+      return realCandidate === realRoot || realCandidate.startsWith(realRoot + path.sep);
+    } catch {
+      return candidate === root || candidate.startsWith(root + path.sep);
+    }
+  }
+
   function resolveSafe(relativePath) {
     const normalized = String(relativePath || '')
       .replace(/\\/g, '/')
@@ -56,6 +68,63 @@ function createDevGameFsMiddleware(gameDir) {
     }
   }
 
+  /** Case-insensitive segment walk for Linux dev installs (movies vs Movies, etc.). */
+  function resolveSafeCaseInsensitive(relativePath) {
+    const direct = resolveSafe(relativePath);
+    if (direct && fs.existsSync(direct)) {
+      return direct;
+    }
+
+    const normalized = String(relativePath || '')
+      .replace(/\\/g, '/')
+      .replace(/\.\.\//g, '')
+      .replace(/\.\./g, '')
+      .replace(/^\/+/, '');
+    const parts = normalized.split('/').filter(Boolean);
+    if (!parts.length) {
+      return isWithinRoot(root) ? root : null;
+    }
+
+    let current = root;
+    for (const part of parts) {
+      let entries;
+      try {
+        entries = fs.readdirSync(current);
+      } catch {
+        return null;
+      }
+      const match = entries.find((entry) => entry.toLowerCase() === part.toLowerCase());
+      if (!match) {
+        return null;
+      }
+      current = path.join(current, match);
+      if (!isWithinRoot(current)) {
+        return null;
+      }
+    }
+
+    try {
+      const realFull = fs.realpathSync(current);
+      if (realFull !== realRoot && !realFull.startsWith(realRoot + path.sep)) {
+        return null;
+      }
+      return realFull;
+    } catch (err) {
+      if (err && err.code === 'ENOENT') {
+        return isWithinRoot(current) ? current : null;
+      }
+      return null;
+    }
+  }
+
+  function resolveForAction(relativePath) {
+    const caseResolved = resolveSafeCaseInsensitive(relativePath);
+    if (caseResolved) {
+      return caseResolved;
+    }
+    return resolveSafe(relativePath);
+  }
+
   return (req, res, next) => {
     const url = new URL(req.url, 'http://localhost');
     if (!url.pathname.startsWith('/__kotor_dev_fs')) {
@@ -71,7 +140,7 @@ function createDevGameFsMiddleware(gameDir) {
 
     const action = url.searchParams.get('action') || 'read';
     const relPath = url.searchParams.get('path') || '';
-    const full = resolveSafe(relPath);
+    const full = resolveForAction(relPath);
     if (!full) {
       res.statusCode = 403;
       res.end('Forbidden');

--- a/webpack/dev-game-fs-middleware.js
+++ b/webpack/dev-game-fs-middleware.js
@@ -8,6 +8,17 @@ const path = require('path');
  */
 const MAX_WHOLE_FILE_BYTES = 64 * 1024 * 1024;
 
+const LOCALHOST_ADDRESSES = new Set([
+  '127.0.0.1',
+  '::1',
+  '::ffff:127.0.0.1',
+]);
+
+function isLocalhostRequest(req) {
+  const addr = req?.socket?.remoteAddress || '';
+  return LOCALHOST_ADDRESSES.has(addr);
+}
+
 /**
  * Dev-only middleware: expose a local KOTOR install to the browser game client
  * when File System Access API directory picking is unavailable (automation/HMR).
@@ -49,6 +60,12 @@ function createDevGameFsMiddleware(gameDir) {
     const url = new URL(req.url, 'http://localhost');
     if (!url.pathname.startsWith('/__kotor_dev_fs')) {
       next();
+      return;
+    }
+
+    if (!isLocalhostRequest(req)) {
+      res.statusCode = 403;
+      res.end('Forbidden: dev game FS is localhost-only');
       return;
     }
 

--- a/webpack/dev-game-fs-middleware.js
+++ b/webpack/dev-game-fs-middleware.js
@@ -7,6 +7,12 @@ const path = require('path');
  */
 function createDevGameFsMiddleware(gameDir) {
   const root = path.resolve(gameDir);
+  let realRoot;
+  try {
+    realRoot = fs.realpathSync(root);
+  } catch {
+    realRoot = root;
+  }
 
   function resolveSafe(relativePath) {
     const normalized = String(relativePath || '')
@@ -16,7 +22,18 @@ function createDevGameFsMiddleware(gameDir) {
     if (full !== root && !full.startsWith(root + path.sep)) {
       return null;
     }
-    return full;
+    try {
+      const realFull = fs.realpathSync(full);
+      if (realFull !== realRoot && !realFull.startsWith(realRoot + path.sep)) {
+        return null;
+      }
+      return realFull;
+    } catch (err) {
+      if (err && err.code === 'ENOENT') {
+        return full;
+      }
+      return null;
+    }
   }
 
   return (req, res, next) => {

--- a/webpack/dev-game-fs-middleware.js
+++ b/webpack/dev-game-fs-middleware.js
@@ -1,0 +1,94 @@
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * Dev-only middleware: expose a local KOTOR install to the browser game client
+ * when File System Access API directory picking is unavailable (automation/HMR).
+ */
+function createDevGameFsMiddleware(gameDir) {
+  const root = path.resolve(gameDir);
+
+  function resolveSafe(relativePath) {
+    const normalized = String(relativePath || '')
+      .replace(/\\/g, '/')
+      .replace(/^\/+/, '');
+    const full = path.resolve(root, normalized);
+    if (full !== root && !full.startsWith(root + path.sep)) {
+      return null;
+    }
+    return full;
+  }
+
+  return (req, res, next) => {
+    const url = new URL(req.url, 'http://localhost');
+    if (!url.pathname.startsWith('/__kotor_dev_fs')) {
+      next();
+      return;
+    }
+
+    const action = url.searchParams.get('action') || 'read';
+    const relPath = url.searchParams.get('path') || '';
+    const full = resolveSafe(relPath);
+    if (!full) {
+      res.statusCode = 403;
+      res.end('Forbidden');
+      return;
+    }
+
+    if (action === 'exists') {
+      fs.stat(full, (err, stats) => {
+        res.setHeader('Content-Type', 'application/json');
+        res.end(JSON.stringify({ exists: !err && stats.isFile() }));
+      });
+      return;
+    }
+
+    if (action === 'stat') {
+      fs.stat(full, (err, stats) => {
+        res.setHeader('Content-Type', 'application/json');
+        if (err) {
+          res.end(JSON.stringify({ exists: false, isDirectory: false, isFile: false }));
+          return;
+        }
+        res.end(JSON.stringify({
+          exists: true,
+          isDirectory: stats.isDirectory(),
+          isFile: stats.isFile(),
+        }));
+      });
+      return;
+    }
+
+    if (action === 'readdir') {
+      fs.readdir(full, { withFileTypes: true }, (err, entries) => {
+        if (err) {
+          res.statusCode = 404;
+          res.end('Not found');
+          return;
+        }
+        const names = entries.map((e) => (e.isDirectory() ? `${e.name}/` : e.name));
+        res.setHeader('Content-Type', 'application/json');
+        res.end(JSON.stringify({ entries: names }));
+      });
+      return;
+    }
+
+    if (action === 'read') {
+      fs.readFile(full, (err, data) => {
+        if (err) {
+          res.statusCode = 404;
+          res.end('Not found');
+          return;
+        }
+        res.setHeader('Content-Type', 'application/octet-stream');
+        res.end(data);
+      });
+      return;
+    }
+
+    res.statusCode = 400;
+    res.end('Unknown action');
+  };
+}
+
+module.exports = { createDevGameFsMiddleware };

--- a/webpack/dev-game-fs-middleware.js
+++ b/webpack/dev-game-fs-middleware.js
@@ -17,6 +17,8 @@ function createDevGameFsMiddleware(gameDir) {
   function resolveSafe(relativePath) {
     const normalized = String(relativePath || '')
       .replace(/\\/g, '/')
+      .replace(/\.\.\//g, '')
+      .replace(/\.\./g, '')
       .replace(/^\/+/, '');
     const full = path.resolve(root, normalized);
     if (full !== root && !full.startsWith(root + path.sep)) {

--- a/webpack/dev-game-fs-middleware.js
+++ b/webpack/dev-game-fs-middleware.js
@@ -2,6 +2,13 @@ const fs = require('fs');
 const path = require('path');
 
 /**
+ * Upper bound for whole-file (non-ranged) reads. Large archives (BIF/RIM) must be
+ * read via ranged requests; buffering a multi-hundred-MB file whole would OOM both
+ * this server and the browser. Ranged reads are unaffected by this limit.
+ */
+const MAX_WHOLE_FILE_BYTES = 64 * 1024 * 1024;
+
+/**
  * Dev-only middleware: expose a local KOTOR install to the browser game client
  * when File System Access API directory picking is unavailable (automation/HMR).
  */
@@ -73,6 +80,7 @@ function createDevGameFsMiddleware(gameDir) {
           exists: true,
           isDirectory: stats.isDirectory(),
           isFile: stats.isFile(),
+          size: stats.size,
         }));
       });
       return;
@@ -93,14 +101,71 @@ function createDevGameFsMiddleware(gameDir) {
     }
 
     if (action === 'read') {
-      fs.readFile(full, (err, data) => {
-        if (err) {
+      const offsetParam = url.searchParams.get('offset');
+      const lengthParam = url.searchParams.get('length');
+      const hasRange = offsetParam !== null && lengthParam !== null;
+      const offset = hasRange ? Number(offsetParam) : 0;
+      const length = hasRange ? Number(lengthParam) : null;
+
+      if (hasRange && (!Number.isFinite(offset) || !Number.isFinite(length) || offset < 0 || length < 0)) {
+        res.statusCode = 400;
+        res.end('Invalid offset or length');
+        return;
+      }
+
+      if (hasRange && length > MAX_WHOLE_FILE_BYTES) {
+        res.statusCode = 413;
+        res.end(
+          `Requested range length ${length} exceeds ${MAX_WHOLE_FILE_BYTES}. Read large archives in smaller windows.`,
+        );
+        return;
+      }
+
+      if (hasRange) {
+        fs.open(full, 'r', (openErr, fd) => {
+          if (openErr) {
+            res.statusCode = 404;
+            res.end('Not found');
+            return;
+          }
+          const buffer = Buffer.alloc(length);
+          fs.read(fd, buffer, 0, length, offset, (readErr, bytesRead) => {
+            fs.close(fd, () => {
+              if (readErr) {
+                res.statusCode = 500;
+                res.end('Read failed');
+                return;
+              }
+              res.setHeader('Content-Type', 'application/octet-stream');
+              res.end(buffer.subarray(0, bytesRead));
+            });
+          });
+        });
+        return;
+      }
+
+      fs.stat(full, (statErr, stats) => {
+        if (statErr) {
           res.statusCode = 404;
           res.end('Not found');
           return;
         }
-        res.setHeader('Content-Type', 'application/octet-stream');
-        res.end(data);
+        if (stats.size > MAX_WHOLE_FILE_BYTES) {
+          res.statusCode = 413;
+          res.end(
+            `File too large for whole-file read: ${stats.size} bytes exceeds ${MAX_WHOLE_FILE_BYTES}. Use a ranged read (offset/length).`,
+          );
+          return;
+        }
+        fs.readFile(full, (err, data) => {
+          if (err) {
+            res.statusCode = 404;
+            res.end('Not found');
+            return;
+          }
+          res.setHeader('Content-Type', 'application/octet-stream');
+          res.end(data);
+        });
       });
       return;
     }

--- a/webpack/dev-game-fs-middleware.test.ts
+++ b/webpack/dev-game-fs-middleware.test.ts
@@ -14,7 +14,11 @@ interface InvokeResult {
   passedThrough?: boolean;
 }
 
-function invoke(middleware: (req: unknown, res: unknown, next: () => void) => void, url: string): Promise<InvokeResult> {
+function invoke(
+  middleware: (req: unknown, res: unknown, next: () => void) => void,
+  url: string,
+  remoteAddress = '127.0.0.1',
+): Promise<InvokeResult> {
   return new Promise((resolve) => {
     const res = {
       statusCode: 200,
@@ -26,7 +30,7 @@ function invoke(middleware: (req: unknown, res: unknown, next: () => void) => vo
         resolve({ statusCode: this.statusCode, headers: this.headers, body: data });
       },
     };
-    const req = { url };
+    const req = { url, socket: { remoteAddress } };
     middleware(req, res, () => resolve({ statusCode: 0, headers: {}, body: undefined, passedThrough: true }));
   });
 }
@@ -119,5 +123,15 @@ describe('dev-game-fs-middleware', () => {
   it('rejects a ranged read with negative offset/length (400)', async () => {
     const result = await invoke(middleware, '/__kotor_dev_fs?action=read&path=chitin.key&offset=-1&length=4');
     expect(result.statusCode).toBe(400);
+  });
+
+  it('rejects non-localhost clients before touching disk (403)', async () => {
+    const result = await invoke(
+      middleware,
+      '/__kotor_dev_fs?action=stat&path=chitin.key',
+      '192.168.1.50',
+    );
+    expect(result.statusCode).toBe(403);
+    expect(String(result.body)).toContain('localhost-only');
   });
 });

--- a/webpack/dev-game-fs-middleware.test.ts
+++ b/webpack/dev-game-fs-middleware.test.ts
@@ -1,0 +1,123 @@
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+// The middleware is a CommonJS dev-only module; require it directly.
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { createDevGameFsMiddleware } = require('./dev-game-fs-middleware.js');
+
+interface InvokeResult {
+  statusCode: number;
+  headers: Record<string, string>;
+  body: unknown;
+  passedThrough?: boolean;
+}
+
+function invoke(middleware: (req: unknown, res: unknown, next: () => void) => void, url: string): Promise<InvokeResult> {
+  return new Promise((resolve) => {
+    const res = {
+      statusCode: 200,
+      headers: {} as Record<string, string>,
+      setHeader(key: string, value: string) {
+        this.headers[key.toLowerCase()] = value;
+      },
+      end(data: unknown) {
+        resolve({ statusCode: this.statusCode, headers: this.headers, body: data });
+      },
+    };
+    const req = { url };
+    middleware(req, res, () => resolve({ statusCode: 0, headers: {}, body: undefined, passedThrough: true }));
+  });
+}
+
+describe('dev-game-fs-middleware', () => {
+  let root: string;
+  let outside: string;
+  let middleware: (req: unknown, res: unknown, next: () => void) => void;
+
+  beforeAll(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'kotor-fs-root-'));
+    outside = fs.mkdtempSync(path.join(os.tmpdir(), 'kotor-fs-out-'));
+
+    fs.writeFileSync(path.join(root, 'chitin.key'), Buffer.from([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]));
+    fs.mkdirSync(path.join(root, 'rims'));
+    fs.writeFileSync(path.join(root, 'rims', 'global.rim'), Buffer.from('RIMV'));
+    fs.writeFileSync(path.join(outside, 'secret.txt'), 'top secret');
+
+    // Symlink inside root that escapes to a directory outside root — the realpath guard must reject reads through it.
+    try {
+      fs.symlinkSync(outside, path.join(root, 'escape'), 'dir');
+    } catch {
+      // Symlink creation may be unavailable on some CI runners; the escape test guards for this.
+    }
+
+    // Sparse file larger than MAX_WHOLE_FILE_BYTES (64 MiB) without writing 64 MiB of data.
+    const huge = path.join(root, 'huge.bif');
+    const fd = fs.openSync(huge, 'w');
+    fs.ftruncateSync(fd, 65 * 1024 * 1024);
+    fs.closeSync(fd);
+
+    middleware = createDevGameFsMiddleware(root);
+  });
+
+  afterAll(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+    fs.rmSync(outside, { recursive: true, force: true });
+  });
+
+  it('stat returns exists/isFile and the file size', async () => {
+    const result = await invoke(middleware, '/__kotor_dev_fs?action=stat&path=chitin.key');
+    const data = JSON.parse(String(result.body)) as { exists: boolean; isFile: boolean; size: number };
+    expect(data.exists).toBe(true);
+    expect(data.isFile).toBe(true);
+    expect(data.size).toBe(10);
+  });
+
+  it('read with offset/length returns only the requested byte window', async () => {
+    const result = await invoke(middleware, '/__kotor_dev_fs?action=read&path=chitin.key&offset=2&length=3');
+    expect(result.statusCode).toBe(200);
+    expect(Array.from(result.body as Buffer)).toEqual([2, 3, 4]);
+  });
+
+  it('readdir lists files and marks directories with a trailing slash', async () => {
+    const result = await invoke(middleware, '/__kotor_dev_fs?action=readdir&path=');
+    const data = JSON.parse(String(result.body)) as { entries: string[] };
+    expect(data.entries).toContain('chitin.key');
+    expect(data.entries).toContain('rims/');
+  });
+
+  it('does not serve files outside the game root via ../ traversal', async () => {
+    const result = await invoke(middleware, '/__kotor_dev_fs?action=stat&path=../../etc/passwd');
+    // Normalization strips '..', so the path resolves inside root and simply does not exist.
+    const data = JSON.parse(String(result.body)) as { exists: boolean };
+    expect(data.exists).toBe(false);
+  });
+
+  it('rejects reads through a symlink that escapes the game root (403)', async () => {
+    if (!fs.existsSync(path.join(root, 'escape'))) {
+      return; // Symlink unavailable on this platform; skip.
+    }
+    const result = await invoke(middleware, '/__kotor_dev_fs?action=read&path=escape/secret.txt');
+    expect(result.statusCode).toBe(403);
+  });
+
+  it('refuses a whole-file read above the size limit (413) but allows ranged reads', async () => {
+    const whole = await invoke(middleware, '/__kotor_dev_fs?action=read&path=huge.bif');
+    expect(whole.statusCode).toBe(413);
+
+    const ranged = await invoke(middleware, '/__kotor_dev_fs?action=read&path=huge.bif&offset=0&length=4');
+    expect(ranged.statusCode).toBe(200);
+    expect((ranged.body as Buffer).length).toBe(4);
+  });
+
+  it('rejects a ranged read whose length would allocate an oversized buffer (413)', async () => {
+    const result = await invoke(middleware, '/__kotor_dev_fs?action=read&path=chitin.key&offset=0&length=2000000000');
+    expect(result.statusCode).toBe(413);
+  });
+
+  it('rejects a ranged read with negative offset/length (400)', async () => {
+    const result = await invoke(middleware, '/__kotor_dev_fs?action=read&path=chitin.key&offset=-1&length=4');
+    expect(result.statusCode).toBe(400);
+  });
+});

--- a/webpack/dev-game-fs-middleware.test.ts
+++ b/webpack/dev-game-fs-middleware.test.ts
@@ -134,4 +134,14 @@ describe('dev-game-fs-middleware', () => {
     expect(result.statusCode).toBe(403);
     expect(String(result.body)).toContain('localhost-only');
   });
+
+  it('resolves paths case-insensitively (movies vs Movies)', async () => {
+    fs.mkdirSync(path.join(root, 'movies'));
+    fs.writeFileSync(path.join(root, 'movies', 'leclogo.bik'), Buffer.from('BIK'));
+
+    const result = await invoke(middleware, '/__kotor_dev_fs?action=stat&path=Movies/leclogo.bik');
+    const data = JSON.parse(String(result.body)) as { exists: boolean; isFile: boolean };
+    expect(data.exists).toBe(true);
+    expect(data.isFile).toBe(true);
+  });
 });

--- a/webpack/kotor-watch.config.js
+++ b/webpack/kotor-watch.config.js
@@ -1,0 +1,5 @@
+const libraryConfig = require('./KotOR');
+
+module.exports = [
+  libraryConfig('KotOR.js', 'green'),
+];


### PR DESCRIPTION
## Summary

- **Forge:** Loading-screen progress (bar, percent, ETA) during resource explorer startup via `LoaderProgressTracker` in `GameInitializer` / `ForgeInitializer` / `TabResourceExplorerState`.
- **HMR / dev FS:** Session-preserving hot reload, `KOTOR_DEV_GAME_DIR` middleware (`/__kotor_dev_fs`), stale FS Access handle clear, ranged BIF reads, docs + agent onboarding.
- **HMR snapshot-reload-resume (new):** Engine modules cannot hot-swap in place — abort/fail and F5 now snapshot to `localStorage` and auto-resume into the saved module/position via `DevSessionResume`. Three tiers: in-place (React UI + probe), engine-edit reload-resume, manual F5 resume. E2E extended with F5 + engine-edit phases when `KOTOR_HMR_E2E_MODULE` is set.

**Head:** `321d741d` · Rebased onto `upstream/master` · CI restored (`.github/workflows/ci.yml`).

## CI

All checks **green** @ previous head; re-run pending on `321d741d`.

## Test plan

### Automated (CI + local)

- [x] `LoaderProgress.test.ts`, `ResourceLoader.test.ts`
- [x] `DevGameFileBackend.test.ts`, `dev-game-fs-middleware.test.ts`, `HotReloadManager.test.ts`
- [x] `DevSessionResume.test.ts` (14 tests — snapshot, resume, crash-loop breaker)
- [x] `npm run test:hmr-e2e` (synthetic probe cycles; F5 + engine-edit when `KOTOR_HMR_E2E_MODULE=end_m01aa` + real assets)
- [x] `npm run webpack:prod`, `npm run electron:compile`

```bash
npm test -- --testPathPatterns=DevSessionResume|DevGameFileBackend|dev-game-fs-middleware|HotReloadManager|LoaderProgress
npm run test:hmr-e2e
# Real-asset in-module (local only):
KOTOR_DEV_GAME_DIR=/path/to/swkotor KOTOR_HMR_E2E_MODULE=end_m01aa npm run test:hmr-e2e
```

### Manual dev (real KOTOR install — **not covered by CI**)

CI HMR E2E uses port **8099** and synthetic session (probe-only). Manual real-asset dev uses port **8130**:

```bash
KOTOR_DEV_GAME_DIR=/path/to/swkotor KOTOR_DEV_PORT=8130 npm run dev:hmr
# → http://127.0.0.1:8130/game/?key=kotor
KOTOR_DEV_PORT=8130 ./scripts/prove-dev-fs-smoke.sh
```

Browser diagnostic: `window.__KOTOR_HMR_TEST__?.getBootstrapStatus?.()`

Disable auto-resume: `?devresume=0`

See [AGENTS.md](AGENTS.md) for port map and verification ladder.

### Manual QA (maintainer)

- [ ] Game client loading progress during asset init
- [ ] Forge resource explorer tree build progress
- [ ] Edit engine file while in-module → auto reload → resume at same position
- [ ] F5 while in-module → resume (not main menu)

## Documented solutions

Search before debugging HMR / dev FS issues:

- `docs/solutions/developer-experience/engine-hmr-snapshot-reload-resume.md` — **three-tier HMR model**
- `docs/solutions/runtime-errors/dev-fs-stale-handle-hmr-parity.md`
- `docs/solutions/performance-issues/dev-game-fs-range-reads-and-size-guards.md`
- `docs/solutions/developer-experience/hmr-real-asset-in-module-e2e.md`

## Residual Review Findings

From ce-reliability/correctness review on `321d741d` — **addressed in commit:**

- localStorage write failures no longer silently succeed (writeSnapshot returns boolean; attempt counter verified)
- Menu-init grace bypass removed (wait for engine + menus before quick-play)
- Resume success requires player transform applied
- HMR abort handler: reload-in-flight guard + skip reload when no live session
- E2E F5/engine phases assert against post-resume localStorage snapshot (not stale pre-edit position)

**Optional follow-up (not merge blockers):**

- In-memory last-known-good snapshot for beforeunload during module transitions
- Multi-tab localStorage coordination
- Real-asset in-module HMR phases in CI (requires game install in runner)

## Risk callout

Dev FS middleware is a **localhost-only** dev aid. Requires user-supplied game install. HMR stack is **branch-only** (~12 files upstream lacks); regressions during HMR dev are often dev infrastructure, not Odyssey engine bugs.